### PR TITLE
Removed legacy information from contribution page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,6 @@ In order to contribute new or updated documentation, you must first create a Git
 
 **NOTE:** Unless you are opening a pull request which will only make small corrections, for instance to correct a typo, you are more likely to get traction for your changes if you [open an issue](https://github.com/arduino/docs.arduino.cc/issues) first to discuss the proposed changes.
 
-**NOTE:** The default [branch](https://github.com/arduino/docs.arduino.cc/branches) of the repository is the `develop` branch, and this should be the branch you get by default when you initially checkout the repository. You should target any pull requests against the `develop` branch, pull requests against the `master` branch will automatically fail checks and not be accepted.
-
 ## Type of Content
 
 We welcome contributions from the community, ranging from correcting small typos all the way through to adding entire new sections to the documentation. However, we are looking to keep the contents of this repository focussed on Arduino-specific things.


### PR DESCRIPTION
## What This PR Changes
There were some information in the contribution page that contained legacy information that is no longer true. This PR removes the paragraph.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
