### PR TITLE
Update i2c.md

### DIFF
--- a/content/hardware/03.nano/boards/nano-every/tutorials/i2c/content.md
+++ b/content/hardware/03.nano/boards/nano-every/tutorials/i2c/content.md
@@ -91,6 +91,7 @@ Let's start by adding the `Wire.h` library by adding the `#include <Wire.h>` sta
 void setup() {
   Wire.begin(8);                // join i2c bus with address #8
   Wire.onReceive(receiveEvent); // function that executes whenever data is received from writer
+  pinMode(LED_BUILTIN,OUTPUT);  // sets onBoard LED as output
 }
 ```
 
@@ -186,6 +187,7 @@ If you choose to skip the code building section, the complete code for both the 
 void setup() {
   Wire.begin(8);                // join i2c bus with address #8
   Wire.onReceive(receiveEvent); // function that executes whenever data is received from writer
+  pinMode(LED_BUILTIN,OUTPUT);  // sets onBoard LED as output
 }
 
 void loop() {


### PR DESCRIPTION
Builtin LED is not set as output in Reader (I2C slave) program. Thus the LED is not turning on.
So following line needs to be added.
  pinMode(LED_BUILTIN,OUTPUT);  // sets onBoard LED as output

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)
- Original code for I2C slave (reader) is not working.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
