### PR TITLE
Fix broken link to cloud variables page

### DIFF
--- a/content/arduino-cloud/01.getting-started/02.technical-reference/iot-cloud-tech-ref.md
+++ b/content/arduino-cloud/01.getting-started/02.technical-reference/iot-cloud-tech-ref.md
@@ -153,7 +153,7 @@ The steps below can be used as guidance when **setting up a Thing**:
 
 ## Variables
 
-***Visit the main article on [Cloud Variables](arduino-cloud/getting-started/cloud-variables) for a more detailed coverage.***
+***Visit the main article on [Cloud Variables](/arduino-cloud/getting-started/cloud-variables) for a more detailed coverage.***
 
 A thing can have one or more variables. A variable can be used for multiple purposes:
 


### PR DESCRIPTION
## What This PR Changes

This PR fixes a broken link in https://docs.arduino.cc/arduino-cloud/getting-started/technical-reference#variables

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
