### PR TITLE
fixed typos -- see commit description

### DIFF
--- a/content/hardware/02.hero/boards/due/features.md
+++ b/content/hardware/02.hero/boards/due/features.md
@@ -13,7 +13,7 @@ Based on the ARM® Cortex®-M3 processor, this 32-bit microcontroller has 84 MHz
 
 <Feature title="54 digital pins" image="hw-pin">
 
-The Due has 54 digital pins, whereas 12 supports PWM (Pulse Width Modulation).
+The Due has 54 digital pins, 12 of which support PWM (Pulse Width Modulation).
 
 </Feature>
 


### PR DESCRIPTION
whereas is incorrect in this context (and supports->support should agree with the plural "pins") -- I think "12 of which" is more appropriate but another option is "The Due has 54 digital pins, including 12 which support PWM (Pulse Width Modulation)."

## What This PR Changes
- typos, including subject-verb agreement

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
