### PR TITLE
Add changed send trigger to list of changes in IDE 2.x Serial Monitor

### DIFF
--- a/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
@@ -24,6 +24,8 @@ You can also follow the [downloading and installing the Arduino IDE 2.0](/en/Tut
 
 ## Notable Changes
 
+### Integrated Monitor
+
 One major change that was introduced with the Arduino IDE 2.0 is the **integrated Serial Monitor**. The older versions of the editor features an external window that matches the port/board that we select. 
 
 The Arduino IDE 2.0 works a bit differently. Instead of opening an external window for the Serial Monitor, it shows up where the console log is located, as an additional tab. To understand how this works, let's take a look at how the old editor works:
@@ -36,7 +38,7 @@ Now, let's take a look at the IDE 2.0. Notice how the Serial Monitor is located 
 
 The Serial Monitor settings are also located here, such as adjusting the baud rate and sending messages. 
 
-### Advantages with New Integration
+#### Advantages
 
 A major advantage with having the Serial Monitor integrated with the editor is the possibility to have multiple monitors open simultaneously. In the old editor, when changing the port/board, it changed across all windows. In addition, we were limited to **one Serial Monitor window**, an obstacle that the IDE 2.0 removes. 
 

--- a/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
@@ -44,6 +44,10 @@ A major advantage with having the Serial Monitor integrated with the editor is t
 
 You will find an example with more information on how to use this feature, further down this tutorial under the **Using multiple Serial Monitors simultaneously** section.
 
+### Different Send Trigger
+
+In the Arduino IDE 1.x Serial Monitor, data can be sent to the board by entering it in the field at the top of the window and then clicking the **Send** button or pressing the <kbd>**Enter**</kbd> key. In the Arduino IDE 2.0 Serial Monitor you must instead use the <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd> keyboard shortcut (<kbd>**Command**</kbd>+<kbd>**Enter**</kbd> for macOS users).
+
 ## Using the Serial Monitor Tool
 
 The Serial Monitor tool is a really great tool for debugging and establishing communication between a computer and an Arduino. To use it is really easy, but there are some things that we need to do first.


### PR DESCRIPTION
## What This PR Changes

In the Arduino IDE 1.x Serial Monitor, sending is triggered via the "Send" button or by pressing the "Enter" key.

There is no "Send" button in the Arduino IDE 2.x Serial Monitor.

The keyboard trigger was changed from "Enter" to "Ctrl + Enter". This is explained to the user by placeholder text in the input field, but that text disappears as soon as they click on the field, so it is easy to miss that information. Feedback from users indicates this is the case (see: https://github.com/arduino/arduino-ide/issues/348, https://github.com/arduino/arduino-ide/issues/572).

For this reason, it will be important to clearly document the change.

---

I had to adjust the heading structure of the existing content of this "**Notable Changes**" section because the previous structure would not accommodate the listing of multiple changes (only one was listed previously).

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
