### PR TITLE
IoT Cloud frequency band support [MKC-490]

### DIFF
--- a/content/cloud/iot-cloud/tutorials/01.iot-cloud-getting-started/iot-cloud-getting-started.md
+++ b/content/cloud/iot-cloud/tutorials/01.iot-cloud-getting-started/iot-cloud-getting-started.md
@@ -49,6 +49,8 @@ To use the Arduino IoT Cloud, a **cloud compatible board** is required. You can 
 
 ### Wi-Fi
 
+***Official Arduino boards only supports the 2.4GHz frequency band for transmitting data.***
+
 The following boards connect to the Arduino IoT Cloud via Wi-Fi.
 
 - [MKR 1000 WiFi](https://store.arduino.cc/arduino-mkr1000-wifi)

--- a/content/cloud/iot-cloud/tutorials/02.technical-reference/iot-cloud-tech-ref.md
+++ b/content/cloud/iot-cloud/tutorials/02.technical-reference/iot-cloud-tech-ref.md
@@ -17,6 +17,8 @@ To use the Arduino IoT Cloud, a **cloud compatible board** is required. You can 
 
 ### Wi-Fi
 
+***Official Arduino boards only supports the 2.4GHz frequency band for transmitting data.***
+
 The following boards connect to the Arduino IoT Cloud via Wi-Fi.
 
 - [MKR 1000 WiFi](https://store.arduino.cc/arduino-mkr1000-wifi)


### PR DESCRIPTION
## What This PR Changes
Arduino IoT cloud compatible devices only support 2.4GHz band (not 5GHz). This note was added to the getting started + cheat sheet guides.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
