### PR TITLE
Fix typo in CureTime Library

### DIFF
--- a/content/retired/05.archived-libraries/CurieTime/CurieTime.md
+++ b/content/retired/05.archived-libraries/CurieTime/CurieTime.md
@@ -162,7 +162,7 @@ second: the second value to be set.
 
 day: the day value to be set.
 
-minute: the minute value to be set.
+month: the month value to be set.
 
 year: the year value to be set.
 


### PR DESCRIPTION
Was fixed by @juditmv but was accidentally merged in the wrong repository. So I've recreated it here.