### PR TITLE
Fixed dead link on Introduction to MIDI page

### DIFF
--- a/content/built-in-examples/04.communication/Midi/Midi.md
+++ b/content/built-in-examples/04.communication/Midi/Midi.md
@@ -20,7 +20,7 @@ MIDI bytes are divided into two types: **command bytes** and **data bytes**. Com
 
 MIDI data is usually notated in hexadecimal because MIDI banks and instruments are grouped in groups of 16.
 
-For more see this [introduction to MIDI](http://tigoe.net/pcomp/code/communication/midi) or this [example](https://itp.nyu.edu/physcomp/labs/labs-serial-communication/lab-midi-output-using-an-arduino/).
+For more see this [introduction to MIDI](https://web.archive.org/web/20220331023548/https://www.tigoe.com/pcomp/code/communication/midi/) (web archive link) or this [example](https://itp.nyu.edu/physcomp/labs/labs-serial-communication/lab-midi-output-using-an-arduino/).
 
 ### Hardware Required
 

--- a/content/built-in-examples/04.communication/Midi/Midi.md
+++ b/content/built-in-examples/04.communication/Midi/Midi.md
@@ -20,7 +20,7 @@ MIDI bytes are divided into two types: **command bytes** and **data bytes**. Com
 
 MIDI data is usually notated in hexadecimal because MIDI banks and instruments are grouped in groups of 16.
 
-For more see this [introduction to MIDI](http://www.tigoe.net/pcomp/code/communication/midi) or this [example](https://itp.nyu.edu/physcomp/labs/labs-serial-communication/lab-midi-output-using-an-arduino/).
+For more see this [introduction to MIDI](http://tigoe.net/pcomp/code/communication/midi) or this [example](https://itp.nyu.edu/physcomp/labs/labs-serial-communication/lab-midi-output-using-an-arduino/).
 
 ### Hardware Required
 


### PR DESCRIPTION
They took their `www` subdomain down after temporarily redirecting it to the APEX domain, as found in [the web archive](https://web.archive.org/web/20210210224030/http://www.tigoe.net/pcomp/code/communication/midi).

## What This PR Changes

- Fixed a dead external beginner reference link

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
