### PR TITLE
[MKC-523] Fix broken link to BLE tutorial

### DIFF
--- a/content/hardware/03.nano/boards/nano-rp2040-connect/tutorials/rp2040-01-technical-reference/rp2040-01-technical-reference.md
+++ b/content/hardware/03.nano/boards/nano-rp2040-connect/tutorials/rp2040-01-technical-reference/rp2040-01-technical-reference.md
@@ -506,7 +506,7 @@ BLEDevice central = BLE.central();
 
 ### Tutorials
 
-- [Nano RP2040 device to device via Bluetooth®](/tutorials/nano-rp2040-connect/rp2040-bluetooth-button-led)
+- [Nano RP2040 device to device via Bluetooth®](/tutorials/nano-rp2040-connect/rp2040-ble-device-to-device)
 
 ## USB Keyboard
 


### PR DESCRIPTION
## What This PR Changes
- Fix a broken link in nano rp2040 connect cheat sheet (bluetooth section)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
