### PR TITLE
Updated links to hardware docs pages

### DIFF
--- a/content/learn/06.hardware/nano-pcb-guide/nano-pcb-guide.md
+++ b/content/learn/06.hardware/nano-pcb-guide/nano-pcb-guide.md
@@ -18,8 +18,8 @@ Each Nano Family board has a dedicated documentation page, see the list below:
 - [Nano](/hardware/nano)
 - [Nano Every](/hardware/nano-every)
 - [Nano 33 BLE](/hardware/nano-33-ble)
-- [Nano 33 BLE Sense](hardware/nano-33-ble-sense)
-- [Nano 33 IoT](hardware/nano-33-iot)
+- [Nano 33 BLE Sense](/hardware/nano-33-ble-sense)
+- [Nano 33 IoT](/hardware/nano-33-iot)
 - [Nano RP2040 Connect](/hardware/nano-rp2040-connect)
 
 Inside the documentation page, you will find design files such as full pinout, CAD and Fritzing files. You will also find tutorials and compatible libraries with the respective boards in this page.

--- a/content/learn/06.hardware/nano-pcb-guide/nano-pcb-guide.md
+++ b/content/learn/06.hardware/nano-pcb-guide/nano-pcb-guide.md
@@ -18,8 +18,8 @@ Each Nano Family board has a dedicated documentation page, see the list below:
 - [Nano](/hardware/nano)
 - [Nano Every](/hardware/nano-every)
 - [Nano 33 BLE](/hardware/nano-33-ble)
-- [Nano 33 BLE Sense](/nano-33-ble-sense)
-- [Nano 33 IoT](/nano-33-iot)
+- [Nano 33 BLE Sense](hardware/nano-33-ble-sense)
+- [Nano 33 IoT](hardware/nano-33-iot)
 - [Nano RP2040 Connect](/hardware/nano-rp2040-connect)
 
 Inside the documentation page, you will find design files such as full pinout, CAD and Fritzing files. You will also find tutorials and compatible libraries with the respective boards in this page.


### PR DESCRIPTION
## What This PR Changes
From issue #587, these links didn't work. By adding the `hardware/`, the links should now work.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
