### PR TITLE
Update getting-started.md

### DIFF
--- a/content/hardware/05.nicla/boards/nicla-sense-me/tutorials/getting-started/getting-started.md
+++ b/content/hardware/05.nicla/boards/nicla-sense-me/tutorials/getting-started/getting-started.md
@@ -105,7 +105,7 @@ The **Arduino_BHY2** library contains these sensors:
     valueY = gyroscope.y();
     valueZ = gyroscope.z();
 
-    Serial.println(gyroscope.toString); //Prints all the data "automatically"
+    Serial.println(gyroscope.toString()); //Prints all the data "automatically"
 
     //Print the individual values
     Serial.println(valueX);


### PR DESCRIPTION
minor fix on call `gyroscope.toString` this is a function, change to `gyroscope.toString()`

## What This PR Changes
- trying "Getting Started" I found an error on compiling the gyroscope example, by this fix it seem working.

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
