### PR TITLE
Use preferred Arduino IDE 2.x Auto Format menu path

### DIFF
--- a/content/software/ide-v2/tutorials/ide-v2-customize-auto-formatter/content.md
+++ b/content/software/ide-v2/tutorials/ide-v2-customize-auto-formatter/content.md
@@ -8,7 +8,7 @@ tags:
 author: 'Benjamin Dannegård, Per Tillisch'
 ---
 
-Selecting **Tools > Auto Format** or pressing CTRL + T on Windows/Linux or CMD + T on MacOS when writing a sketch in the Arduino IDE 2.0 will automatically format the sketch. It is possible to change the behaviour of this command. In this tutorial we will go through how you can change the behaviour of this command. 
+Selecting **Edit > Auto Format** or pressing CTRL + T on Windows/Linux or CMD + T on MacOS when writing a sketch in the Arduino IDE 2.0 will automatically format the sketch. It is possible to change the behaviour of this command. In this tutorial we will go through how you can change the behaviour of this command. 
 
 You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
 


### PR DESCRIPTION
The "**Auto Format**" feature has always been found under the "**Tools**" menu in the Arduino IDE. The Arduino IDE 2.x designers determined it was necessary to move it to the "**Edit**" menu instead. That change was made in the Arduino IDE 2.0.0-rc9.2 release (https://github.com/arduino/arduino-ide/pull/1230)

![image](https://user-images.githubusercontent.com/8572152/190158856-a005680f-1740-4d38-a383-a88b4a4ce776.png)

Although the previous **Tools > Auto Format** menu path is still present for now, the plan is to eventually remove it and for **Edit > Auto Format** to be the sole path to this feature.

## What This PR Changes

Change the Arduino IDE 2.x documentation to use the preferred menu path for "**Auto Format**" instead of the deprecated path.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
