### PR TITLE
Add library specification to library tutorial

### DIFF
--- a/content/learn/08.contributions/03.arduino-creating-library-guide/arduino-creating-library-guide.md
+++ b/content/learn/08.contributions/03.arduino-creating-library-guide/arduino-creating-library-guide.md
@@ -253,7 +253,8 @@ It's also nice to provide people with an example sketch that uses your library. 
 
 If you'd like to check out the complete library (with keywords and example), you can download it: [Morse.zip](https://www.arduino.cc/en/uploads/Hacking/Morse.zip).
 
-If you'd like to make your library available to others in Arduino's **Library Manager** you will also have to inlcude a **library.properties** file. Check out the [Library specification](https://arduino.github.io/arduino-cli/0.23/library-specification/) for more info on that.
+If you'd like to make your library available to others in Arduino's **Library Manager** you will also have to include a **library.properties** file. Check out the [library specification](https://arduino.github.io/arduino-cli/latest/library-specification/) for more info on that.
+For general questions on the Arduino Library Manager, see the [FAQ](https://github.com/arduino/library-registry/blob/main/FAQ.md#readme).
 
 If you have any problems or suggestions, please post them to the [Software Development forum](https://forum.arduino.cc/c/development/libraries/39).
 


### PR DESCRIPTION
This PR includes a reference to the library specification at the end of the article.

## What This PR Changes
- The library creation tutorial is great but lacks information on how to make the library available in the library manager. This PR adds a link to the library specification at the end of the tutorial.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.