### PR TITLE
Correct typo in IDE 2.x upload process introduction

### DIFF
--- a/content/software/ide-v2/tutorials/getting-started/02.ide-v2-uploading-a-sketch/ide-v2-uploading-a-sketch.md
+++ b/content/software/ide-v2/tutorials/getting-started/02.ide-v2-uploading-a-sketch/ide-v2-uploading-a-sketch.md
@@ -28,7 +28,7 @@ A good practice is to use the verifying tool before attempting to upload anythin
 
 ### Uploading a Sketch
 
-Installing a core is quick and easy, but let's take a look at what we need to do. 
+Uploading a sketch is quick and easy, but let's take a look at what we need to do. 
 
 **1.** Open the Arduino IDE 2.0. 
 


### PR DESCRIPTION
A copy/paste error resulted in irrelevant mention of "Installing a core" in the introductory sentence for the sketch upload procedure.

## What This PR Changes

Correct the typo.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
