### PR TITLE
Add MKR GSM memory disclaimer for IoT Cloud usage

### DIFF
--- a/content/cloud/iot-cloud/tutorials/01.iot-cloud-getting-started/iot-cloud-getting-started.md
+++ b/content/cloud/iot-cloud/tutorials/01.iot-cloud-getting-started/iot-cloud-getting-started.md
@@ -84,7 +84,7 @@ Connection through mobile networks can be considered in remote areas where there
 
 ***For more information, visit the [Arduino SIM page](https://store.arduino.cc/digital/sim).***
 
-***Note that connection via GSM is a memory intense operation, so there's not a lot of memory for the user application (around 2.6 kB). Using a lot of IoT Cloud variables may cause the sketch to run out of memory on the MKR GSM 1400 and make it crash.***
+***Note that a secured connection is a memory intense operation, so there's not a lot of memory for the user application (e.g. around 2.6 kB on the MKR GSM 1400). Using a lot of IoT Cloud variables may cause the sketch to run out of memory on boards which don't offload the SSL stack and make it crash.***
 
 ### ESP32 / ESP8266
 

--- a/content/cloud/iot-cloud/tutorials/01.iot-cloud-getting-started/iot-cloud-getting-started.md
+++ b/content/cloud/iot-cloud/tutorials/01.iot-cloud-getting-started/iot-cloud-getting-started.md
@@ -84,6 +84,8 @@ Connection through mobile networks can be considered in remote areas where there
 
 ***For more information, visit the [Arduino SIM page](https://store.arduino.cc/digital/sim).***
 
+***Note that connection via GSM is a memory intense operation, so there's not a lot of memory for the user application (around 2.6 kB). Using a lot of IoT Cloud variables may cause the sketch to run out of memory on the MKR GSM 1400 and make it crash.***
+
 ### ESP32 / ESP8266
 
 The Arduino IoT Cloud supports a wide range of third party boards based on the ESP32 and ESP8266 microcontrollers with support for Wi-Fi. To set them up, simply choose the **third party option** in the device setup.


### PR DESCRIPTION
There are currently some issues with running a lot of cloud variables on the MKR GSM 1400. This PR adds a note in the getting started guide for the Arduino IoT Cloud to inform users.