### PR TITLE
fix multiple content linter warnings

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/wifi-101-library-examples/wifi-101-library-examples.md
+++ b/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/wifi-101-library-examples/wifi-101-library-examples.md
@@ -1,6 +1,6 @@
 ---
 title: Guide to WiFi101
-description: 'Find examples & utilities for using the WiFi101 library, designed for the MKR 1000 WiFi and WiFi 101 Shield (retired).'
+description: 'Find examples & utilities for using the WiFi101 library, designed for the MKR 1000 WiFi and WiFi Shield 101 (retired).'
 tags: [Wi-Fi]
 author: Arduino
 ---
@@ -50,7 +50,7 @@ When you load the sketch on the board, it will wait for a serial monitor console
 
  * Circuit:
 
- * - WiFi101 Shield attached
+ * - WiFi Shield 101 attached
 
  *
 
@@ -83,7 +83,7 @@ void setup() {
 
   // Check for the presence of the shield
 
-  Serial.print("WiFi101 shield: ");
+  Serial.print("WiFi Shield 101: ");
 
   if (WiFi.status() == WL_NO_SHIELD) {
 
@@ -154,7 +154,7 @@ void loop() {
 
 ### Update Firmware / Load Certificates
 
-The 19.6.1 firmware is only available for model B of the WINC1500, this is used in the MKR1000 board. Unfortunately, the WiFi101 shield uses model A, which Atmel has stopped supporting, so there is no 19.6.1 firmware release for it, 19.4.4 will be the latest firmware version that is compatible.
+The 19.6.1 firmware is only available for model B of the WINC1500, this is used in the MKR1000 board. Unfortunately, the WiFi shield 101 uses model A, which Atmel has stopped supporting, so there is no 19.6.1 firmware release for it, 19.4.4 will be the latest firmware version that is compatible.
 
 To simplify the process, we have prepared a specific sketch - this **FirmwareUpdater** - that you must load on the host board (either the one with the shield plugged in, or the MKR1000 itself) and an easy to use plug-in available in Arduino Software (IDE) 1.6.10 onwards.
 
@@ -163,7 +163,7 @@ The `FirmwareUpdater.ino` sketch is available in **Examples > WiFi101**
 
 ![Select the "FirmwareUpdater" example.](assets/firmware_updater_sketch_101.png)
 
-***When you load the sketch on the board, it prepares the communication between the plug-in and the WiFi chip. It opens up the communication through the serial port to the WiFi module hosted on the board. It is necessary to perform all the procedures managed by the Firmware Upgrader Plugin. Everything will be managed by the plug-in, but it is important to upload this sketch first.***
+***When you load the sketch on the board, it prepares the communication between the plug-in and the Wi-Fi chip. It opens up the communication through the serial port to the Wi-Fi module hosted on the board. It is necessary to perform all the procedures managed by the Firmware Upgrader Plugin. Everything will be managed by the plug-in, but it is important to upload this sketch first.***
 
 Upload the sketch and keep the board (either the one with the shield plugged in, or the MKR1000 itself) connected to the computer.
 
@@ -176,7 +176,7 @@ Once done, open the plug-in that is available in the tools menu.
 Your board should be in the list of the available serial ports.
 If not, please check that it is properly configured in the Tools menu.
 
-To update the firmware you should choose the right typer of board. You can find your model looking at the WiFi module: the first line in the sticker or the last line of the silk print on the right side of the PCB shows the microcontroller model. It can be either MR210PA or MR510PB and the last letter shows yor model accordingly.
+To update the firmware you should choose the right typer of board. You can find your model looking at the Wi-Fi module: the first line in the sticker or the last line of the silk print on the right side of the PCB shows the microcontroller model. It can be either MR210PA or MR510PB and the last letter shows yor model accordingly.
 
 ![Find the model.](assets/MKR1000_RevA_B_20copy.png)
 
@@ -186,10 +186,10 @@ Choose in the dropdown list the model corresponding to your unit and proceed cli
 
 #### Certificate Uploading
 
-With the same procedure, you may load root certificates on the WiFi module to access securely specific websites. Your board must be running the **FirmwareUpdater** sketch to work .The root certificates are issued by a limited number of certification authorities, but it is difficult to know which site is using which authority. To ease your life, we allow you to specify directly the URL to which you need to connect securely, leaving to us the task to download the root certificate.
-The list you are building is not saved from one session to the next one. It might happen that a few websites share the same root certificate. You don't have to worry about this as we take care of it. The space available on your WiFi module to store the certificates is limited to around 10 certificates that, being issued by a limited number of authorities, should be more than enough for the average projects.
+With the same procedure, you may load root certificates on the Wi-Fi module to access securely specific websites. Your board must be running the **FirmwareUpdater** sketch to work .The root certificates are issued by a limited number of certification authorities, but it is difficult to know which site is using which authority. To ease your life, we allow you to specify directly the URL to which you need to connect securely, leaving to us the task to download the root certificate.
+The list you are building is not saved from one session to the next one. It might happen that a few websites share the same root certificate. You don't have to worry about this as we take care of it. The space available on your Wi-Fi module to store the certificates is limited to around 10 certificates that, being issued by a limited number of authorities, should be more than enough for the average projects.
 
-The procedure starts connecting your board (either the one with the shield plugged in, or the MKR1000 itself) to your computer and selecting it from the Tools menu of the Arduino Software (IDE). Load the FirmwareUpdater on the board and launch the **WiFi 101 Firmware Updater** from Tools and go to the third section of the interface.
+The procedure starts connecting your board (either the one with the shield plugged in, or the MKR1000 itself) to your computer and selecting it from the Tools menu of the Arduino Software (IDE). Load the FirmwareUpdater on the board and launch the **WiFi101 Firmware Updater** from Tools and go to the third section of the interface.
 
 ![Adding SSL root certificates.](assets/certificates_upload_101.png)
 
@@ -972,7 +972,7 @@ void printMacAddress(byte mac[]) {
 }
 ```
 
-### Wifi101 Simple Web Server WiFi
+### Wifi101 Simple Web Server Wi-Fi
 
 In this example,  a simple web server lets you blink an LED via the web. This example will print the IP address of your WiFi Shield 101 or MKR1000 board (once connected) to the Arduino Software (IDE) Serial Monitor. Once you know the IP address of our board, you can open that address in a web browser to turn on and off the LED on pin 9.
 
@@ -1531,7 +1531,7 @@ void printWiFiStatus() {
 }
 ```
 
-### Wifi101 WiFi Chat Server
+### Wifi101 Wi-Fi Chat Server
 
 A simple server that distributes any incoming messages to all connected clients.  To use, open a terminal window, telnet to your WiFi shield's or MKR1000's IP address, and type away.  Any incoming text will be sent to all connected clients (including the one typing). Additionally, you will be able to see the client's input in your Arduino Software (IDE) serial monitor as well.
 
@@ -1704,7 +1704,7 @@ void printWiFiStatus() {
 ```
 
 
-### Wifi101 WiFi Udp Send Receive String
+### Wifi101 Wi-Fi Udp Send Receive String
 
 This tutorial waits for a UDP packet on a local port. When a valid packet is received, an acknowledge packet is sent back to the client on a specified outgoing port. It relies on a WiFi connection made to your LAN using an Arduino Wifi 101 Shield and Zero Board or the MKR1000 board.
 
@@ -1872,7 +1872,7 @@ void printWiFiStatus() {
 }
 ```
 
-### Wifi101 WiFi Web Client
+### Wifi101 Wi-Fi Web Client
 
 This example shows you how to make a HTTP request using a WiFi Shield 101 or a MKR1000 board. It returns a [Google search for the term "Arduino"](http://www.google.com/search?q=arduino). The results of this search are viewable as HTML through your Arduino Software (IDE) serial window.
 
@@ -2057,7 +2057,7 @@ void printWiFiStatus() {
 ```
 
 
-### Wifi101 WiFi Web Client Repeating
+### Wifi101 Wi-Fi Web Client Repeating
 
 This example shows you how to make repeated HTTP requests using a WiFi Shield 101 or a MKR1000 board.  It connects to  [http://www.arduino.cc/latest.txt](/latest.txt). The content of the page is viewable through your Arduino Software (IDE) Serial Monitor window.
 
@@ -2262,9 +2262,9 @@ void printWiFiStatus() {
 ```
 
 
-### Wifi101 Simple Web Server WiFi
+### Wifi101 Simple Web Server Wi-Fi
 
-In this example, you will use your WiFi Shield 101 and your Arduino Zero, or a MKR1000 board, to create a simple Web server. Using the WiFi library, your device will be able to answer a HTTP request received from the WiFI connection. After opening a browser and navigating to your WiFi shield's or MKR1000's IP address, your board will respond with just enough HTML for a browser to display the input values from all six analog pins.
+In this example, you will use your WiFi Shield 101 and your Arduino Zero, or a MKR1000 board, to create a simple Web server. Using the Wi-Fi library, your device will be able to answer a HTTP request received from the Wi-FI connection. After opening a browser and navigating to your WiFi shield's or MKR1000's IP address, your board will respond with just enough HTML for a browser to display the input values from all six analog pins.
 
 This example is written for a network using WPA encryption. For  WEP or WPA, change the Wifi.begin() call accordingly.
 

--- a/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/wifi-101-ota/WiFi101OTA.md
+++ b/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/wifi-101-ota/WiFi101OTA.md
@@ -5,7 +5,7 @@ title: 'WiFi101 OTA with MKR 1000 WiFi'
 tags: [WiFi101]
 ---
 
-This example shows how to use the WiFi101OTA library to update your sketch over the air. No extra hardware is required since the update is applied directly in the upper half of the  internal flash. This means that the biggest possible size of the compiled sketch is 120KB.
+This example shows how to use the WiFi101OTA library to update your sketch over the air. No extra hardware is required since the update is applied directly in the upper half of the  internal flash. This means that the biggest possible size of the compiled sketch is 120 KB.
 
 ## Hardware Required
 
@@ -29,7 +29,7 @@ Upload the example using the "classic" serial port method
 
 ![Step 4.](assets/WiFiOTA4.png)
 
-Your MKR1000 will connect to the WiFi and expose itself as a Network port with the name and password you declared in the sketch with `WiFiOTA.begin` (the defaults name is "Arduino" while the password is "password").
+Your MKR1000 will connect to the Wi-Fi and expose itself as a Network port with the name and password you declared in the sketch with `WiFiOTA.begin` (the defaults name is "Arduino" while the password is "password").
 
 At this point you are already able to update the sketch over the air! Open another sketch and make sure to add `WiFiOTA.begin()` in `setup()` and  `WiFiOTA.poll()` in your `loop()` . If you forget about this you will lose the ability to upload over the air again (but you can still upload via serial, of course)
 

--- a/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-scan-network/nb-scan-network.md
+++ b/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-scan-network/nb-scan-network.md
@@ -43,7 +43,7 @@ The goals of this project are:
 
 ## The uBlox SARA-R4 Module
 
-As every other MKR family board, the MKR NB 1500 board has a specific module for connectivity. It is called uBlox SARA-R4, and is designed to communicate over LTE Cat M1 or NB IoT networks with a speed of up to 375 KBps.
+As every other MKR family board, the MKR NB 1500 board has a specific module for connectivity. It is called uBlox SARA-R4, and is designed to communicate over LTE Cat M1 or NB IoT networks with a speed of up to 375 kbps.
 
 It is designed to operate in temperature conditions between –40 °C to +85 °C, making it quite durable. It also offers low power consumption and coverage enhancement for deeper range into buildings and basements (and underground with NB1).
 

--- a/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-scan-network/nb-scan-network.md
+++ b/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-scan-network/nb-scan-network.md
@@ -43,7 +43,7 @@ The goals of this project are:
 
 ## The uBlox SARA-R4 Module
 
-As every other MKR family board, the MKR NB 1500 board has a specific module for connectivity. It is called uBlox SARA-R4, and is designed to communicate over LTE Cat M1 or NB IoT networks with a speed of up to 375 kb/s.
+As every other MKR family board, the MKR NB 1500 board has a specific module for connectivity. It is called uBlox SARA-R4, and is designed to communicate over LTE Cat M1 or NB IoT networks with a speed of up to 375 KBps.
 
 It is designed to operate in temperature conditions between –40 °C to +85 °C, making it quite durable. It also offers low power consumption and coverage enhancement for deeper range into buildings and basements (and underground with NB1).
 

--- a/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-scan-network/nb-scan-network.md
+++ b/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-scan-network/nb-scan-network.md
@@ -43,7 +43,7 @@ The goals of this project are:
 
 ## The uBlox SARA-R4 Module
 
-As every other MKR family board, the MKR NB 1500 board has a specific module for connectivity. It is called uBlox SARA-R4, and is designed to communicate over LTE Cat M1 or NB IoT networks with a speed of up to 375 kbps.
+As every other MKR family board, the MKR NB 1500 board has a specific module for connectivity. It is called uBlox SARA-R4, and is designed to communicate over LTE Cat M1 or NB IoT networks with a speed of up to 375 Kbps.
 
 It is designed to operate in temperature conditions between –40 °C to +85 °C, making it quite durable. It also offers low power consumption and coverage enhancement for deeper range into buildings and basements (and underground with NB1).
 

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-button-press/lora-button-press.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-button-press/lora-button-press.md
@@ -9,7 +9,7 @@ tags:
   - LED
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300
@@ -32,7 +32,7 @@ ___
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software)).
-- LoRa® library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa).
+- LoRa library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa).
 - 2x [Arduino MKR WAN 1300](https://store.arduino.cc/mkr-wan-1300).
 - 2x [Antenna](https://store.arduino.cc/antenna).
 - 1x Pushbutton.

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-button-press/lora-button-press.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-button-press/lora-button-press.md
@@ -9,7 +9,7 @@ tags:
   - LED
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-button-press/lora-button-press.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-button-press/lora-button-press.md
@@ -26,7 +26,7 @@ software:
 
 In this tutorial, we will set up two Arduino MKR WAN 1300 to host a remote LED control. One board will be set up as a sender with a pushbutton that when it is pressed, an LED on the other board will turn on or off. 
  
-We will use the **LoRa®** library for the communication, and we will not use any external service. 
+We will use the **LoRa** library for the communication, and we will not use any external service. 
 ___
 
 ## Hardware & Software Needed
@@ -63,7 +63,7 @@ But let's take a look at what we need to include in the code. As we are using tw
 
 **To create the sender sketch, we will have to do the following steps:**
 
-- Initialize the **SPI** and **LoRa®** libraries.
+- Initialize the **SPI** and **LoRa** libraries.
 - Create a counter variable.
 - Set the radio frequency to 868E6 (Europe) or 915E6 (North America).
 - Create an if statement that checks if the button is pressed.
@@ -73,7 +73,7 @@ But let's take a look at what we need to include in the code. As we are using tw
 
 **To create the receiver sketch, we will have to do the following steps:**
 
-- Initialize the **SPI** and **LoRa®** libraries.
+- Initialize the **SPI** and **LoRa** libraries.
 - Create a string with the message "button pressed" stored.
 - Set the radio frequency to 868E6 (Europe) or 915E6 (North America).
 - Create a function to parse incoming packet.
@@ -85,11 +85,11 @@ But let's take a look at what we need to include in the code. As we are using tw
 
 **1.** First, let's make sure we have the drivers installed. If we are using the Web Editor, we do not need to install anything. If we are using an offline editor, we need to install it manually. This can be done by navigating to **Tools > Board > Board Manager...**. Here we need to look for the **Arduino SAMD boards (32-bits ARM Cortex M0+)** and install it. 
 
-**2.** Now we need to download the **LoRa®** library from [this repository](https://github.com/sandeepmistry/arduino-LoRa), where you can install it by navigating to **Sketch > Include Library > Add .ZIP Library...** in the offline IDE. 
+**2.** Now we need to download the **LoRa** library from [this repository](https://github.com/sandeepmistry/arduino-LoRa), where you can install it by navigating to **Sketch > Include Library > Add .ZIP Library...** in the offline IDE. 
 
 ### Programming the Sender
 
-In the initialization we will include the **SPI** and **LoRa®** libraries. We will then create the `counter` variable to track how many times we have pressed the button. Next, we will create the `button` and `buttonState` variables, used to assign the pushbutton to pin 2, and to read the state of it.
+In the initialization we will include the **SPI** and **LoRa** libraries. We will then create the `counter` variable to track how many times we have pressed the button. Next, we will create the `button` and `buttonState` variables, used to assign the pushbutton to pin 2, and to read the state of it.
 
 ```arduino
 #include <SPI.h>
@@ -102,7 +102,7 @@ int buttonState;
 
 In the `setup()` we will first define the `button` pin as an `INPUT_PULLUP`. We will then begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 ```arduino
 void setup() {
@@ -146,7 +146,7 @@ void loop() {
 
 ### Programming the Receiver
 
-In the initialization we will first include the **SPI** and **LoRa®** libraries. Then we will create two strings: one empty, and one with the message "button pressed" stored. The `contents` string will be used to store incoming data, and the `buttonPress` string will be used to compare the contents with the incoming data.
+In the initialization we will first include the **SPI** and **LoRa** libraries. Then we will create two strings: one empty, and one with the message "button pressed" stored. The `contents` string will be used to store incoming data, and the `buttonPress` string will be used to compare the contents with the incoming data.
 
 We then create the boolean `x`, which will switch from true to false each time `buttonPress` matches `contents`. We will also assign the `led` variable to pin 2. 
 
@@ -164,7 +164,7 @@ int led = 2;
 
 In the `setup()` we will first define the `led` pin as an output. We will then begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 ```arduino
 void setup() {

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-message/lora-message.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-message/lora-message.md
@@ -21,7 +21,7 @@ software:
 
 In this tutorial, we will use two MKR WAN 1300's to set up a simple message service over the LoRa® network. This communication will be achieved through the Serial Monitor, where you can send and receive messages directly.  
  
-We will use the **LoRa®** library to for the communication, and we will not use any external services. Additionally, we will also create specific addresses for each board. This will help ensure that the messages that we send and receive are only displayed on the corresponding devices.
+We will use the **LoRa** library to for the communication, and we will not use any external services. Additionally, we will also create specific addresses for each board. This will help ensure that the messages that we send and receive are only displayed on the corresponding devices.
 
 Special thanks to [Sandeep Mistry](https://github.com/sandeepmistry) for creating the [LoRa library](https://github.com/sandeepmistry/arduino-LoRa).
 
@@ -54,7 +54,7 @@ To do this, we basically only need to create one sketch that we will upload to e
 
 In the code, we will have to do the following to make it work: 
 
-- Initialize the **SPI** and **LoRa®** libraries.
+- Initialize the **SPI** and **LoRa** libraries.
 - Create a string to store outgoing messages.
 - Create two bytes: one for local address, one for the destination address.
 - Set the radio frequency to 868E6 (Europe) or 915E6 (North America).

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-message/lora-message.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-message/lora-message.md
@@ -8,7 +8,7 @@ tags:
   - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-message/lora-message.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-message/lora-message.md
@@ -8,7 +8,7 @@ tags:
   - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300
@@ -23,7 +23,7 @@ In this tutorial, we will use two MKR WAN 1300's to set up a simple message serv
  
 We will use the **LoRa®** library to for the communication, and we will not use any external services. Additionally, we will also create specific addresses for each board. This will help ensure that the messages that we send and receive are only displayed on the corresponding devices.
 
-Special thanks to [Sandeep Mistry](https://github.com/sandeepmistry) for creating the [LoRa® library](https://github.com/sandeepmistry/arduino-LoRa).
+Special thanks to [Sandeep Mistry](https://github.com/sandeepmistry) for creating the [LoRa library](https://github.com/sandeepmistry/arduino-LoRa).
 
 ___
 

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-send-and-receive/lora-send-and-receive.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-send-and-receive/lora-send-and-receive.md
@@ -8,7 +8,7 @@ tags:
   - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300
@@ -57,7 +57,7 @@ ___
 -   2x Micro USB cable .
 -   Arduino IDE (offline and online versions available).
 -   Arduino SAMD core installed ([follow this link for instructions](/content/software/ide-v1/installing-samd21-core)).
--   LoRa library installed (see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)).
+-   LoRa® library installed (see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)).
 
 
 ### Circuit

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-send-and-receive/lora-send-and-receive.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-send-and-receive/lora-send-and-receive.md
@@ -8,7 +8,7 @@ tags:
   - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300
@@ -57,7 +57,7 @@ ___
 -   2x Micro USB cable .
 -   Arduino IDE (offline and online versions available).
 -   Arduino SAMD core installed ([follow this link for instructions](/content/software/ide-v1/installing-samd21-core)).
--   LoRa® library installed (see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)).
+-   LoRa library installed (see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)).
 
 
 ### Circuit

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-send-and-receive/lora-send-and-receive.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-send-and-receive/lora-send-and-receive.md
@@ -104,7 +104,7 @@ int counter = 0;
 
 In the `setup()` we will first begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 
 ```arduino

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-sensor-data/lora-sensor-data.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-sensor-data/lora-sensor-data.md
@@ -9,7 +9,7 @@ tags:
   - Environmental data
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-sensor-data/lora-sensor-data.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-sensor-data/lora-sensor-data.md
@@ -21,7 +21,7 @@ software:
   - web-editor
 ---
 
-In this tutorial, we will set up a configuration that allows two MKR WAN 1300's to send and receive sensor data. We will use the **LoRa®** library to send data, and we will not use any external service. The sensor data will be recorded through the [MKR ENV Shield](https://store.arduino.cc/arduino-mkr-env-shield), a shield that can record temperature, humidity, barometric pressure & ambient light.
+In this tutorial, we will set up a configuration that allows two MKR WAN 1300's to send and receive sensor data. We will use the **LoRa** library to send data, and we will not use any external service. The sensor data will be recorded through the [MKR ENV Shield](https://store.arduino.cc/arduino-mkr-env-shield), a shield that can record temperature, humidity, barometric pressure & ambient light.
 
 ## Hardware & Software Needed
 
@@ -88,7 +88,7 @@ int counter = 0;
 
 In the `setup()` we will begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 As we are using the MKR ENV shield, we also need to initialize the **Arduino_MKRENV** library by using the line `if (!ENV.begin())` followed by an error message in case it failed to initialize.
 

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-sensor-data/lora-sensor-data.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/tutorials/lora-sensor-data/lora-sensor-data.md
@@ -9,7 +9,7 @@ tags:
   - Environmental data
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1300

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-button-press/lora-button-press.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-button-press/lora-button-press.md
@@ -9,7 +9,7 @@ tags:
  - LED
 author: Karl Söderby
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-button-press/lora-button-press.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-button-press/lora-button-press.md
@@ -26,7 +26,7 @@ software:
 
 In this tutorial, we will set up two MKR WAN 1310's to host a remote LED control. One board will be set up as a sender with a pushbutton that when it is pressed, an LED on the other board will turn on or off. 
  
-We will use the **LoRa®** library for the communication, and we will not use any external service. 
+We will use the **LoRa** library for the communication, and we will not use any external service. 
 
 ## Hardware & Software Needed
 
@@ -101,7 +101,7 @@ int buttonState;
 
 In the `setup()` we will first define the `button` pin as an `INPUT_PULLUP`. We will then begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 ```arduino
 void setup() {
@@ -163,7 +163,7 @@ int led = 2;
 
 In the `setup()` we will first define the `led` pin as an output. We will then begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 ```arduino
 void setup() {

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-button-press/lora-button-press.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-button-press/lora-button-press.md
@@ -9,7 +9,7 @@ tags:
  - LED
 author: Karl Söderby
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310
@@ -31,7 +31,7 @@ We will use the **LoRa®** library for the communication, and we will not use an
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- LoRa® library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
+- LoRa library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
 - 2x Arduino MKR WAN 1310  ([link to store](https://store.arduino.cc/mkr-wan-1310))
 - 2x antenna ([link to store](https://store.arduino.cc/antenna))
 - 1x Pushbutton

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-message/lora-message.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-message/lora-message.md
@@ -21,7 +21,7 @@ software:
 
 In this tutorial, we will use two MKR WAN 1310's to set up a simple message service over the LoRa® network. This communication will be achieved through the Serial Monitor, where you can send and receive messages directly.  
  
-We will use the **LoRa®** library to for the communication, and we will not use any external services. Additionally, we will also create specific addresses for each board. This will help ensure that the messages that we send and receive are only displayed on the corresponding devices.
+We will use the **LoRa** library to for the communication, and we will not use any external services. Additionally, we will also create specific addresses for each board. This will help ensure that the messages that we send and receive are only displayed on the corresponding devices.
 
 Special thanks to [Sandeep Mistry](https://github.com/sandeepmistry) for creating the [LoRa library](https://github.com/sandeepmistry/arduino-LoRa).
 
@@ -55,7 +55,7 @@ To do this, we basically only need to create one sketch that we will upload to e
 
 In the code, we will have to do the following to make it work: 
 
-- Initialize the **SPI** and **LoRa®** libraries.
+- Initialize the **SPI** and **LoRa** libraries.
 - Create a string to store outgoing messages.
 - Create two bytes: one for local address, one for the destination address.
 - Set the radio frequency to 868E6 (Europe) or 915E6 (North America).
@@ -69,7 +69,7 @@ In the code, we will have to do the following to make it work:
 
 **1.** First, let's make sure we have the drivers installed. If we are using the Web Editor, we do not need to install anything. If we are using an offline editor, we need to install it manually. This can be done by navigating to **Tools > Board > Board Manager...**. Here we need to look for the **Arduino SAMD boards (32-bits ARM Cortex M0+)** and install it. 
 
-**2.** Now we need to download the **LoRa®** library from [this repository](https://github.com/sandeepmistry/arduino-LoRa), where you can install it by navigating to **Sketch > Include Library > Add .ZIP Library...** in the offline IDE. 
+**2.** Now we need to download the **LoRa** library from [this repository](https://github.com/sandeepmistry/arduino-LoRa), where you can install it by navigating to **Sketch > Include Library > Add .ZIP Library...** in the offline IDE. 
 
 
 ### Code Explanation

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-message/lora-message.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-message/lora-message.md
@@ -8,7 +8,7 @@ tags:
  - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-message/lora-message.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-message/lora-message.md
@@ -8,7 +8,7 @@ tags:
  - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-send-and-receive/lora-send-and-receive.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-send-and-receive/lora-send-and-receive.md
@@ -8,7 +8,7 @@ tags:
  - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310
@@ -59,7 +59,7 @@ ___
 -   2x Micro USB cable 
 -   Arduino IDE (offline and online versions available)
 -   Arduino SAMD core installed, [follow this link for instructions](https://www.arduino.cc/en/Guide/MKRWiFi1010#installing-drivers-for-the-mkr-wifi-1010)
--   LoRa® library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
+-   LoRa library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
 
 
 ### Circuit

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-send-and-receive/lora-send-and-receive.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-send-and-receive/lora-send-and-receive.md
@@ -8,7 +8,7 @@ tags:
  - LoRa®
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310
@@ -59,7 +59,7 @@ ___
 -   2x Micro USB cable 
 -   Arduino IDE (offline and online versions available)
 -   Arduino SAMD core installed, [follow this link for instructions](https://www.arduino.cc/en/Guide/MKRWiFi1010#installing-drivers-for-the-mkr-wifi-1010)
--   LoRa library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
+-   LoRa® library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
 
 
 ### Circuit

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-send-and-receive/lora-send-and-receive.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-send-and-receive/lora-send-and-receive.md
@@ -116,7 +116,7 @@ int counter = 0;
 
 In the `setup()` we will first begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 
 ```arduino

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
@@ -21,7 +21,7 @@ software:
   - web-editor
 ---
 
-In this tutorial, we will set up a configuration that allows two MKR WAN 1310's to send and receive sensor data. We will use the **LoRa®** library to send data, and we will not use any external service. The sensor data will be recorded through the [MKR ENV Shield](https://store.arduino.cc/arduino-mkr-env-shield), a shield that can record temperature, humidity, barometric pressure & ambient light.
+In this tutorial, we will set up a configuration that allows two MKR WAN 1310's to send and receive sensor data. We will use the **LoRa** library to send data, and we will not use any external service. The sensor data will be recorded through the [MKR ENV Shield](https://store.arduino.cc/arduino-mkr-env-shield), a shield that can record temperature, humidity, barometric pressure & ambient light.
 
 ___
 
@@ -100,7 +100,7 @@ int counter = 0;
 
 In the `setup()` we will begin serial communication, where we will use the command `while(!Serial);` to prevent the program from running until we open the Serial Monitor.
 
-We will then initialize the **LoRa®** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
+We will then initialize the **LoRa** library, where we will set the radio frequency to 868E6, which is used in Europe for LoRa® communication. If we are located in North America, we need to change this to 915E6.
 
 As we are using the MKR ENV shield, we also need to initialize the **Arduino_MKRENV** library by using the line `if (!ENV.begin())` followed by an error message in case it failed to initialize.
 

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
@@ -9,7 +9,7 @@ tags:
   - Environmental data
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
@@ -5,7 +5,7 @@ compatible-products: [mkr-wan-1310]
 description: 'Learn how to send environmental data with LoRa® using two MKR WAN 1310 and a MKR ENV shield.'
 tags: 
   - IoT
-  - LoRa®
+  - LoRa
   - Environmental data
 author: 'Karl Söderby'
 libraries: 
@@ -33,7 +33,7 @@ ___
 - 2x Micro USB cable
 - Arduino IDE (offline and online versions available).
 - Arduino SAMD core installed, [follow this link for instructions](https://www.arduino.cc/en/Guide/MKRWiFi1010#installing-drivers-for-the-mkr-wifi-1010).
-- **LoRa®** library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa).
+- **LoRa** library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa).
 - **Arduino_MKRENV** installed, [click here for more documentation](https://www.arduino.cc/en/Reference/ArduinoMKRENV).
 
 

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lora-sensor-data/lora-sensor-data.md
@@ -9,7 +9,7 @@ tags:
   - Environmental data
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
 hardware:
   - hardware/01.mkr/01.boards/mkr-wan-1310

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lorawan-regional-parameters/lorawan-regional-parameters.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/lorawan-regional-parameters/lorawan-regional-parameters.md
@@ -1,8 +1,8 @@
 ---
 title: 'LoRaWAN® Regional Parameters in the Arduino® MKRWAN 1310'
-description: 'Learn how to set up specific LoRaWAN regional parameters in the LoRa® module of the Arduino® MKR WAN 1310 board using the Arduino MKRWAN library.'
+description: 'Learn how to set up specific LoRaWAN® regional parameters in the LoRa® module of the Arduino® MKR WAN 1310 board using the Arduino MKRWAN library.'
 tags: 
-  - LoRaWAN
+  - LoRaWAN®
   - Regional parameters
   - MKR WAN 1310
   - MKRWAN
@@ -17,7 +17,7 @@ In this tutorial, we will learn how to set up specific LoRaWAN® regional parame
 
 - Learn LoRaWAN® networking protocol basics. 
 - Learn about the [LoRaWAN® Regional Parameters](https://lora-alliance.org/wp-content/uploads/2020/11/RP_2-1.0.2.pdf) specification.
-- Use the Arduino [MKRWAN library](https://github.com/arduino-libraries/MKRWAN) for setting up specific LoRaWAN® regional parameters in the LoRa module (Murata CMWX1ZZABZ-078) of the [Arduino® MKR WAN 1310](https://store.arduino.cc/mkr-wan-1310) board.
+- Use the Arduino [MKRWAN library](https://github.com/arduino-libraries/MKRWAN) for setting up specific LoRaWAN® regional parameters in the LoRa® module (Murata CMWX1ZZABZ-078) of the [Arduino® MKR WAN 1310](https://store.arduino.cc/mkr-wan-1310) board.
 
 ### Required Hardware and Software
 
@@ -32,12 +32,12 @@ LoRaWAN® is a "Low Power Wide Area (LPWA) end-to-end system architecture design
 
 LoRaWAN® **fundamental characteristics** are the following:
 
-* **Long-range**: typically two to 5 km in urban areas (obstacles) and 5 to 15 km in rural areas. 
-* **Long battery duration**: up to 10 years without a replacement (note that long battery duration will require an increased downlink latency configuration). 
-* **Low cost**: regarding sensors and maintenance. 
+* **Long-range**: typically two to 5 km in urban areas (obstacles) and 5 to 15 km in rural areas.
+* **Long battery duration**: up to 10 years without a replacement (note that long battery duration will require an increased downlink latency configuration).
+* **Low cost**: regarding sensors and maintenance.
 * **License-free spectrum**: LoRaWAN® networks operates on license-free and cost-​free ISM (Industrial, Scientific, Medical) bands; however, **region-specific regulations apply**. 
-* **Limited payload**: 51 to 256 bytes (depending on data rate). 
-* **Limited data rate**: 0.3 to 27 kbps. 
+* **Limited payload**: 51 to 256 bytes (depending on data rate).
+* **Limited data rate**: 0.3 to 27 Kbps.
 
 The LoRa Alliance® specifies the LoRaWAN® networking protocol in the **LoRaWAN® specification** documents. These documents are developed and maintained by the LoRa® Alliance, an open association of collaborating members. As stated before, though LoRaWAN® operates on **license-free and cost-​free ISM bands**, **manufacturers and operators of LoRaWAN® devices still have to fulfill various country-specific regulations**. 
 

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/mkr-wan-library-examples/mkr-wan-library-examples.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/mkr-wan-library-examples/mkr-wan-library-examples.md
@@ -1,6 +1,6 @@
 ---
 title: MKRWAN Examples
-description: 'Examples for the MKRWAN library, which is used to communicate with the LoRa module onboard the MKR WAN 1300/1310 boards.'
+description: 'Examples for the MKRWAN library, which is used to communicate with the LoRa® module onboard the MKR WAN 1300/1310 boards.'
 tags: [LoRa, WAN]
 author: Arduino
 ---
@@ -21,7 +21,7 @@ These examples will show you how to set up your board to use the LoRa® network 
 
 ### MKR WAN First Configuration
 
-This example for a MKR WAN 1300 allows you to setup your board to use the LoRa network.
+This example for a MKR WAN 1300 allows you to setup your board to use the LoRa® network.
 
 ```arduino
 /*
@@ -188,9 +188,9 @@ void loop() {
 }
 ```
 
-### MKR WAN Lora Send and Receive
+### MKR WAN Lora® Send and Receive
 
-This sketch demonstrates how to send and receive data with the MKR WAN 1300 LoRa module.
+This sketch demonstrates how to send and receive data with the MKR WAN 1300 LoRa® module.
 
 ```arduino
 

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/wan-and-gps/wan-and-gps.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/wan-and-gps/wan-and-gps.md
@@ -9,7 +9,7 @@ tags:
  - GPS
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa
+  - name: LoRa®
     url: https://github.com/sandeepmistry/arduino-LoRa
   - name: Arduino_MKRGPS
     url: https://www.arduino.cc/en/Reference/ArduinoMKRGPS
@@ -76,7 +76,7 @@ Some of the main functions of this sketch are listed below:
 
 - `byte localAddress = 0xBB;` - create a local address for our board.
 - `byte destination = 0xFF;` - create a destination address we will send our data to. 
-- `LoRa.begin(868E6)` - initializes the LoRa® module to operate on 868MHz frequency (European, for American, change to 915E6).
+- `LoRa.begin(868E6)` - initializes the LoRa® module to operate on 868 MHz frequency (European, for American, change to 915E6).
 - `GPS.begin` - initializes the GPS library.
 - `GPS.latitude()` - records latitude.
 - `GPS.longitude()` - records longitude.

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/wan-and-gps/wan-and-gps.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/wan-and-gps/wan-and-gps.md
@@ -9,7 +9,7 @@ tags:
  - GPS
 author: 'Karl Söderby'
 libraries: 
-  - name: LoRa®
+  - name: LoRa
     url: https://github.com/sandeepmistry/arduino-LoRa
   - name: Arduino_MKRGPS
     url: https://www.arduino.cc/en/Reference/ArduinoMKRGPS
@@ -27,7 +27,7 @@ software:
 
 In this tutorial, we will use the [MKR GPS Shield](https://store.arduino.cc/arduino-mkr-gps-shield) to record the longitude and latitude, and transmit it to another board using LoRa® technology. This setup can be very useful for scenarios involving remote areas, where tracking location might be essential. 
 
-Special thanks to [Sandeep Mistry](https://github.com/sandeepmistry) for creating the [LoRa® library](https://github.com/sandeepmistry/arduino-LoRa).
+Special thanks to [Sandeep Mistry](https://github.com/sandeepmistry) for creating the [LoRa library](https://github.com/sandeepmistry/arduino-LoRa).
 
 ## Goals
 
@@ -41,7 +41,7 @@ The goals of this project are:
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- LoRa® library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
+- LoRa library installed, see the [github repository](https://github.com/sandeepmistry/arduino-LoRa)
 - [Arduino_MKRGPS](https://www.arduino.cc/en/Reference/ArduinoMKRGPS) library installed
 - 2x Arduino MKR WAN 1310  ([link to store](https://store.arduino.cc/mkr-wan-1310))
 - 2x antenna ([link to store](https://store.arduino.cc/antenna))

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/wan-and-gps/wan-and-gps.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/tutorials/wan-and-gps/wan-and-gps.md
@@ -64,7 +64,7 @@ There is, of course, much more behind the GPS technology. If we want to read mor
 
 We will now go through a series of step by steps, to set up our GPS + LoRa® device. 
 
-Before starting, we will need to make sure that we have all the dependencies. For this setup, we are using **two** MKR WAN 1310 boards, two antennas and one MKR GPS Shield. We will also need to install the **Arduino_MKRGPS** library, the **LoRa®** library. The latter can be downloaded from the [LoRa® repository](https://github.com/sandeepmistry/arduino-LoRa), where you can install it by navigating to **Sketch > Include Library > Add .ZIP Library...** in the offline IDE. 
+Before starting, we will need to make sure that we have all the dependencies. For this setup, we are using **two** MKR WAN 1310 boards, two antennas and one MKR GPS Shield. We will also need to install the **Arduino_MKRGPS** library, the **LoRa** library. The latter can be downloaded from the [LoRa® repository](https://github.com/sandeepmistry/arduino-LoRa), where you can install it by navigating to **Sketch > Include Library > Add .ZIP Library...** in the offline IDE. 
 
 Since we are using two boards, we will also need to program them separately. 
 

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/securely-connecting-an-arduino-mkr-wifi-1010-to-aws-iot-core/securely-connecting-an-arduino-mkr-wifi-1010-to-aws-iot-core.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/securely-connecting-an-arduino-mkr-wifi-1010-to-aws-iot-core/securely-connecting-an-arduino-mkr-wifi-1010-to-aws-iot-core.md
@@ -134,9 +134,9 @@ Now that we have a CSR to identify the board, we need to login into the AWS cons
 
 ## Connecting the Board to AWS IoT Core
 
-1) Open the AWS IoT WiFi sketch in the Arduino IDE using the **File -> Examples -> Arduino Cloud Provider Examples -> AWSIoT-> AWS_IoT_WiFi.**
+1) Open the AWS IoT Wi-Fi sketch in the Arduino IDE using the **File -> Examples -> Arduino Cloud Provider Examples -> AWSIoT-> AWS_IoT_WiFi.**
 
-2) In the arduino_secrets.h tab. update the WiFi settings with the SSID and password of your WiFi network.
+2) In the arduino_secrets.h tab. update the Wi-Fi settings with the SSID and password of your Wi-Fi network.
 
 ```arduino
 // Fill in  your WiFi networks SSID and password
@@ -161,7 +161,7 @@ const char SECRET_CERTIFICATE[] = R"(
 )";
 ```
 
-5) Upload the sketch to your board and open the serial monitor. The board will attempt to connect to the WiFi network and if successful try to connect to AWS IoT using MQTT.
+5) Upload the sketch to your board and open the serial monitor. The board will attempt to connect to the Wi-Fi network and if successful try to connect to AWS IoT using MQTT.
 
 ### Interacting with the Board on AWS IoT Core
 

--- a/content/hardware/01.mkr/02.shields/mkr-485-shield/tutorials/mkr-485-communication/mkr-485-communication.md
+++ b/content/hardware/01.mkr/02.shields/mkr-485-shield/tutorials/mkr-485-communication/mkr-485-communication.md
@@ -46,7 +46,7 @@ The goals of this project are:
 
 RS485 is used as a physical layer for many industrial automation protocols, such as the **Modbus** protocol. It was created for the purpose of transferring data at high speeds in noisy electrical environments, typically industrial facilities. It is also commonly known as TIA-485 and EIA-485, whose names derive from the **Telecommunications Industry Association** and **Electronic Industries Alliance**. These organizations also collaborate on publishing the standard. 
 
-RS485 is able to provide speeds of up to 10 Mbps for short distances (15 meters, 50 feet), but distances can be extended if the speed is reduced to around 100 kbps (1200 meters, 4000 feet). A common setup is to have one controller* device, with several peripheral* devices.
+RS485 is able to provide speeds of up to 10 Mbps for short distances (15 meters, 50 feet), but distances can be extended if the speed is reduced to around 100 Kbps (1200 meters, 4000 feet). A common setup is to have one controller* device, with several peripheral* devices.
 
 >**Note:** Controller/peripheral is formerly known as **master/slave**. Arduino no longer supports the use of this terminology. 
 

--- a/content/hardware/01.mkr/02.shields/mkr-can-shield/tutorials/mkr-can-communication/mkr-can-communication.md
+++ b/content/hardware/01.mkr/02.shields/mkr-can-shield/tutorials/mkr-can-communication/mkr-can-communication.md
@@ -91,7 +91,7 @@ We will now get to the programming part of this tutorial.
 
 **3.** We can now take a look at some core functions we are going to use: 
 
-- `CAN.begin(500E3)` - initializes the library with a speed of 500 kbps.
+- `CAN.begin(500E3)` - initializes the library with a speed of 500 Kbps.
 - `CAN.beginPacket(0x12)` - begins a packet with specific ID (ID is 11 bits).
 - `CAN.beginExtendedPacket(0xabcdef)` - begins an extended packet with specific ID (ID is 29 bits).
 - `CAN.write('o')` - writes a byte to the packet. 

--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
@@ -56,7 +56,7 @@ The MKR IoT Carrier can be controlled through the [Arduino IoT Cloud](https://cr
 - [MKR WAN 1310](https://docs.arduino.cc/hardware/mkr-wan-1310)
 - [MKR WiFi 1010](https://docs.arduino.cc/hardware/mkr-wifi-1010)
 
-***Note: The MKR GSM 1400 and MKR NB 1500 require a SIM card to connect to the Cloud, as they communicate over the mobile networks. The MKR WAN 1300 and 1310 board requires a Arduino PRO Gateway LoRa to connect to the cloud.***
+***Note: The MKR GSM 1400 and MKR NB 1500 require a SIM card to connect to the Cloud, as they communicate over the mobile networks. The MKR WAN 1300 and 1310 board requires a Arduino PRO Gateway LoRa® to connect to the cloud.***
 
 If you need help to get started, you can go through the [Arduino IoT Cloud tutorial](https://docs.arduino.cc/cloud/iot-cloud/tutorials/iot-cloud-getting-started).
 

--- a/content/hardware/02.hero/boards/uno-rev3/tutorials/intro-to-board/intro-to-board.md
+++ b/content/hardware/02.hero/boards/uno-rev3/tutorials/intro-to-board/intro-to-board.md
@@ -32,7 +32,7 @@ Starting clockwise from the top center:
 - DC Current per I/O Pin:	40 mA
 - Flash Memory:	32 KB
 - SRAM:	2 KB
-- EEPROM:	1KB
+- EEPROM:	1 KB
 
 
 

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/file-write-script/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/file-write-script/content.md
@@ -54,7 +54,7 @@ void loop() {
 }
 ```
 
-Your `uploadScript()` function will create a shell script in the Linux file system that will check the network traffic of the WiFi interface. Create the file and open it by creating an instance of the `File@ class, and calling`FileSystem.open()@@ indicating where you would like to create the script. You'll store the script in "/tmp", which resides in RAM, to preserve the limited number of FLASH memory read/write cycles.
+Your `uploadScript()` function will create a shell script in the Linux file system that will check the network traffic of the Wi-Fi interface. Create the file and open it by creating an instance of the `File@ class, and calling`FileSystem.open()@@ indicating where you would like to create the script. You'll store the script in "/tmp", which resides in RAM, to preserve the limited number of FLASH memory read/write cycles.
 
 ```arduino
 void uploadScript() {
@@ -62,7 +62,7 @@ void uploadScript() {
   File script = FileSystem.open("/tmp/wlan-stats.sh", FILE_WRITE);
 ```
 
-Write the contents of the script to the file with `File.print()`. begin by printing the header, "#!/bin/s", then the utility `ifconfig`.  @ifconfig@ is a command line utility for controlling network interfaces. you'll be looking at the WiFi interface, which is referred to as "wlan0". The utility `grep` will search the output of `ifconfig`. You're looking for the number of bytes received , so search for the keywords "RX bytes" and close the file.
+Write the contents of the script to the file with `File.print()`. begin by printing the header, "#!/bin/s", then the utility `ifconfig`.  @ifconfig@ is a command line utility for controlling network interfaces. you'll be looking at the Wi-Fi interface, which is referred to as "wlan0". The utility `grep` will search the output of `ifconfig`. You're looking for the number of bytes received , so search for the keywords "RX bytes" and close the file.
 
 ```arduino
 script.print("#!/bin/sh\n");
@@ -179,7 +179,7 @@ void loop() {
 }
 
 // this function creates a file into the linux processor that contains a shell script
-// to check the network traffic of the WiFi interface
+// to check the network traffic of the Wi-Fi interface
 void uploadScript() {
 
   // Write our shell script in /tmp

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/http-client-console/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/http-client-console/content.md
@@ -2,10 +2,10 @@
 tags: [Yún]
 author: Arduino
 title: 'Arduino Yún HTTP Client Console'
-description: 'Create a simple client that downloads a webpage and prints it to the serial monitor via WiFi using Console.'
+description: 'Create a simple client that downloads a webpage and prints it to the serial monitor via Wi-Fi using Console.'
 ---
 
-This example for a Yún device shows how create a basic HTTP client that connects to the Internet and downloads content. In this case, you'll connect to the Arduino website and download a version of the logo as ASCII text. This version uses Console and shows the output on your Arduino Software (IDE) Console through a WiFi connection and not the USB one.
+This example for a Yún device shows how create a basic HTTP client that connects to the Internet and downloads content. In this case, you'll connect to the Arduino website and download a version of the logo as ASCII text. This version uses Console and shows the output on your Arduino Software (IDE) Console through a Wi-Fi connection and not the USB one.
 
 Select the IP port as connection to your board and open the Serial Monitor in the IDE once you've programmed the board.
 

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/remote-due-blink/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/remote-due-blink/content.md
@@ -5,7 +5,7 @@ title: 'Arduino Yún Remote Due Blink'
 description: 'Demonstrates how to upload remotely a sketch on DUE boards.'
 ---
 
-This is a special version of the basic **Blink** example. It's made for demonstrating how to enable the possibility to upload a sketch on a DUE board and a Yún shield using the remote upload feature (via WiFi or Ethernet) offered by the Arduino Software (IDE).
+This is a special version of the basic **Blink** example. It's made for demonstrating how to enable the possibility to upload a sketch on a DUE board and a Yún shield using the remote upload feature (via Wi-Fi or Ethernet) offered by the Arduino Software (IDE).
 
 ## Preparing Arduino Due For Remote Upload
 

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/shell-commands/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/shell-commands/content.md
@@ -9,7 +9,7 @@ This sketch demonstrates running Linux shell commands on a Yún device.
 
 It runs the wifiCheck script (located at /usr/bin/pretty-wifi-info.lua) on the Linux processor, then uses grep to get the signal strength.
 
-On the board, parseInt() is called to read the WiFi signal strength as an integer, and uses that number to fade an LED with `analogWrite()`.
+On the board, parseInt() is called to read the Wi-Fi signal strength as an integer, and uses that number to fade an LED with `analogWrite()`.
 
 ## Hardware Required
 
@@ -57,7 +57,7 @@ void setup() {
 }
 ```
 
-Create a named Process with which you'll use to run the WiFi status script and grep.
+Create a named Process with which you'll use to run the Wi-Fi status script and grep.
 
 ```arduino
 void loop() {

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/time-check/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/time-check/content.md
@@ -5,13 +5,13 @@ title: 'Arduino Yún Time Check'
 description: 'Get the time from a network time server and print it to the serial monitor.'
 ---
 
-This example for a Yún device gets the time from the Linux processor via Bridge, then parses out hours, minutes and seconds for the Arduino. The Yún device must be connected to a network to get the correct time. If you used the web-based WiFi interface to configure the Yún device for the network, make sure you've selected the proper time zone.
+This example for a Yún device gets the time from the Linux processor via Bridge, then parses out hours, minutes and seconds for the Arduino. The Yún device must be connected to a network to get the correct time. If you used the web-based Wi-Fi interface to configure the Yún device for the network, make sure you've selected the proper time zone.
 
 ## Hardware Required
 
 - Yún board or shield
 
-- WiFi network connected to the internet
+- Wi-Fi network connected to the internet
 
 ## Circuit
 

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/wifi-status/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/wifi-status/content.md
@@ -1,11 +1,11 @@
 ---
 tags: [Yún]
 author: Arduino
-title: 'Arduino Yún WiFi Status'
-description: 'Runs a pre-configured script that reports back the strength of the current WiFi network.'
+title: 'Arduino Yún Wi-Fi Status'
+description: 'Runs a pre-configured script that reports back the strength of the current Wi-Fi network.'
 ---
 
-This sketch runs a script called "pretty-wifi-info.lua" installed on your Yún device in the folder /usr/bin. It prints information about the status of your WiFi connection.
+This sketch runs a script called "pretty-wifi-info.lua" installed on your Yún device in the folder /usr/bin. It prints information about the status of your Wi-Fi connection.
 
 It uses Serial to print, so you need to connect your Yún device to your computer using a USB cable and select the appropriate port from the Port menu before it will run.
 
@@ -51,7 +51,7 @@ void setup() {
 }
 ```
 
-In `loop()`, initialize a new process that will run the WiFi check script. you can run the script by calling `runShellCommand()` with the path to the script.
+In `loop()`, initialize a new process that will run the Wi-Fi check script. you can run the script by calling `runShellCommand()` with the path to the script.
 
 ```arduino
 void loop() {

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
@@ -2,13 +2,13 @@
 tags: [Yún]
 author: Arduino
 title: 'Arduino Yún Yún First Configuration'
-description: 'Connect your Yun product to the WiFi networks in a breeze using the Serial Monitor and answering a few simple questions within it.'
+description: 'Connect your Yun product to the Wi-Fi networks in a breeze using the Serial Monitor and answering a few simple questions within it.'
 ---
 
-This example shows you how to connect to a WiFi network with your Yún device using the Serial Monitor as the communication interface during the whole process.
+This example shows you how to connect to a Wi-Fi network with your Yún device using the Serial Monitor as the communication interface during the whole process.
 
 Upload the sketch on your Yún device and open the Serial Monitor.
-The Serial Monitor output will display the available WiFi networks, then asks you to choose the one to use. You have to input the network password and then you are asked to give your Yún device a name and a password. If the connection with the selected network is successful, you get a confirmation message and the IP assigned to your Yún device. By pasting this IP address on your web browser you will be able to reach the Yún Panel for further options.
+The Serial Monitor output will display the available Wi-Fi networks, then asks you to choose the one to use. You have to input the network password and then you are asked to give your Yún device a name and a password. If the connection with the selected network is successful, you get a confirmation message and the IP assigned to your Yún device. By pasting this IP address on your web browser you will be able to reach the Yún Panel for further options.
 
 If something goes wrong, you can restart the procedure; if the network you want to connect to is not in the list, you may proceed with the manual selection specifying the network SSID and passkey.
 
@@ -32,13 +32,13 @@ image developed using [Fritzing](http://www.fritzing.org). For more circuit exam
 
 ### Libraries
 
-**Process.h** is used to launch processes on the Linux processor, and other things like shell scripts. Here we use it to get the list of APs and to perform other actions that let us know the WiFi parameters.
+**Process.h** is used to launch processes on the Linux processor, and other things like shell scripts. Here we use it to get the list of APs and to perform other actions that let us know the Wi-Fi parameters.
 
 ### Functions
 
 **String getUserInput(String out, bool obfuscated)*** - manages the input from the user through the Serial Monitor, printing back in the window. The boolean variable "obfuscated" is used to print out "**" when a password is entered.
 
-**void wifiConfig(String yunName, String yunPsw, String wifissid, String wifipsw, String wifiAPname, String countryCode, String encryption)** - uses Process to execute a series of commands and scripts, under linux, that set the WiFi and network parameters as chosen by the user.
+**void wifiConfig(String yunName, String yunPsw, String wifissid, String wifipsw, String wifiAPname, String countryCode, String encryption)** - uses Process to execute a series of commands and scripts, under linux, that set the Wi-Fi and network parameters as chosen by the user.
 
 **void startSerialTerminal()** - simply initialize the two serial ports needed to perform the actions required by the sketch.
 
@@ -47,7 +47,7 @@ image developed using [Fritzing](http://www.fritzing.org). For more circuit exam
 ## Usage
 
 This sketch uses the Serial Monitor of your Arduino Software (IDE) to interact with you, asking the relevant information for the configuration. The Yún device uses the hardware serial port on pins 0 and 1 to communicate with the board, therefore this sketch requires a second hardware serial port to work properly.
-Please get ready with SSID (the Access Point name) and the key or passphrase to access the WiFi network.
+Please get ready with SSID (the Access Point name) and the key or passphrase to access the Wi-Fi network.
 Load the sketch and then open the Serial Monitor clicking on the Magnifier Lens icon on the right of the icon bar.
 You will see a message as the one in the screenshot below.
 
@@ -59,7 +59,7 @@ You choose the AP to use typing in the input field the corresponding number. Ple
 ![Setup window two.](assets/EasySetup_2.png)
 
 The selection of the AP triggers the connection process and the Yún device will sense if the network is open or protected. In this later case, you will be asked to provide the key. The Yún device needs to be named and protected with a password to allow easy and secure connections.
-Following these step, your device is ready to connect to the WiFi network, switching off the AP mode and initiating the access to the selected WiFi network. At the end of this process, the sketch will show the IP address obtained from the WiFi DHCP server.
+Following these step, your device is ready to connect to the Wi-Fi network, switching off the AP mode and initiating the access to the selected Wi-Fi network. At the end of this process, the sketch will show the IP address obtained from the Wi-Fi DHCP server.
 
 ![Setup window three.](assets/EasySetup_3.png)
 

--- a/content/hardware/03.nano/boards/nano-33-ble-sense/tutorials/get-started-with-machine-learning/get-started-with-machine-learning.md
+++ b/content/hardware/03.nano/boards/nano-33-ble-sense/tutorials/get-started-with-machine-learning/get-started-with-machine-learning.md
@@ -63,7 +63,7 @@ Unlike classic Arduino Uno, the board combines a microcontroller with onboard se
 ## Microcontrollers and TinyML
 Microcontrollers, such as those used on Arduino boards, are low-cost, single chip, self-contained computer systems. They’re the invisible computers embedded inside billions of everyday gadgets like wearables, drones, 3D printers, toys, rice cookers, smart plugs, e-scooters, washing machines. The trend to connect these devices is part of what is referred to as the Internet of Things.
 
-Arduino is an open-source platform and community focused on making microcontroller application development accessible to [everyone](https://create.arduino.cc/projecthub). The [board](https://store.arduino.cc/usa/nano-33-ble-sense) we’re using here has an Arm Cortex-M4 microcontroller running at 64 MHz with 1MB Flash memory and 256 KB of RAM. This is tiny in comparison to cloud, PC, or mobile but reasonable by microcontroller standards.
+Arduino is an open-source platform and community focused on making microcontroller application development accessible to [everyone](https://create.arduino.cc/projecthub). The [board](https://store.arduino.cc/usa/nano-33-ble-sense) we’re using here has an Arm Cortex-M4 microcontroller running at 64 MHz with 1 MB Flash memory and 256 KB of RAM. This is tiny in comparison to cloud, PC, or mobile but reasonable by microcontroller standards.
 
 ![Arduino Nano 33 BLE Sense board is smaller than a stick of gum.](assets/nanosenseble.png)
 
@@ -97,7 +97,7 @@ Once you connect your Arduino Nano 33 BLE Sense to your desktop machine with a U
 ![Compiling an example from the Arduino_TensorFlowLite library.](assets/create-lib.gif)
 
 ## Focus On The Speech Recognition Example
-One of the first steps with an Arduino board is getting the LED to flash. Here, we’ll do it with a twist by using TensorFlow Lite Micro to recognise voice keywords. It has a simple vocabulary of “yes” and “no.” Remember this model is running locally on a microcontroller with only 256KB of RAM, so don’t expect commercial ‘voice assistant’ level accuracy – it has no Internet connection and on the order of 2000x less local RAM available.
+One of the first steps with an Arduino board is getting the LED to flash. Here, we’ll do it with a twist by using TensorFlow Lite Micro to recognise voice keywords. It has a simple vocabulary of “yes” and “no.” Remember this model is running locally on a microcontroller with only 256 KB of RAM, so don’t expect commercial ‘voice assistant’ level accuracy – it has no Internet connection and on the order of 2000x less local RAM available.
 
 Note the board can be battery powered as well. As the Arduino can be connected to motors, actuators and more this offers the potential for voice-controlled projects.
 

--- a/content/hardware/03.nano/boards/nano-33-ble-sense/tutorials/microphone-sensor/microphone_sensor.md
+++ b/content/hardware/03.nano/boards/nano-33-ble-sense/tutorials/microphone-sensor/microphone_sensor.md
@@ -90,7 +90,7 @@ short sampleBuffer[256];
 volatile int samplesRead;
 ```
 
-In the `setup()`, we use the `PDM.conReceive()` function to configure the data receive callback. Lastly, the `PDM.begin()` sets the sensor to read data from just one channel and a sample rate of 16kHz, this statement is inside an `if()` that will print a message, as a string, in case the sensor has not been properly initialized.
+In the `setup()`, we use the `PDM.conReceive()` function to configure the data receive callback. Lastly, the `PDM.begin()` sets the sensor to read data from just one channel and a sample rate of 16 kHz, this statement is inside an `if()` that will print a message, as a string, in case the sensor has not been properly initialized.
 
 ```arduino
 void setup() {

--- a/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
+++ b/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
@@ -230,7 +230,7 @@ Add a gif/video.
 
 ***For the purposes of this tutorial, we will leave the `Use static IP address and disable DHCP` box unchecked. This means that a dynamic IP address will be allocated to the Nano 33 IoT.***
 
-**2.** We now need to configure the wireless settings. Click on **WiFi properties** and enter the **Service set identifier (SSID)** or name of your wireless network. Select the appropriate encryption (`None`, `WEP` or `WPA`) and enter your password.
+**2.** We now need to configure the wireless settings. Click on **Wi-Fi properties** and enter the **Service set identifier (SSID)** or name of your wireless network. Select the appropriate encryption (`None`, `WEP` or `WPA`) and enter your password.
 
 ![Configure Wi-Fi Credentials](img/nano-Simulink-WiFi-LED-Wi-Fi-Credentials.png)
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
@@ -311,4 +311,4 @@ It's not recommended to use the Flash of the microcontroller as the primary stor
 
 - Learn how to retrieve a collection of keys using TDBStore iterators via [`iterator_open`](https://os.mbed.com/docs/mbed-os/v6.9/mbed-os-api-doxy/classmbed_1_1_k_v_store.html#a77661adec54b9909816e7492a2c61a91) and [`iterator_next`](https://os.mbed.com/docs/mbed-os/v6.9/mbed-os-api-doxy/classmbed_1_1_k_v_store.html#a5116b40a3480462b88dc3f1bb8583ad4)
 - Learn how to create an incremental TDBStore set sequence via [`set_start`](https://os.mbed.com/docs/mbed-os/v6.9/mbed-os-api-doxy/classmbed_1_1_k_v_store.html#a6e882a0d4e0cbadf6269142ac3c4e693), [`set_add_data`](https://os.mbed.com/docs/mbed-os/v6.9/mbed-os-api-doxy/classmbed_1_1_k_v_store.html#adbe636bf8c05834fe68b281fc638c348) and [`set_finalize`](https://os.mbed.com/docs/mbed-os/v6.9/mbed-os-api-doxy/classmbed_1_1_k_v_store.html#a346da66252added46d3b93902066b548)
-- Learn how to use the 16MB QSPI Flash on the Portenta H7
+- Learn how to use the 16 MB QSPI Flash on the Portenta H7

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/openmv-cheat-sheet/openmv-cheat-sheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/openmv-cheat-sheet/openmv-cheat-sheet.md
@@ -531,20 +531,20 @@ uart.write(buffer)
 
 ### WIFI
 
-To use Wifi we first need to import the relevant library.
+To use Wi-Fi we first need to import the relevant library.
 
 ```python
 import network
 ```
 
-Then we need to define the Wifi networks SSID and put that in a variable. We must do the same for the networks password.
+Then we need to define the Wi-Fi networks SSID and put that in a variable. We must do the same for the networks password.
 
 ```python
 SSID=''
 PASSWORD=''
 ```
 
-Next we can create a WLAN network interface object. In the argument we enter `network.STA_IF`, which indicates that our device will be a client and connect to a WiFi access point.
+Next we can create a WLAN network interface object. In the argument we enter `network.STA_IF`, which indicates that our device will be a client and connect to a Wi-Fi access point.
 
 ```python
 wlan = network.WLAN(network.STA_IF)

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -151,7 +151,7 @@ We are using `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name and for fa
 ### QSPI Storage Mode
 
 #### Setting Up
-To use internal **QSPI** storage for downloading the binary file via OTA (Over-The-Air), you will only need the Arduino Portenta H7 board connected to the computer with the [Arduino IDE](https://www.arduino.cc/en/software). With it, you will need to have selected the **Arduino Portenta H7 (M7 Core)** with the Flash split of **1MB M7 + 1MB M4** for the purpose of this tutorial and the corresponding port. 
+To use internal **QSPI** storage for downloading the binary file via OTA (Over-The-Air), you will only need the Arduino Portenta H7 board connected to the computer with the [Arduino IDE](https://www.arduino.cc/en/software). With it, you will need to have selected the **Arduino Portenta H7 (M7 Core)** with the Flash split of **1MB M7 + 1 MB M4** for the purpose of this tutorial and the corresponding port. 
 
 ![Arduino Portenta H7 Board Connection](assets/portenta_h7_board_selection.png)
 
@@ -171,7 +171,7 @@ To use the **SD card** as the preferred OTA (Over-The-Air) storage device, we wi
 
 ![Arduino Portenta H7 with Vision Shield (Ethernet)](assets/portenta_h7_plus_vision_shield.svg)
 
-With this, you will need the Arduino Portenta H7 board connected to the computer with the Arduino IDE. You will need to have selected the **Arduino Portenta H7 (M7 Core)** with the Flash split of **1MB M7 + 1MB M4** for the purpose of this tutorial and the corresponding port.
+With this, you will need the Arduino Portenta H7 board connected to the computer with the Arduino IDE. You will need to have selected the **Arduino Portenta H7 (M7 Core)** with the Flash split of **1MB M7 + 1 MB M4** for the purpose of this tutorial and the corresponding port.
 
 #### Writing the Script
 As same as QSPI storage mode, to proceed with a OTA using the SD Card, you can open the sketch from **Examples > Arduino_Portenta_OTA > OTA_SD_Portenta**.

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -151,7 +151,7 @@ We are using `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name and for fa
 ### QSPI Storage Mode
 
 #### Setting Up
-To use internal **QSPI** storage for downloading the binary file via OTA (Over-The-Air), you will only need the Arduino Portenta H7 board connected to the computer with the [Arduino IDE](https://www.arduino.cc/en/software). With it, you will need to have selected the **Arduino Portenta H7 (M7 Core)** with the Flash split of **1MB M7 + 1 MB M4** for the purpose of this tutorial and the corresponding port. 
+To use internal **QSPI** storage for downloading the binary file via OTA (Over-The-Air), you will only need the Arduino Portenta H7 board connected to the computer with the [Arduino IDE](https://www.arduino.cc/en/software). With it, you will need to have selected the **Arduino Portenta H7 (M7 Core)** with the Flash split of **1MB M7 + 1MB M4** for the purpose of this tutorial and the corresponding port. 
 
 ![Arduino Portenta H7 Board Connection](assets/portenta_h7_board_selection.png)
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/wifi-access-point/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/wifi-access-point/content.md
@@ -4,7 +4,7 @@ description: 'In this tutorial you will configure the Portenta H7 as an access p
 coverImage: assets/por_ard_ap_cover.svg
 difficulty: easy
 tags:
-  - WiFi
+  - Wi-Fi
   - Access Point
   - HTTP
   - Web Server
@@ -37,7 +37,7 @@ Portenta H7 comes with an on-board Wi-Fi and a Bluetooth® Module that allows to
 - A smart phone
 
 ## Access Point Configuration
-The Portenta H7 features a  [Murata 1DX](https://wireless.murata.com/type-1dx.html), which is a high performance chipset which supports  Wi-Fi 802.11b/g/n + Bluetooth® 5.1 BR/EDR/LE up to 65Mbps PHY data rate on Wi-Fi and 3Mbps PHY data rate on Bluetooth®. This module helps to configure the Portenta into three different modes of operation -  an Access Point,  a Station, or both. In this tutorial we will only focus on the access point configuration.
+The Portenta H7 features a  [Murata 1DX](https://wireless.murata.com/type-1dx.html), which is a high performance chipset which supports  Wi-Fi 802.11b/g/n + Bluetooth® 5.1 BR/EDR/LE up to 65 Mbps PHY data rate on Wi-Fi and 3 Mbps PHY data rate on Bluetooth®. This module helps to configure the Portenta into three different modes of operation -  an Access Point,  a Station, or both. In this tutorial we will only focus on the access point configuration.
 
 When the  board is configured to operate as an access point, it can create its own wireless LAN (WLAN) network. In this mode, the board transmits and receives signals at 2.4 GHz allowing other electronic devices with Wi-Fi capabilities using the same bandwidth to connect to the board.
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/display-output-webgl/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/display-output-webgl/content.md
@@ -74,7 +74,7 @@ IN-USE  BSSID              SSID             MODE   CHAN  RATE        SIGNAL  BAR
         AA:BB:CC:DD:EE:FF  <yourAP-SSID>    Infra  X     130 Mbit/s  --      *     WPA2
 ```
 
-You can save your WiFi details with these commands:
+You can save your Wi-Fi details with these commands:
 ```
 nmcli c add type wifi con-name <customName> ifname wlan0 ssid <SSID>
 nmcli con modify <customName> wifi-sec.key-mgmt wpa-psk

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/out-of-the-box/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/out-of-the-box/content.md
@@ -43,19 +43,19 @@ Once the Portenta X8 is plugged in via USB, you can open your browser and go to 
 
 Click the Wi-Fi button to start configuring your network connection.
 
-![Select wifi on set up page](assets/x8-oob-main-wifi.png)
+![Select Wi-Fi on set up page](assets/x8-oob-main-wifi.png)
 
 Select your Wi-Fi SSID.
 
-![Wifi ssid set up](assets/x8-oob-wifi-ssid.png)
+![Wi-Fi ssid set up](assets/x8-oob-wifi-ssid.png)
 
 Type the password.
 
-![Wifi password set up](assets/x8-oob-wifi-pass.png)
+![Wi-Fi password set up](assets/x8-oob-wifi-pass.png)
 
 Once it is connected, you should see the Wi-Fi status bullet in the bottom left turning green.
 
-![Wifi connection done](assets/x8-oob-wifi-sucess.png)
+![Wi-Fi connection done](assets/x8-oob-wifi-sucess.png)
 
 ***You can change your network by clicking on the button again and repeat the above steps***
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
@@ -181,7 +181,7 @@ If the code is not working, there are some common issues we can troubleshoot:
 
 - The Portenta Max Carrier offers a lot of features when used with the Portenta H7. If you want to learn more about the Portenta Max Carriers peripherals and features, check out our [Getting Started guide for Max Carrier and Portenta H7](/tutorials/getting-started-with-H7).
 
-- If you are interested in trying out more of the Max Carriers connectivity options. Be sure to check out our tutorial on how to use [LoRa with the Max Carrier and Portenta H7](/tutorials/lora-tutorial).
+- If you are interested in trying out more of the Max Carriers connectivity options. Be sure to check out our tutorial on how to use [LoRa® with the Max Carrier and Portenta H7](/tutorials/lora-tutorial).
 
 ## Conclusion
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/connecting-to-ttn/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/connecting-to-ttn/content.md
@@ -170,10 +170,10 @@ On the registration page, click on **Manually**; you will have to add the follow
 * **LoRaWAN® version**: 1.0.2.
 * **Regional Parameters version**: 1.0.2.
 
-Click on Show advanced activation, **LoRaWAN class and cluster settings** and choose: 
+Click on Show advanced activation, **LoRaWAN® class and cluster settings** and choose: 
 
 * **Activation mode**: Over the air activation (OTAA).
-* **Additional LoRaWAN class capabilities**: None (class A only).
+* **Additional LoRaWAN® class capabilities**: None (class A only).
 * **Network defaults**: Use network's default MAC settings.
 
 Leave the **Cluster settings** option unchecked. Then continue with the following information:

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/getting-started/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/getting-started/content.md
@@ -113,7 +113,7 @@ The Portenta Max Carrier equips two different memory units on-board: Flash Memor
 
 **On-Board Flash Memory**
 
-- The Flash memory on-board the Portenta Max Carrier has 2MB of storage via QSPI (Quad Serial Peripheral Interface).
+- The Flash memory on-board the Portenta Max Carrier has 2 MB of storage via QSPI (Quad Serial Peripheral Interface).
 
 ***For more information on how to use the Flash Memory storage, please follow this [guide](https://docs.arduino.cc/tutorials/portenta-h7/reading-writing-flash-memory) to get most out of the Flash Memory.***
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/x8-getting-started/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/x8-getting-started/content.md
@@ -59,7 +59,7 @@ To make use of the Portenta Max Carrier you will need to power it through either
 
 ### Memory
 
-The Portenta Max Carrier equips two different memory units on-board, a flash memory and a mini SD card slot. The Flash memory on-board the Portenta Max Carrier has 2MB of storage via QSPI. The Mini SD card interface makes it possible to extend the storage size. It can be used to process log data, from sensors or programmed on-board computer registry.
+The Portenta Max Carrier equips two different memory units on-board, a flash memory and a mini SD card slot. The Flash memory on-board the Portenta Max Carrier has 2 MB of storage via QSPI. The Mini SD card interface makes it possible to extend the storage size. It can be used to process log data, from sensors or programmed on-board computer registry.
 
 If you have a sd card connected to the Max Carrier you can create a directory on the sd card by using the following command:
 ```python
@@ -83,11 +83,11 @@ apk update && apk add alsa-utils alsa-utils-doc alsa-lib alsaconf alsa-ucm-conf 
 
 The Portenta Max Carrier carries a cellular modem SARA-R412M-02B to carry out tasks requiring general network connectivity. This cellular modem is capable of establishing 2G / Cat-M1 / NB-IoT connections globally. It is powered by bidirectional logic level shifter SN74LVC1T45 and an internal regulator, implemented for the use of SIM card and I/O. The cellular modem requires a SIM card and an antenna connected to the SMA connector.
 
-![LoRa and GSM peripherals on the Max Carrier](assets/lora-on-max-carrier.svg)
+![LoRa® and GSM peripherals on the Max Carrier](assets/lora-on-max-carrier.svg)
 
 If you want to use this feature with python scripts, have a look at the [Modem Manager api](https://github.com/freedesktop/ModemManager).
 
-### LoRa
+### LoRa®
 
 One of the many features of the Portenta Max Carrier is the Murata CMWX1ZZABZ-078 that enables LoRaWAN® connectivity. LoRaWAN® is a Low Power Wide Area Network (LPWAN) designed to connect low power devices to the Internet. It was developed to meet and fulfill Internet of Things (IoT) devices' requirements, such as low-power consumption and low data throughput.
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/datasheet/datasheet.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/datasheet/datasheet.md
@@ -1,6 +1,6 @@
 ---
 identifier: ASX00026
-title: Arduino® Portenta Vision Shield - LoRa
+title: Arduino® Portenta Vision Shield - LoRa®
 type: pro
 ---
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/connecting-to-ttn/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/connecting-to-ttn/content.md
@@ -78,7 +78,7 @@ After completing these two fields, press the "Create application" button located
 
 Let's take a closer look at these sections:
 
-- **Application Overview**: in order to use this app, you'll need the Application ID and a device specific AppKey. An EUI is a globally unique identifier for networks, gateways applications and devices. The EUIs are used to identify all parts of the LoRaWAN inside the backend server.
+- **Application Overview**: in order to use this app, you'll need the Application ID and a device specific AppKey. An EUI is a globally unique identifier for networks, gateways applications and devices. The EUIs are used to identify all parts of the LoRaWAN® inside the backend server.
 - **End devices**: here you can see and manage all the associated devices (e.g. your Portenta H7 with Vision Shield - LoRa®, Arduino MKR WAN 1300 or MKR WAN 1310), or proceed with the registration of a new one. Registering a new device lets you generate an AppEUI and an AppKey.
 - **Collaborators**: here you can see and manage all the app collaborators. To integrate with other collaborative platforms or to manage access rights to the app with other TTN registered profiles.
 - **API keys**: here you can create an API key, it's the most sensible information. It is basically the key to gain access to your app, so keep it safe.

--- a/content/hardware/05.nicla/boards/nicla-sense-me/tutorials/use-as-mkr-shield/use-as-mkr-shield.md
+++ b/content/hardware/05.nicla/boards/nicla-sense-me/tutorials/use-as-mkr-shield/use-as-mkr-shield.md
@@ -32,7 +32,7 @@ The form factor of the Nicla Sense allows the board to be used as a MKR shield. 
 ## Goals.
 
 -   How to solder the headers on the Nicla Sense ME.
--   To establish an I<sup>2</sup>C communication between the MKRWiFi 1010 and the Nicla Sense  
+-   To establish an I<sup>2</sup>C communication between the MKR WiFi 1010 and the Nicla Sense  
 
 ### Required Hardware and Software
 

--- a/content/hardware/05.nicla/boards/nicla-vision/tutorials/proximity/content.md
+++ b/content/hardware/05.nicla/boards/nicla-vision/tutorials/proximity/content.md
@@ -95,7 +95,7 @@ Inside the setup you need to initialize and configure the proximity sensor. Also
   }
 ```
 
-***Make sure you initialize `Wire1`, set the clock speed to 400kHz and set the bus pointer to `Wire1`, it won't work if you don't add these setting.***
+***Make sure you initialize `Wire1`, set the clock speed to 400 kHz and set the bus pointer to `Wire1`, it won't work if you don't add these setting.***
 
 ### Control the Speed of the Blink
 

--- a/content/learn/05.communication/05.lorawan-101/lorawan-101.md
+++ b/content/learn/05.communication/05.lorawan-101/lorawan-101.md
@@ -2,8 +2,8 @@
 title: 'The Arduino Guide to LoRa® and LoRaWAN®'
 description: 'Learn the basics of LoRa® and LoRaWAN® and how to use them with Arduino hardware and software.'
 tags: 
-  - LoRa
-  - LoRaWAN
+  - LoRa®
+  - LoRaWAN®
   - MKR WAN 1310
 author: 'José Bagur, Taddy Chung'
 ---

--- a/content/retired/06.getting-started-guides/ArduinoWiFiShield101/ArduinoWiFiShield101.md
+++ b/content/retired/06.getting-started-guides/ArduinoWiFiShield101/ArduinoWiFiShield101.md
@@ -320,7 +320,7 @@ When it is needed, the WiFi101 library is updated to implement new features. Thi
 Here a list of tutorials that will help you in making very cool things!
 
 [Interact with Google Calendar](/en/Tutorial/Wifi101GoogleCalendar)
-This example shows you how to make requests to Google Calendar using a WiFi101 shield.
+This example shows you how to make requests to Google Calendar using a WiFi shield 101.
 
 [Weather audio notifier](/en/Tutorial/WiFi101WeatherAudioNotifier)
 In this example, weather information from openweathermap.org is used to display the current weather information.

--- a/content/tutorials/generic/WiFi101ThingSpeakDataUploader/WiFi101ThingSpeakDataUploader.md
+++ b/content/tutorials/generic/WiFi101ThingSpeakDataUploader/WiFi101ThingSpeakDataUploader.md
@@ -1,13 +1,13 @@
 ---
 author: 'Arduino'
-description: 'This tutorial demonstrates how to use the Arduino Zero or Arduino Uno and the WiFi101 shield to send a live stream of the light and temperature values.'
+description: 'This tutorial demonstrates how to use the Arduino Zero or Arduino Uno and the WiFi shield 101 to send a live stream of the light and temperature values.'
 title: 'WiFi101 ThingSpeak Data Uploader Example'
 tags: [WiFi101]
 ---
 
 ## WiFi 101 ThingSpeak Data Uploader
 
-This tutorial demonstrates how to use the Arduino Zero or Arduino Uno and the WiFi101 shield to send a live stream of the light and temperature values in your environment using [ThingSpeak.com](https://www.thingspeak.com). ThingSpeak is an open data platform for the Internet of Things which allows you to collect data in a your own channel and get data from other channels using the API. In this example, we will use a photocell and a temperature sensor and send their values wirelessly to the ThingSpeak server.
+This tutorial demonstrates how to use the Arduino Zero or Arduino Uno and the WiFi Shield 101 to send a live stream of the light and temperature values in your environment using [ThingSpeak.com](https://www.thingspeak.com). ThingSpeak is an open data platform for the Internet of Things which allows you to collect data in a your own channel and get data from other channels using the API. In this example, we will use a photocell and a temperature sensor and send their values wirelessly to the ThingSpeak server.
 
 ## Hardware Required
 

--- a/content/tutorials/generic/Wifi101GoogleCalendar/Wifi101GoogleCalendar.md
+++ b/content/tutorials/generic/Wifi101GoogleCalendar/Wifi101GoogleCalendar.md
@@ -1,13 +1,13 @@
 ---
 author: 'Arduino'
-description: 'This example shows you how to make repeated HTTP requests using a WiFi101 shield.'
+description: 'This example shows you how to make repeated HTTP requests using a WiFi shield 101.'
 title: 'Wifi101 Google Calendar Example'
 tags: [WiFi101]
 ---
 
 ## Google Calendar Actions Planner
 
-This example shows you how to make repeated HTTP requests using a WiFi101 shield.  It connects to  a given Google Calendar. The content of the page is downloaded and parsed in order to extract commands from the event title and planning actions to be executed at a given time.
+This example shows you how to make repeated HTTP requests using a WiFi shield 101.  It connects to  a given Google Calendar. The content of the page is downloaded and parsed in order to extract commands from the event title and planning actions to be executed at a given time.
 
 This example is written for a network using WPA encryption. For  WEP or WPA, change the Wifi101.begin() call accordingly.
 
@@ -15,7 +15,7 @@ I this particular example if an event called **LED1** is added to the specified 
 
 ## Hardware Required
 
-- Arduino WiFi101 Shield
+- Arduino WiFi Shield 101
 
 - Arduino Zero board
 
@@ -122,7 +122,7 @@ This function is used **event title** and the **event duration**  in order to un
 
   This sketch connects to Gogole Calendar, makes a HTTP request and downloads the day events.Comparing the actual time with the one of the events actions can be programmed.
 
-  using an Arduino Wifi101 shield and Arduino Zero.
+  using an Arduino Wifi shield 101 and Arduino Zero.
 
   created 08 Sept 2015
 

--- a/content/tutorials/generic/firmware-updater/firmware-updater.md
+++ b/content/tutorials/generic/firmware-updater/firmware-updater.md
@@ -33,7 +33,7 @@ This tutorial will guide you in the process of updating the firmware or loading 
 The board should be connected to the USB port of the computer ready with Arduino IDE.
 
 
-***Important note: The 19.6.1 firmware is only available for model B of the WINC1500, this is used in the MKR1000 board. Unfortunately, the WiFi101 shield uses model A, which Atmel has stopped supporting, so there is no 19.6.1 firmware release for it, 19.4.4 will be the latest firmware version that is compatible.***
+***Important note: The 19.6.1 firmware is only available for model B of the WINC1500, this is used in the MKR1000 board. Unfortunately, the WiFi shield 101 uses model A, which Atmel has stopped supporting, so there is no 19.6.1 firmware release for it, 19.4.4 will be the latest firmware version that is compatible.***
 
 ## Firmware Update Procedure
 

--- a/scripts/validation/rules/rules-spelling.yml
+++ b/scripts/validation/rules/rules-spelling.yml
@@ -76,7 +76,7 @@
   errorMessage: Space between unit and value required
 
 # Excludes Wi-Fi in URLs (prepended by dash or slash) and WiFi.XY and MKR WiFi
-- regex: "(?<![\\/-]|Arduino |MKR |UNO |MKR 1000 )[wW]i[fF]i(?![-\\/]|\\.?\\S| [sS]hield)"
+- regex: "(?<![\\/-]|Arduino |UNO |MKR |MKR 1000 |MKR1000)[wW]i[fF]i(?![-\\/]|\\.?\\S| [sS]hield|101| 101)"
   shouldMatch: false
   type: warning
   format: markdown


### PR DESCRIPTION
## What This PR Changes
- rename some Wi-Fi Boards to have consistent names
- fix LoRa® / LoRaWAN® trademarks
- fix spaces between value and unit
- fix unit names

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
