### PR TITLE
Fix broken symlink of Portenta H7 tutorial

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tutorials/flash-optimized-key-value-storage
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tutorials/flash-optimized-key-value-storage
@@ -1,1 +1,0 @@
-../../portenta-h7/tutorials/flash-optimized-key-value-storage

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tutorials/flash-optimized-key-value-store
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tutorials/flash-optimized-key-value-store
@@ -1,0 +1,1 @@
+../../portenta-h7/tutorials/flash-optimized-key-value-store


### PR DESCRIPTION
## What This PR Changes
- Changes the path of the symlink to the correct one

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
