### PR TITLE
Benjamindannegard/fix-x8-quickstart-links

### DIFF
--- a/content/hardware/04.pro/boards/portenta-x8/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-x8/essentials.md
@@ -1,5 +1,5 @@
 <EssentialsColumn title="First Steps">
-    <EssentialElement title="Quickstart Guide" type="getting-started" link="http://docs.arduino.cc/tutorials/portenta-x8/out-of-the-box">
+    <EssentialElement title="Quickstart Guide" link="http://docs.arduino.cc/tutorials/portenta-x8/out-of-the-box">
         A quick guide to installing your board with the Arduino IDE.
     </EssentialElement>
     <EssentialElement link="https://docs.arduino.cc/tutorials/portenta-x8/x8-fundamentals" title="Fundamentals of Portenta X8" type="tutorial">

--- a/content/hardware/04.pro/boards/portenta-x8/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-x8/essentials.md
@@ -1,6 +1,6 @@
 <EssentialsColumn title="First Steps">
     <EssentialElement title="Quickstart Guide" link="http://docs.arduino.cc/tutorials/portenta-x8/out-of-the-box">
-        A quick guide to installing your board with the Arduino IDE.
+        A quick guide to getting started with your board.
     </EssentialElement>
     <EssentialElement link="https://docs.arduino.cc/tutorials/portenta-x8/x8-fundamentals" title="Fundamentals of Portenta X8" type="tutorial">
         This article contains information about the fundamental concepts of the Portenta X8.

--- a/content/hardware/04.pro/boards/portenta-x8/product.md
+++ b/content/hardware/04.pro/boards/portenta-x8/product.md
@@ -1,9 +1,9 @@
 ---
 title: Portenta X8
 url_shop: https://store.arduino.cc/portenta-x8
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_portenta
+url_guide: /tutorials/portenta-x8/out-of-the-box
 core: arduino:mbed_portenta
-productCode: '125'
+productCode: "125"
 ---
 
 Portenta X8 offers the best of two approaches: flexibility of usage with Linux combined with real-time applications through the Arduino environment. The board comes with a Linux OS (Yocto) distribution, already preloaded onboard.

--- a/content/hardware/04.pro/boards/portenta-x8/product.md
+++ b/content/hardware/04.pro/boards/portenta-x8/product.md
@@ -1,7 +1,7 @@
 ---
 title: Portenta X8
 url_shop: https://store.arduino.cc/portenta-x8
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_portenta
+url_guide: http://docs.arduino.cc/tutorials/portenta-x8/out-of-the-box
 core: arduino:mbed_portenta
 productCode: '125'
 ---

--- a/content/hardware/04.pro/boards/portenta-x8/product.md
+++ b/content/hardware/04.pro/boards/portenta-x8/product.md
@@ -3,7 +3,7 @@ title: Portenta X8
 url_shop: https://store.arduino.cc/portenta-x8
 url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_portenta
 core: arduino:mbed_portenta
-productCode: "125"
+productCode: '125'
 ---
 
 Portenta X8 offers the best of two approaches: flexibility of usage with Linux combined with real-time applications through the Arduino environment. The board comes with a Linux OS (Yocto) distribution, already preloaded onboard.

--- a/content/hardware/04.pro/boards/portenta-x8/product.md
+++ b/content/hardware/04.pro/boards/portenta-x8/product.md
@@ -1,7 +1,7 @@
 ---
 title: Portenta X8
 url_shop: https://store.arduino.cc/portenta-x8
-url_guide: /tutorials/portenta-x8/out-of-the-box
+url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_portenta
 core: arduino:mbed_portenta
 productCode: "125"
 ---


### PR DESCRIPTION
## What This PR Changes
- Changed the quickstart links on the portenta X8 docs page

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
