### PR TITLE
Update link to Library Manager submission instructions

### DIFF
--- a/content/learn/01.starting-guide/04.software-libraries/libraries.md
+++ b/content/learn/01.starting-guide/04.software-libraries/libraries.md
@@ -23,7 +23,7 @@ A number of libraries come installed with the IDE, but you can also download or 
 
 Once it has finished, an **Installed** tag should appear next to the Bridge library, so you can go ahead and close the library manager.
 
-Now the new library will be available in the **Sketch > Include Library** menu. If you want to add your own library to Library Manager, follow [these instructions](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).
+Now the new library will be available in the **Sketch > Include Library** menu. If you want to add your own library to Library Manager, follow [these instructions](https://github.com/arduino/library-registry#adding-a-library-to-library-manager).
 
 ### Online IDE
 

--- a/content/software/ide-v1/tutorials/installing-libraries/installing-libraries.md
+++ b/content/software/ide-v1/tutorials/installing-libraries/installing-libraries.md
@@ -31,7 +31,7 @@ Once it has finished, an _Installed_ tag should appear next to the Bridge librar
 ![](assets/LibraryManager_3.png)
 
 You can now find the new library available in the _Sketch > Include Library_ menu.
-If you want to add your own library to Library Manager, follow [these instructions](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).
+If you want to add your own library to Library Manager, follow [these instructions](https://github.com/arduino/library-registry#adding-a-library-to-library-manager).
 
 ## Importing a .zip Library
 


### PR DESCRIPTION
The library submission documentation was moved from the wiki of the Arduino IDE 1.x repository to the dedicated repository for the Arduino Library Manager registry.

## What This PR Changes

There was still a redirection link at the previously referenced page, but it will be best for this link to send the reader directly to the relevant information, as is provided by this proposal.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
