### PR TITLE
Replace inappropriately version-specific description of Arduino IDE 1.x

### DIFF
--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -21,7 +21,7 @@ You can easily download the editor from the [Arduino Software page](https://www.
 
 ### The Arduino IDE 2.0
 
-The Arduino IDE 2.0 is an open-source project. It is a big step from it's sturdy predecessor, Arduino IDE (1.8.13), and comes with revamped UI, improved board & library manager, autocomplete feature and much more. 
+The Arduino IDE 2.0 is an open-source project. It is a big step from it's sturdy predecessor, Arduino IDE 1.x, and comes with revamped UI, improved board & library manager, autocomplete feature and much more. 
 
 ### Download the Editor
 


### PR DESCRIPTION
This sentence is simply comparing the Arduino IDE 2.x major version series to the 1.x major version series. In this context, the use of a specific and outdated patch version to describe the 1.x series is completely inappropriate and might cause confusion to the user.

## What This PR Changes

Use an appropriate description for the Arduino IDE 1.x major version series.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
