### PR TITLE
Skip PDFs also in fixing task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -159,7 +159,7 @@
         {
             "label": "Fix misspellings",
             "type": "shell",
-            "command": "(pip install codespell > /dev/null 2>&1 || pip3 install codespell > /dev/null 2>&1) && codespell -w -I 'scripts${pathSeparator}resources${pathSeparator}spell-check-ignore-list.txt' --skip='*.svg,*.dxf' .${pathSeparator}content${pathSeparator}",
+            "command": "(pip install codespell > /dev/null 2>&1 || pip3 install codespell > /dev/null 2>&1) && codespell -w -I 'scripts${pathSeparator}resources${pathSeparator}spell-check-ignore-list.txt' --skip='*.svg,*.dxf,*.pdf' .${pathSeparator}content${pathSeparator}",
             "options": {
                 "cwd": "${workspaceFolder}"
             },


### PR DESCRIPTION
## What This PR Changes
- Skips PDFs also in mispelling-fix VSCode task

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
