### PR TITLE
[TC-270] Add Portenta H7 Bluetooth version support to datasheet

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -54,9 +54,9 @@ Laboratory equipment, Computer vision
       </tr>
       <tr>
          <td style="text-align: center;">Connectivity</td>
-         <td style="text-align: center;">Ethernet PHY / Wi-Fi / Bluetooth® Low Energy</td>
+         <td style="text-align: center;">Ethernet PHY / Wi-Fi® / Bluetooth® Low Energy (BLE 5 via Cordio stack, BLE 4.2 via Arduino Stack)</td>
          <td style="text-align: center;">Ethernet FHY</td>
-         <td style="text-align: center;">Ethernet PHY / Wi-Fi / Bluetooth® Low Energy</td>
+         <td style="text-align: center;">Ethernet PHY / Wi-Fi® / Bluetooth® Low Energy (BLE 5 via Cordio stack, BLE 4.2 via Arduino Stack)</td>
       </tr>
       <tr>
          <td style="text-align: center;">Memory</td>
@@ -131,10 +131,6 @@ Laboratory equipment, Computer vision
       </tr>
       <tr>
          <td>Voltage scaling in Run and Stop mode 6 configurable ranges</td>
-         <td></td>
-      </tr>
-      <tr>
-         <td>2.95μA in Standby mode Backup SRAM OFF, RTC/LSE/ON</td>
          <td></td>
       </tr>
       <tr>


### PR DESCRIPTION
## What This PR Changes
- Add statement regarding BT support for Portenta H7: (BLE 5 via Cordio stack, BLE 4.2 via Arduino Stack)

## What Needs To Be Reviewed
- Has the info been correctly added?
- Is the table rendered correctly?

## How To Give Feedback
Please leave your feedback as a [Github review](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews). 
You can add comments to specific lines of content / code and ideally use Github's [suggestion feature](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request). 🙏
