### PR TITLE
[MKC-663] Update IMU on MKR IoT Carrier

### DIFF
--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/datasheet/datasheet.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/datasheet/datasheet.md
@@ -24,7 +24,7 @@ IoT applications, MKR hobbyists
     * 2x analog sensor input
     * 1x I2C interface 
 
-* **ST LSM6DSOX 6-axis IMU Sensor**
+* **ST LSM6DS3 6-axis IMU Sensor**
     * 3-axis accelerometer 2/±4/±8/±16 g full scale
     * 3-axis gyroscope 125/±250/±500/±1000/±2000 dps (degrees per second)
     * I2C interface to Arduino MKR board
@@ -118,7 +118,7 @@ IoT applications, MKR hobbyists
 
 | **Ref.** | **Description**                        | **Ref.** | **Description**                    |
 | -------- | -------------------------------------- | -------- | ---------------------------------- |
-| U1       | LSM6DSOXTR 6-axis IMU IC               | U3       | LV52204MTTBG LED Boost Driver IC   |
+| U1       | LSM6DS3 6-axis IMU IC                  | U3       | LV52204MTTBG LED Boost Driver IC   |
 | U2       | APDS-9660 RGB and Gesture Sensor IC    | HS-1     | HTS221 Humidity Sensor IC          |
 | LPS-1    | LPS22HBTR Pressure Sensor IC           | L0-L4    | APA1022020-2018 RGB LED IC         |
 | J6       | FH26W-45S-0.3SHW(60) Display Connector | J12      | SFV24R-1STBE1HLF Display Connector |
@@ -336,7 +336,8 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 
 ## Revision History
 
-| **Date**   | **Revision** | **Changes**   |
-| ---------- | ------------ | ------------- |
-| 02/24/2021 | 1            | First Release |
+| **Date**   | **Revision** | **Changes**       |
+| ---------- | ------------ | ----------------- |
+| 02/24/2021 | 1            | First Release     |
 | 05/17/2022 | 2            | Technical updates |
+| 08/26/2022 | 3            | IMU ID fix        |

--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tech-specs.yml
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tech-specs.yml
@@ -7,7 +7,7 @@ Connectors: 3x Grove connectors
 Sensors:
   HTS221: Temperature & humidity
   LPS22HB: Barometric pressure 
-  LSM6DSOX: Accelerometer & gyroscope
+  LSM6DS3: Accelerometer & gyroscope
   APDS-9960: Ambient light, gesture and proximity
   Capacitive buttons: 5x
 Actuators:

--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
@@ -157,11 +157,11 @@ Returns pressure value in Kilopascal (kPa).
 
 ![The IMU on the MKR IoT Carrier](assets/mkrIotCarrier-sensor-imu.png)
 
-The **LSM6DSOXTR** from STM is an IMU (Inertial Measurement Unit) that features a 3D digital accelerometer and a 3D digital gyroscope. It features among many other things, a machine learning core, which is useful for any motion detection projects, such as free fall, step detector, step counter, pedometer. The unit is placed underneath the MKR IoT Carrier's display, connects to the mounted Arduino MKR board through an I2C interface, and acquires Low power consumption (0.55mA max).
+The **LSM6DS3** from STM is an IMU (Inertial Measurement Unit) that features a 3D digital accelerometer and a 3D digital gyroscope.
 
 ### Code
 
-To access the data from the **LSM6DSOX module**, the **MKRIoTCarrier** library needs to be included. The carrier's library includes the **Arduino_LSM6DS3** and functions similarly. The 3-axis values from the **accelerometer** and **gyroscope** sensors can be stored in **float** variables as shown below:
+To access the data from the **LSM6DS3 module**, the **MKRIoTCarrier** library needs to be included. The carrier's library includes the **Arduino_LSM6DS3** and functions similarly. The 3-axis values from the **accelerometer** and **gyroscope** sensors can be stored in **float** variables as shown below:
 
 ```arduino
 float x, y, z;


### PR DESCRIPTION
## What This PR Changes
- Documentation listed the wrong IMU, which is corrected in this PR (correcrt one is LSM6DS3). 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
