### PR TITLE
[MKC-557] Add EEPROM.length() to docs

### DIFF
--- a/content/learn/07.built-in-libraries/03.eeprom/eeprom.md
+++ b/content/learn/07.built-in-libraries/03.eeprom/eeprom.md
@@ -289,7 +289,8 @@ void loop() {   /* Empty loop */ }
 ```
 
 ### `EEPROM[]`
-Description
+
+#### Description
 This operator allows using the identifier `EEPROM` like an array. EEPROM cells can be read and written directly using this method.
 
 #### Syntax
@@ -330,3 +331,23 @@ void setup(){
 void loop(){ /* Empty loop */ }
  
 ```
+
+### `length()`
+
+This function returns an unsigned int containing the number of cells in the EEPROM.
+
+#### Description
+
+This function returns an `unsigned int` containing the number of cells in the EEPROM.
+
+#### Syntax
+
+```
+EEPROM.length()
+```
+
+#### Returns
+
+Number of cells in the EEPROM as an `unsigned int`.
+
+


### PR DESCRIPTION
## What This PR Changes
- As requested in a #370 , the EEPROM.length() should be added to the EEPROM reference. 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
