### PR TITLE
Fix linter failing with `ERROR: 'Learn more' is not title case.`

### DIFF
--- a/contribution-templates/how-to-template/how-to-template.md
+++ b/contribution-templates/how-to-template/how-to-template.md
@@ -45,6 +45,6 @@ Add the image of the schematic here. This section should not need any text follo
 
 Example code for the reader to copy and paste into their own sketch. This section should explain the different sections in the code. 
 
-## Learn more
+## Learn More
 
 Information on how the reader could delve deeper into the topic. For example linking to other tutorials or projects. 


### PR DESCRIPTION
## What This PR Changes
The linter is failing because the title is not "title case": example run [here](https://github.com/arduino/docs-content/runs/5768515634?check_suite_focus=true#step:3:46)
## What Needs To Be Reviewed
@jhansson-ard
## How To Give Feedback
Please leave your feedback as a [Github review](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews). 
You can add comments to specific lines of content / code and ideally use Github's [suggestion feature](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request). 🙏
