### PR TITLE
Fixed formatting error on LCD displays article

### DIFF
--- a/content/learn/04.electronics/03.lcd-displays/lcd-displays.md
+++ b/content/learn/04.electronics/03.lcd-displays/lcd-displays.md
@@ -271,7 +271,7 @@ void loop() {
 
   lcd.clear();
 }
-```s
+```
 
 ### Blink Example
 


### PR DESCRIPTION
I have fixed a formatting error on the [Liquid Crystal Displays (LCD) article](https://docs.arduino.cc/learn/electronics/lcd-displays) where the "Blink Example" section was accidentally put as part of the [autoscroll example](https://docs.arduino.cc/learn/electronics/lcd-displays#autoscroll-example).

## What This PR Changes
- I created this pull request because I am finding this error affects the readability of the code sample.
- I fixed the blink example and put it as a section in the article.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
