### PR TITLE
Add rules to find incorrectly formatted units

### DIFF
--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -27,7 +27,7 @@
   errorMessage: "'Kilohertz' should be abbreviated as kHz"
 
 # Mbps / Gbps spacing
-- regex: "(?<!\\S)\\b\\d+[MG]bps\\b"
+- regex: "(?<!\\S)\\b\\d+[MGK]bps\\b"
   shouldMatch: false
   type: warning
   format: markdown

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -18,7 +18,7 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Megahertz/Gigahertz should be abbreviated as MHz/GHz
+  errorMessage: 'Megahertz'/'Gigahertz' should be abbreviated as MHz/GHz
 
 # Mbps / Gbps spacing
 - regex: "(?<!\\S)\\b\\d+[MG]bps\\b"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -46,7 +46,7 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Kilobyte should be abbreviated as KB, Kilobit as Kb.
+  errorMessage: 'Kilobyte' should be abbreviated as KB, 'Kilobit' as Kb.
 
 # MB spelling
 - regex: "(?<!\\S)\\b\\d+\\s?m[bB]\\b"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -14,7 +14,7 @@
   errorMessage: Space between unit and value required
 
 # MHz / GHz spelling
-- regex: "(?<!\\S)\\b\\d+\\s?[MG]hz\\b"
+- regex: "(?<!\\S)\\b\\d+\\s?[MGmg]hz\\b"
   shouldMatch: false
   type: warning
   format: markdown

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -33,12 +33,12 @@
   format: markdown
   errorMessage: Space between unit and value required
 
-# Kbps/ Mbps / Gbps spelling
-- regex: "(?<!\\S)\\b\\d+\\s?[mgk]bps\\b"
+# Kbps / KBps / Mbps / MBps / Gbps / GBps spelling
+- regex: "(?<!\\S)\\b\\d+\\s?[kmg][Bb][Pp][Ss]\\b"
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: "'Kilobit per second' should be abbreviated as Kbps, 'Megabit per second' as Mbps and 'Gigabit per second' Gbps"
+  errorMessage: "Incorrect abbreviation used. Use one of the following: Kbps, KBps, Mbps, MBps, Gbps or GBps (b = bits, B = bytes)"
 
 # kB / KB / Mb / MB / Gb / GB spacing
 - regex: "(?<!\\S)\\b\\d+[gBmMkK][bB]\\b"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -3,22 +3,22 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Megabytes should be either written as 'megabytes' or abbreviated as
-    'MB'
+  errorMessage: "Megabytes should be either written as 'megabytes' or abbreviated as
+    'MB'"
 
 # MHz / GHz spacing
-- regex: "(?<!\\S)\\b\\d+[MG][hH]z\\b"
+- regex: "(?<!\\S)\\b\\d+[MmGg][hH]z\\b"
   shouldMatch: false
   type: warning
   format: markdown
   errorMessage: Space between unit and value required
 
 # MHz / GHz spelling
-- regex: "(?<!\\S)\\b\\d+\\s?[MGmg]hz\\b"
+- regex: "(?<!\\S)\\b\\d+\\s?[MmGg]hz\\b"
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: 'Megahertz'/'Gigahertz' should be abbreviated as MHz/GHz
+  errorMessage: "'Megahertz'/'Gigahertz' should be abbreviated as MHz/GHz"
 
 # Mbps / Gbps spacing
 - regex: "(?<!\\S)\\b\\d+[MG]bps\\b"
@@ -32,7 +32,7 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: 'Megabit per second' should be abbreviated Mbps, 'Gigabit per second' Gbps  
+  errorMessage: "'Megabit per second' should be abbreviated Mbps, 'Gigabit per second' Gbps"
 
 # kB / MB spacing
 - regex: "(?<!\\S)\\b\\d+[mMkK][bB]\\b"
