### PR TITLE
Remove obsolete fragment identifier from Arduino IDE 2.x download links

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/atmel-ice/using-an-atmel-ice-with-the-ide-v2.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/atmel-ice/using-an-atmel-ice-with-the-ide-v2.md
@@ -11,20 +11,20 @@ author: 'José Bagur'
 
 ## Introduction
 
-In this tutorial, we will learn how to use the [Atmel-ICE](https://www.microchip.com/DevelopmentTools/ProductDetails/ATATMEL-ICE) development tool with the new [Arduino IDE 2.0](https://www.arduino.cc/en/software#experimental-software) for debugging SAM-based Arduino® boards. Using an [Arduino MKR WiFi 1010](https://store.arduino.cc/arduino-mkr-wifi-1010) board and a simple program, we will learn about the debugging functionalities that are integrated with the debugger tool of the new IDE 2.0.
+In this tutorial, we will learn how to use the [Atmel-ICE](https://www.microchip.com/DevelopmentTools/ProductDetails/ATATMEL-ICE) development tool with the new [Arduino IDE 2.0](https://www.arduino.cc/en/software) for debugging SAM-based Arduino® boards. Using an [Arduino MKR WiFi 1010](https://store.arduino.cc/arduino-mkr-wifi-1010) board and a simple program, we will learn about the debugging functionalities that are integrated with the debugger tool of the new IDE 2.0.
 
 ## Goals
 
 The goals with this tutorial are: 
 
-- Learn how to use an [Atmel-ICE](https://www.microchip.com/DevelopmentTools/ProductDetails/ATATMEL-ICE) development tool with the new [Arduino IDE 2.0](https://www.arduino.cc/en/software#experimental-software) and a SAM-based Arduino® board.
-- Learn about the debugging functionalities of the new [Arduino IDE 2.0](https://www.arduino.cc/en/software#experimental-software).
+- Learn how to use an [Atmel-ICE](https://www.microchip.com/DevelopmentTools/ProductDetails/ATATMEL-ICE) development tool with the new [Arduino IDE 2.0](https://www.arduino.cc/en/software) and a SAM-based Arduino® board.
+- Learn about the debugging functionalities of the new [Arduino IDE 2.0](https://www.arduino.cc/en/software).
 
 ## Hardware and Software Needed
 
 The hardware and software used in this tutorial:
 
-- [Arduino IDE 2.0](https://www.arduino.cc/en/software#experimental-software).
+- [Arduino IDE 2.0](https://www.arduino.cc/en/software).
 - [Arduino MKR WiFi 1010](https://store.arduino.cc/arduino-mkr-wifi-1010) board.
 - [Atmel-ICE](https://www.microchip.com/DevelopmentTools/ProductDetails/ATATMEL-ICE) development tool.
 - 10-pin mini-squid cable (included with the Atmel-ICE development tool)

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -9,7 +9,7 @@ description: This tutorial teaches you how to set up a MKR board with the Segger
 This tutorial will show you how to debug an Arduino sketch using an Arduino MKR board and the Segger J-Link probe. It will go through how to connect these and use the Arduino IDE 2.0 to then debug a sketch.
 
 ### Required Hardware and Software
--   [Arduino IDE 2.0](https://www.arduino.cc/en/software#experimental-software)
+-   [Arduino IDE 2.0](https://www.arduino.cc/en/software)
 -   Segger J-link device ([EDU](https://store.arduino.cc/j-link-edu) or [BASE](https://store.arduino.cc/j-link-base))
 -   [Arduino MKR WiFi 1010](https://store.arduino.cc/mkr-wifi-1010) (other boards from the MKR family works as well).
 -   Soldering equipment

--- a/content/hardware/03.nano/boards/nano-rp2040-connect/tutorials/rp2040-upgrading-nina-firmware/rp2040-upgrading-nina-firmware.md
+++ b/content/hardware/03.nano/boards/nano-rp2040-connect/tutorials/rp2040-upgrading-nina-firmware/rp2040-upgrading-nina-firmware.md
@@ -35,7 +35,7 @@ In this article, we will cover three methods to upgrade your NINA module's firmw
 ## Hardware & Software Needed
 
 - [Arduino Nano RP2040 Connect](https://store.arduino.cc/nano-rp2040-connect)
-- [Arduino IDE 2](https://www.arduino.cc/en/software#experimental-software)
+- [Arduino IDE 2](https://www.arduino.cc/en/software)
 - [arduino-fwuploader tool](https://github.com/arduino/arduino-fwuploader/releases)
 - [Arduino Cloud IoT](https://create.arduino.cc/iot/)
 

--- a/content/software/ide-v2/tutorials/01.getting-started-ide-v2/ide-v2-autocomplete-feature.md
+++ b/content/software/ide-v2/tutorials/01.getting-started-ide-v2/ide-v2-autocomplete-feature.md
@@ -14,13 +14,13 @@ The Arduino IDE 2.0 is an improvement of the classic IDE, with increased perform
 
 In this guide, we will cover the basics of the Arduino IDE 2.0, where you will find links to more detailed resources on how to use specific features!
 
-***You can download the IDE 2.0 from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software).*** 
+***You can download the IDE 2.0 from the [Arduino Software page](https://www.arduino.cc/en/software).*** 
 
 ***You can also follow the [downloading and installing the Arduino IDE 2.0](/software/ide-v2/tutorials/getting-started/ide-v2-downloading-and-installing) tutorial for more detailed guide on how to install the editor.***
 
 ## Requirements
 
-- [Arduino IDE 2.0](https://www.arduino.cc/en/software#future-version-of-the-arduino-ide) installed. 
+- [Arduino IDE 2.0](https://www.arduino.cc/en/software) installed. 
 
 ## Overview
 

--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -11,7 +11,7 @@ author: 'Karl Söderby'
 
 In this tutorial, we will show how to download and install the Arduino IDE 2.0 on your Windows, Mac, or Linux computer.
 
-You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 ### Requirements
 
@@ -25,7 +25,7 @@ The Arduino IDE 2.0 is an open-source project. It is a big step from its sturdy 
 
 ### Download the Editor
 
-Downloading the Arduino IDE 2.0 is done through the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). Here you will also find information on the other editors available to use. 
+Downloading the Arduino IDE 2.0 is done through the [Arduino Software page](https://www.arduino.cc/en/software). Here you will also find information on the other editors available to use. 
 
 ### Installation
 
@@ -51,7 +51,7 @@ You can now use the Arduino IDE 2.0 on your macOS computer!
 
 #### Linux 
 
-To install the Arduino IDE 2.0 on Linux, first download the **AppImage 64 bits (X86-64)** from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+To install the Arduino IDE 2.0 on Linux, first download the **AppImage 64 bits (X86-64)** from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 Before we can launch the editor, we need to first make it an **executable file**. This is done by:
 - right-click the file,

--- a/content/software/ide-v2/tutorials/getting-started/02.ide-v2-uploading-a-sketch/ide-v2-uploading-a-sketch.md
+++ b/content/software/ide-v2/tutorials/getting-started/02.ide-v2-uploading-a-sketch/ide-v2-uploading-a-sketch.md
@@ -12,7 +12,7 @@ author: 'Karl Söderby'
 
 In the Arduino environment, we write **sketches** that can be uploaded to Arduino boards. In this tutorial, we will go through how to select a board connected to your computer, and how to upload a sketch to that board, using the Arduino IDE 2.0.
 
-You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 You can also follow the [downloading and installing the Arduino IDE 2.0](./ide-v2-downloading-and-installing) tutorial for more detailed guide on how to install the editor.
 

--- a/content/software/ide-v2/tutorials/ide-v2-autocomplete-feature/ide-v2-autocomplete-feature.md
+++ b/content/software/ide-v2/tutorials/ide-v2-autocomplete-feature/ide-v2-autocomplete-feature.md
@@ -12,7 +12,7 @@ Autocompletion when writing code is great. Not only does it save you time, but i
 
 The Arduino IDE 2.0 comes equipped with this tool, to make your code-writing experience, a pleasant one. In this tutorial, we will go through some basics on how to use it.
 
-You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 You can also follow the [downloading and installing the Arduino IDE 2.0](/en/Tutorial/getting-started-with-ide-v2/ide-v2-downloading-and-installing) tutorial for more detailed guide on how to install the editor.
 

--- a/content/software/ide-v2/tutorials/ide-v2-board-manager/ide-v2-board-manager.md
+++ b/content/software/ide-v2/tutorials/ide-v2-board-manager/ide-v2-board-manager.md
@@ -10,7 +10,7 @@ author: 'Karl Söderby'
 
 The board manager is a great tool for installing the necessary cores to use your Arduino boards. In this quick tutorial, we will take a look at how to install one, and choosing the right core for your board! 
 
-You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 You can also follow the [downloading and installing the Arduino IDE 2.0](/en/Tutorial/getting-started-with-ide-v2/ide-v2-downloading-and-installing) tutorial for more detailed guide on how to install the editor.
 

--- a/content/software/ide-v2/tutorials/ide-v2-cloud-sketch-sync/ide-v2-cloud-sketch-sync.md
+++ b/content/software/ide-v2/tutorials/ide-v2-cloud-sketch-sync/ide-v2-cloud-sketch-sync.md
@@ -55,7 +55,7 @@ In a nutshell, the steps required to make this integration are the following:
 
 ### Requirements
 
-- [Arduino IDE 2.0](https://www.arduino.cc/en/software#experimental-software)
+- [Arduino IDE 2.0](https://www.arduino.cc/en/software)
 - Arduino account, [click here to register](https://login.arduino.cc/login).
 
 ## Understanding the Remote Sketchbook Concept
@@ -117,7 +117,7 @@ void loop() {
 
 After we have created a Sketch in the Arduino Cloud, we can move on to **authenticating the Cloud and the IDE 2.0**. To continue, you need to have installed the Arduino IDE 2.0.
 
->You can download the IDE 2.0 from the [software page](https://www.arduino.cc/en/software#experimental-software). If you need help installing it, you can visit [this installation guide](/software/ide-v2/tutorials/getting-started/ide-v2-downloading-and-installing).
+>You can download the IDE 2.0 from the [software page](https://www.arduino.cc/en/software). If you need help installing it, you can visit [this installation guide](/software/ide-v2/tutorials/getting-started/ide-v2-downloading-and-installing).
 
 **1.** Open the Arduino IDE 2.0, and click on the folder at the top left corner. This is your **Sketchbook**.
 

--- a/content/software/ide-v2/tutorials/ide-v2-customize-auto-formatter/content.md
+++ b/content/software/ide-v2/tutorials/ide-v2-customize-auto-formatter/content.md
@@ -10,7 +10,7 @@ author: 'Benjamin Dannegård, Per Tillisch'
 
 Selecting **Edit > Auto Format** or pressing CTRL + T on Windows/Linux or CMD + T on MacOS when writing a sketch in the Arduino IDE 2.0 will automatically format the sketch. It is possible to change the behaviour of this command. In this tutorial we will go through how you can change the behaviour of this command. 
 
-You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 You can also follow the [downloading and installing the Arduino IDE 2.0](/en/Tutorial/getting-started-with-ide-v2/ide-v2-downloading-and-installing) tutorial for more detailed guide on how to install the editor.
 

--- a/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
+++ b/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
@@ -17,7 +17,7 @@ A debugger is a software tool which is used to test and debug programs, hence th
 
 It basically goes through a program in a controlled manner, with the help of a hardware interface which can help navigate through the program's execution. This can be of aid in better understanding the program as well as helping spot potential flaws and code errors.
 
-*** You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). ***
+*** You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). ***
 
 ### Compatible Boards
 

--- a/content/software/ide-v2/tutorials/ide-v2-fw-cert-uploader/ide-v2-fw-cert-uploader.md
+++ b/content/software/ide-v2/tutorials/ide-v2-fw-cert-uploader/ide-v2-fw-cert-uploader.md
@@ -16,7 +16,7 @@ The IDE 2 comes with two really useful tools: the **Firmware Updater for WiFi bo
 
 Only Wi-Fi enabled boards can be updated through these tools, and you can find the full list in the compatible boards section just below.
 
-***You can download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software).***
+***You can download the editor from the [Arduino Software page](https://www.arduino.cc/en/software).***
 
 ## Compatible Boards
 

--- a/content/software/ide-v2/tutorials/ide-v2-installing-a-library/ide-v2-installing-a-library.md
+++ b/content/software/ide-v2/tutorials/ide-v2-installing-a-library/ide-v2-installing-a-library.md
@@ -13,7 +13,7 @@ A large part of the Arduino programming experience is the **use of libraries.** 
 
 In this tutorial, we will go through how to install a library using the library manager in the Arduino IDE 2.0. We will also show how to access examples from a library that you have installed.
 
-You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+You can easily download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 You can also follow the [downloading and installing the Arduino IDE 2.0](/en/Tutorial/getting-started-with-ide-v2/ide-v2-downloading-and-installing) tutorial for more detailed guide on how to install the editor.
 

--- a/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
@@ -12,7 +12,7 @@ The Serial Monitor is an essential tool when creating projects with Arduino. It 
 
 The Arduino IDE 2.0 has the Serial Monitor tool integrated with the editor, which means that no external window is opened when using the Serial Monitor. This means that you can have multiple windows open, each with its own Serial Monitor. 
 
-You can download the editor from the [Arduino Software page](https://www.arduino.cc/en/software#experimental-software). 
+You can download the editor from the [Arduino Software page](https://www.arduino.cc/en/software). 
 
 You can also follow the [downloading and installing the Arduino IDE 2.0](/en/Tutorial/getting-started-with-ide-v2/ide-v2-downloading-and-installing) tutorial for more detailed guide on how to install the editor.
 

--- a/content/software/ide-v2/tutorials/ide-v2-serial-plotter/ide-v2-serial-plotter.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-plotter/ide-v2-serial-plotter.md
@@ -18,7 +18,7 @@ In this tutorial, we will take a quick look on how to enable this feature (works
 
 ## Requirements
 
-- [Arduino IDE 2.0 installed](https://www.arduino.cc/en/software#experimental-software).
+- [Arduino IDE 2.0 installed](https://www.arduino.cc/en/software).
 - [Core installed](/software/ide-v2/tutorials/ide-v2-board-manager) for the board used.
 - Arduino board.
 - Potentiometer (optional).


### PR DESCRIPTION
During the pre-release development phase of the project, the download links for Arduino IDE 2.x were on a sub-section of [the "**Software**" page](https://www.arduino.cc/en/software). For this reason, the linked URL included the [fragment identifier](https://en.wikipedia.org/wiki/URI_fragment) `#experimental-software` or `#future-version-of-the-arduino-ide` so that the page would load scrolled down to the anchor at that section near the bottom of the page.

With [the 2.0.0 release](https://blog.arduino.cc/2022/09/14/its-here-please-welcome-arduino-ide-2-0/), the Arduino IDE 2.x project has graduated to a production development phase. For this reason, the download links have been moved to the top of the "**Software**" page and the `experimental-software` and `future-version-of-the-arduino-ide` anchors removed from the page.

The previous links with that fragment is still perfectly functional, but the fragment to a non-existent anchor serves no purpose and also misrepresents the project status to users who notice the URL that was loaded.

## What This PR Changes

Remove obsolete fragment identifier from Arduino IDE 2.x download links

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
