### PR TITLE
Correct variable name reference in "Writing a Library for Arduino"

### DIFF
--- a/content/learn/08.contributions/03.arduino-creating-library-guide/arduino-creating-library-guide.md
+++ b/content/learn/08.contributions/03.arduino-creating-library-guide/arduino-creating-library-guide.md
@@ -48,7 +48,7 @@ void dash()
 
 If you run this sketch, it will flash out the code for SOS (a distress call) on pin 13.
 
-The sketch has a few different parts that we'll need to bring into our library. First, of course, we have the `dot()` and `dash()` functions that do the actual blinking. Second, there's the **pin** variable which the functions use to determine which pin to use. Finally, there's the call to `pinMode()` that initializes the pin as an output.
+The sketch has a few different parts that we'll need to bring into our library. First, of course, we have the `dot()` and `dash()` functions that do the actual blinking. Second, there's the `pin` variable which the functions use to determine which pin to use. Finally, there's the call to `pinMode()` that initializes the pin as an output.
 
 Let's start turning the sketch into a library!
 

--- a/content/learn/08.contributions/03.arduino-creating-library-guide/arduino-creating-library-guide.md
+++ b/content/learn/08.contributions/03.arduino-creating-library-guide/arduino-creating-library-guide.md
@@ -48,7 +48,7 @@ void dash()
 
 If you run this sketch, it will flash out the code for SOS (a distress call) on pin 13.
 
-The sketch has a few different parts that we'll need to bring into our library. First, of course, we have the `dot()` and `dash()` functions that do the actual blinking. Second, there's the **ledPin** variable which the functions use to determine which pin to use. Finally, there's the call to `pinMode()` that initializes the pin as an output.
+The sketch has a few different parts that we'll need to bring into our library. First, of course, we have the `dot()` and `dash()` functions that do the actual blinking. Second, there's the **pin** variable which the functions use to determine which pin to use. Finally, there's the call to `pinMode()` that initializes the pin as an output.
 
 Let's start turning the sketch into a library!
 


### PR DESCRIPTION
The text description of the library's origin sketch incorrectly references a variable named `ledPin`. That sketch, and all following code based on it uses the variable name `pin`:

```cpp
int pin = 13;
```

Fixes https://github.com/arduino/docs-content/issues/376

## What This PR Changes

The incorrect variable name in the description is hereby changed to match the real variable name in the code.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.