@@ -46,14 +46,14 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: 'Kilobyte' should be abbreviated as KB, 'Kilobit' as Kb.
+  errorMessage: "'Kilobyte' should be abbreviated as KB, 'Kilobit' as Kb."
 
 # MB spelling
 - regex: "(?<!\\S)\\b\\d+\\s?m[bB]\\b"
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: 'Megabyte' should be abbreviated as MB, 'Megabit' as Mb.
+  errorMessage: "'Megabyte' should be abbreviated as MB, 'Megabit' as Mb."
     
 # μm / mm spacing
 - regex: "(?<!\\S)\\b\\d+[μm]m\\b"
@@ -68,7 +68,7 @@
   type: warning
   format: markdown
   includeCodeBlocks: false
-  errorMessage: Incorrect spelling of 'Wi-Fi' found.
+  errorMessage: "Incorrect spelling of 'Wi-Fi' found."
 
 - regex: "(?<!\\/|-)\\b(master|slave)\\b"
   regexModifiers: "gi"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -3,8 +3,7 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: "Megabytes should be either written as 'megabytes' or abbreviated as
-    'MB'"
+  errorMessage: "Megabytes should be either written as 'megabytes' or abbreviated as 'MB'"
 
 # MHz / GHz spacing
 - regex: "(?<!\\S)\\b\\d+[MmGg][hH]z\\b"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -32,7 +32,7 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Megabit per second shout be abbreviated mbps, Gigabit per second gbps  
+  errorMessage: 'Megabit per second' should be abbreviated Mbps, 'Gigabit per second' Gbps  
 
 # kB / MB spacing
 - regex: "(?<!\\S)\\b\\d+[mMkK][bB]\\b"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -27,6 +27,13 @@
   format: markdown
   errorMessage: Space between unit and value required
 
+# Mbps / Gbps spelling
+- regex: "(?<!\\S)\\b\\d+\\s?[mg]bps\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Megabit per second shout be abbreviated mbps, Gigabit per second gbps  
+
 # kB / MB spacing
 - regex: "(?<!\\S)\\b\\d+[mMkK][bB]\\b"
   shouldMatch: false
@@ -39,14 +46,14 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Kilobyte should be abbreviated as kB.
+  errorMessage: Kilobyte should be abbreviated as kB, Kilobit as kb.
 
 # MB spelling
 - regex: "(?<!\\S)\\b\\d+\\s?m[bB]\\b"
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Megabyte should be abbreviated as MB.
+  errorMessage: Megabyte should be abbreviated as MB, Megabit as Mb.
     
 # μm / mm spacing
 - regex: "(?<!\\S)\\b\\d+[μm]m\\b"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -5,7 +5,56 @@
   format: markdown
   errorMessage: Megabytes should be either written as 'megabytes' or abbreviated as
     'MB'
+
+# MHz / GHz spacing
+- regex: "(?<!\\S)\\b\\d+[MG][hH]z\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Space between unit and value required
+
+# MHz / GHz spelling
+- regex: "(?<!\\S)\\b\\d+\\s?[MG]hz\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Megahertz/Gigahertz should be abbreviated as MHz/GHz
+
+# Mbps / Gbps spacing
+- regex: "(?<!\\S)\\b\\d+[MG]bps\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Space between unit and value required
+
+# kB / MB spacing
+- regex: "(?<!\\S)\\b\\d+[mMkK][bB]\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Space between unit and value required
+
+# kB spelling
+- regex: "(?<!\\S)\\b\\d+\\s?K[bB]\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Kilobyte should be abbreviated as kB.
+
+# MB spelling
+- regex: "(?<!\\S)\\b\\d+\\s?m[bB]\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Megabyte should be abbreviated as MB.
     
+# μm / mm spacing
+- regex: "(?<!\\S)\\b\\d+[μm]m\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: Space between unit and value required
+
 # Excludes Wi-Fi in URLs (prepended by dash or slash) and WiFi.XY and MKR WiFi
 - regex: "(?<![\\/-]|Arduino |MKR |UNO |MKR 1000 )[wW]i[fF]i(?![-\\/]|\\.?\\S| [sS]hield)"
   shouldMatch: false

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -53,7 +53,7 @@
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Megabyte should be abbreviated as MB, Megabit as Mb.
+  errorMessage: 'Megabyte' should be abbreviated as MB, 'Megabit' as Mb.
     
 # μm / mm spacing
 - regex: "(?<!\\S)\\b\\d+[μm]m\\b"

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -5,8 +5,8 @@
   format: markdown
   errorMessage: "Megabytes should be either written as 'megabytes' or abbreviated as 'MB'"
 
