### PR TITLE
Bump package.json dependecy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/arduino/docs-content#readme",
   "dependencies": {
-    "@arduino/docs-arduino-cc": "^1.2.6",
+    "@arduino/docs-arduino-cc": "^1.2.7",
     "gatsby": "^4.9.2"
   },
   "volta": {


### PR DESCRIPTION
## What This PR Changes
- Bump package.json dependency version of `docs.arduino.cc` to `1.2.7`