### PR TITLE
Move IDE 2.x Activity Bar debug button screenshot to appropriate location

### DIFF
--- a/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
+++ b/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
@@ -78,9 +78,9 @@ Once you have your hardware set up, we can continue to explore the Debugger tool
 
 The Debugger is a brand new tool integrated in the Arduino IDE 2.0. You can easily access it from the sidebar on the left, grouped with the **Board Manager**, **Library Manager**, **Search** and **Sketchbook Explorer**. 
 
-Mind that doing so will only show you its interface, but the real magic happens when you click the **bug icon** in the buttons menu.
-
 ![The Debugger button.](assets/debugger-img01.png)
+
+Mind that doing so will only show you its interface, but the real magic happens when you click the **bug icon** in the buttons menu.
 
 Now, in order to use the debugger, we need specific hardware instruments, the choice of which is very dependent on what kind of board/processor you are using, and you will almost always need an external debugger.
 


### PR DESCRIPTION
Arduino IDE 2.x has two controls related to the integrated debugger:

- The **Toolbar button**, which is used to initialize the debugger
- The **Activity Bar** button, which is used to open and close the "Debug" view in the **Side Panel**

These two things have completely distinct purposes and can not be used interchangeably. Yet they look very similar. Feedback indicates that this complex interface causes confusion for users, and that such confusion will result in the inability to use the debugger, so it is important for the documentation to clearly differentiate between the two.

The debugger tutorial contains separate introductory text and screenshots for each of the buttons. Previously, the content for these two distinct things was ordered like so:

- Introductory text for **Activity Bar** button
- Introductory text for **Toolbar** button
- Screenshot for **Activity Bar** button
- More text related to **Toolbar** button
- Screenshot for **Toolbar** button

This order could lead the reader to think the **Activity Bar** button screenshot was showing the control referenced by the **Toolbar** button introductory text, since the screenshot came after that introductory text.

## What This PR Changes

Use a more logical and clear order:

- Introductory text for **Activity Bar** button
- Screenshot for **Activity Bar** button
- Introductory text for **Toolbar** button
- More text related to **Toolbar** button
- Screenshot for **Toolbar** button

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
