### PR TITLE
Remove resources sync step from CI

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -54,7 +54,3 @@ jobs:
       - name: Sync all non-cacheable assets
         # Don't cache any HTML or JSON file: they should always be up-to-dates
         run: aws s3 sync --cache-control "public, max-age=0, must-revalidate" --include "*.html" --include="sw.js" --include="*.json" --include "*.css" --exclude="*.js" --exclude="*.gif" --exclude="*.png" --exclude="*.svg" --delete public/ s3://${{ secrets.PROD_AWS_S3_BUCKET_NAME }}/
-
-      # - name: Sync static resources
-      #   # Sync the static resources in a separate pass: their URL is static but we might update the contents once in a while
-      #   run: aws s3 sync --cache-control "public, max-age=14400" --delete public/resources/ s3://${{ secrets.PROD_AWS_S3_BUCKET_NAME }}/resources/

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -58,7 +58,3 @@ jobs:
       - name: Sync all non-cacheable assets
         # Don't cache any HTML or JSON file: they should always be up-to-dates
         run: aws s3 sync --cache-control "public, max-age=0, must-revalidate" --include "*.html" --include="sw.js" --include="*.json" --include "*.css" --exclude="*.js" --exclude="*.gif" --exclude="*.png" --exclude="*.svg" --delete public/ s3://${{ secrets.STAG_AWS_S3_BUCKET_NAME }}/
-
-      - name: Sync static resources
-        # Sync the static resources in a separate pass: their URL is static but we might update them once in a while
-        run: aws s3 sync --cache-control "public, max-age=14400" --delete public/resources/ s3://${{ secrets.STAG_AWS_S3_BUCKET_NAME }}/resources/


### PR DESCRIPTION
Partial revert of https://github.com/arduino/docs-content/pull/20

The cache duration exception for static resources will be handled on Cloudflare for the time being, and we'll add an invalidation step later on