### PR TITLE
Fixed broken link to u-blox datasheet for NINA-W10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ In order to contribute new or updated documentation, you must first create a Git
 
 **NOTE:** Unless you are opening a pull request which will only make small corrections, for instance to correct a typo, you are more likely to get traction for your changes if you [open an issue](https://github.com/arduino/docs.arduino.cc/issues) first to discuss the proposed changes.
 
-**NOTE:** The default [branch](https://github.com/arduino/docs.arduino.cc/branches) of the repository is the `develop` branch, and this should be the branch you get by default when you initially checkout the repository. You should target any pull requests against the `develop` branch, pull requests against the `master` branch will automatically fail checks and not be accepted.
+**NOTE:** The default [branch](https://github.com/arduino/docs.arduino.cc/branches) of the repository is the `main` branch, and this should be the branch you get by default when you initially checkout the repository. You should target any pull requests against the `main` branch.
 
 ## Type of Content
 

--- a/content/hardware/03.nano/boards/nano-rp2040-connect/features.md
+++ b/content/hardware/03.nano/boards/nano-rp2040-connect/features.md
@@ -32,7 +32,7 @@ The feature packed **Arduino Nano RP2040 Connect** brings the new **Raspberry Pi
 
   The first and only RP2040 board with native Bluetooth® and WiFi connectivity.
 
-  <FeatureLink title="Datasheet" url="https://content.u-blox.com/sites/default/files/NINA-W10_ProductSummary_UBX-17051775.pdf" download blank/>
+  <FeatureLink title="Datasheet" url="https://www.u-blox.com/sites/default/files/NINA-W10_ProductSummary_UBX-17051775.pdf" download blank/>
 </Feature>
 
 <Feature title="ST LSM6DSOX 6-axis IMU" image="imu">

--- a/content/hardware/03.nano/boards/nano-rp2040-connect/features.md
+++ b/content/hardware/03.nano/boards/nano-rp2040-connect/features.md
@@ -32,7 +32,7 @@ The feature packed **Arduino Nano RP2040 Connect** brings the new **Raspberry Pi
 
   The first and only RP2040 board with native Bluetooth® and WiFi connectivity.
 
-  <FeatureLink title="Datasheet" url="https://www.u-blox.com/sites/default/files/NINA-W10_ProductSummary_%28UBX-17051775%29_C1-public.pdf" download blank/>
+  <FeatureLink title="Datasheet" url="https://content.u-blox.com/sites/default/files/NINA-W10_ProductSummary_UBX-17051775.pdf" download blank/>
 </Feature>
 
 <Feature title="ST LSM6DSOX 6-axis IMU" image="imu">


### PR DESCRIPTION
## What This PR Changes
- Fixed a broken link to u-blox site
- Minor refactoring to the CONTRIBUTING.md file, where it's mentioned
  that the default branch is called 'develop' and that PR should be
  targeted against it, while actually the default branch is called
  'main' and PR must be issued against it.

 
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
