### PR TITLE
Use correct terminology for Arduino IDE toolbar

### DIFF
--- a/content/software/ide-v2/tutorials/getting-started/02.ide-v2-uploading-a-sketch/ide-v2-uploading-a-sketch.md
+++ b/content/software/ide-v2/tutorials/getting-started/02.ide-v2-uploading-a-sketch/ide-v2-uploading-a-sketch.md
@@ -32,7 +32,7 @@ Installing a core is quick and easy, but let's take a look at what we need to do
 
 **1.** Open the Arduino IDE 2.0. 
 
-**2.** With the editor open, let's take a look at the navigation bar at the top. At the very left, there is a **checkmark** and an **arrow pointing right**. The checkmark is used to **verify**, and the arrow is used to **upload.** 
+**2.** With the editor open, let's take a look at the toolbar at the top. At the very left, there is a **checkmark** and an **arrow pointing right**. The checkmark is used to **verify**, and the arrow is used to **upload.** 
 
 ![Verifying and uploading buttons.](assets/uploading-a-sketch-img01.png)
 


### PR DESCRIPTION
The correct and standard terminology for this user interface element is "toolbar", not "navigation bar".

Reference:

https://github.com/arduino/arduino-ide/pulls?q=is%3Apr+toolbar

## What This PR Changes

Use correct terminology to describe the Arduino IDE toolbar.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