-# MHz / GHz spacing
-- regex: "(?<!\\S)\\b\\d+[MmGg][hH]z\\b"
+# MHz / GHz / kHz spacing
+- regex: "(?<!\\S)\\b\\d+[MmGgk][hH]z\\b"
   shouldMatch: false
   type: warning
   format: markdown
@@ -19,6 +19,13 @@
   format: markdown
   errorMessage: "'Megahertz'/'Gigahertz' should be abbreviated as MHz/GHz"
 
+# kHz spelling
+- regex: "(?<!\\S)\\b\\d+\\s?[Kk]hz\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: "'Kilohertz' should be abbreviated as kHz"
+
 # Mbps / Gbps spacing
 - regex: "(?<!\\S)\\b\\d+[MG]bps\\b"
   shouldMatch: false
@@ -26,15 +33,15 @@
   format: markdown
   errorMessage: Space between unit and value required
 
-# Mbps / Gbps spelling
-- regex: "(?<!\\S)\\b\\d+\\s?[mg]bps\\b"
+# Kbps/ Mbps / Gbps spelling
+- regex: "(?<!\\S)\\b\\d+\\s?[mgk]bps\\b"
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: "'Megabit per second' should be abbreviated Mbps, 'Gigabit per second' Gbps"
+  errorMessage: "'Kilobit per second' should be abbreviated as Kbps, 'Megabit per second' as Mbps and 'Gigabit per second' Gbps"
 
-# kB / MB spacing
-- regex: "(?<!\\S)\\b\\d+[mMkK][bB]\\b"
+# kB / KB / Mb / MB / Gb / GB spacing
+- regex: "(?<!\\S)\\b\\d+[gBmMkK][bB]\\b"
   shouldMatch: false
   type: warning
   format: markdown
@@ -47,13 +54,20 @@
   format: markdown
   errorMessage: "'Kilobyte' should be abbreviated as KB, 'Kilobit' as Kb."
 
-# MB spelling
+# MB / Mb spelling
 - regex: "(?<!\\S)\\b\\d+\\s?m[bB]\\b"
   shouldMatch: false
   type: warning
   format: markdown
   errorMessage: "'Megabyte' should be abbreviated as MB, 'Megabit' as Mb."
     
+# GB / Gb spelling
+- regex: "(?<!\\S)\\b\\d+\\s?g[bB]\\b"
+  shouldMatch: false
+  type: warning
+  format: markdown
+  errorMessage: "'Gigabyte' should be abbreviated as GB, 'Gigabit' as Gb."
+
 # μm / mm spacing
 - regex: "(?<!\\S)\\b\\d+[μm]m\\b"
   shouldMatch: false

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -41,12 +41,12 @@
   format: markdown
   errorMessage: Space between unit and value required
 
-# kB spelling
-- regex: "(?<!\\S)\\b\\d+\\s?K[bB]\\b"
+# KB / Kb spelling
+- regex: "(?<!\\S)\\b\\d+\\s?k[bB]\\b"
   shouldMatch: false
   type: warning
   format: markdown
-  errorMessage: Kilobyte should be abbreviated as kB, Kilobit as kb.
+  errorMessage: Kilobyte should be abbreviated as KB, Kilobit as Kb.
 
 # MB spelling
 - regex: "(?<!\\S)\\b\\d+\\s?m[bB]\\b"


### PR DESCRIPTION
## What Needs To Be Reviewed
- Please check if the rules detect the wanted patterns.

Some test content could be e.g.

```
400 MHz
400 Mhz
400Mhz

480 *Mbps*
480Mbps

150 kB
150kB
200 KB

12 MB
12mb-test of ram
14 mB

18 μm
test-18μm-test
18μm
```

## How To Give Feedback
Please leave your feedback as a [Github review](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews). 
You can add comments to specific lines of content / code and ideally use Github's [suggestion feature](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request). 🙏
