### PR TITLE
Linter: USB-C trademark miss-spelling rule and content fix [PC-1014, PC-1015]

### DIFF
--- a/content/hardware/02.hero/boards/uno-mini-le/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-mini-le/datasheet/datasheet.md
@@ -8,7 +8,7 @@ variant: Limited Edition
 ![](assets/featured.png)
 
 # Description 
-We are celebrating the anniversary of our flagship board, Arduino UNO, by producing a just as effective and versatile miniature: The Arduino UNO Mini. This board is, just as its big brother, equipped with the ATMega328P and the ATMega 16U2 Processor, but is updated with USB-C connector. 
+We are celebrating the anniversary of our flagship board, Arduino UNO, by producing a just as effective and versatile miniature: The Arduino UNO Mini. This board is, just as its big brother, equipped with the ATMega328P and the ATMega 16U2 Processor, but is updated with USB-C® connector. 
 
 # Target Areas:
 Hobby-making, future-shaping, engineering, designing, problem-solving

--- a/content/hardware/02.hero/boards/uno-mini-le/features.md
+++ b/content/hardware/02.hero/boards/uno-mini-le/features.md
@@ -1,6 +1,6 @@
 <FeatureDescription>
 
-The **UNO Mini Limited Edition (LE)** is a miniature version of the classic <a href="../uno-rev3">Arduino UNO board</a>. It is based on the **ATmega328P** microcontroller, has USB-C connector for programming and powering the board, and pins available for connecting external power sources. It also comes with the standard set of female pin connectors, built-in LED, reset button and everything else that the standard UNO have, but at **25% the area size!**. 
+The **UNO Mini Limited Edition (LE)** is a miniature version of the classic <a href="../uno-rev3">Arduino UNO board</a>. It is based on the **ATmega328P** microcontroller, has USB-C® connector for programming and powering the board, and pins available for connecting external power sources. It also comes with the standard set of female pin connectors, built-in LED, reset button and everything else that the standard UNO have, but at **25% the area size!**. 
 
 </FeatureDescription>
 

--- a/content/hardware/02.hero/boards/uno-mini-le/product.md
+++ b/content/hardware/02.hero/boards/uno-mini-le/product.md
@@ -7,4 +7,4 @@ productCode: '117'
 certifications: [CE, UKCA, FCC, RCM]
 ---
 
-The Arduino UNO Mini Limited Edition (LE) is a unique black & gold board, that pays tribute to everyones favorite maker board: [the Arduino UNO](https://store-usa.arduino.cc/products/arduino-uno-rev3). It is only 25% of the area size of the original UNO, comes with a USB-C connector and is delivered in a special case.
+The Arduino UNO Mini Limited Edition (LE) is a unique black & gold board, that pays tribute to everyones favorite maker board: [the Arduino UNO](https://store-usa.arduino.cc/products/arduino-uno-rev3). It is only 25% of the area size of the original UNO, comes with a USB-C® connector and is delivered in a special case.

--- a/content/hardware/02.hero/boards/uno-mini-le/tutorials/uno-mini-le-guide/uno-mini-le-guide.md
+++ b/content/hardware/02.hero/boards/uno-mini-le/tutorials/uno-mini-le-guide/uno-mini-le-guide.md
@@ -15,7 +15,7 @@ software:
 
 The [Arduino UNO Mini LE](https://store.arduino.cc/uno-mini-le) is a great little board that is very much like its dad: the good ol' UNO. It uses the same microcontroller, **ATmega328P** and the same USB-Serial Processor **ATmega16U2**, but differs in size and some other areas. Some notable differences are:
 
-- The UNO Mini LE has a USB-C connector
+- The UNO Mini LE has a USB-C® connector
 - The female header pins are half the pitch of the original UNO (due to its small size). 
 - It does not feature a barrel plug connector for external power supply. Instead, there are two pins available for connecting external power supplies: **VIN** and **GND**. The limit for these pins are 6-21V and should not be exceeded.
 
@@ -33,7 +33,7 @@ The goal with this guide is to:
 
 - [Arduino UNO Mini LE](https://store.arduino.cc/uno-mini-le)
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software) versions).
-- USB-C cable.
+- USB-C® cable.
 
 ## Setup & Installation
 

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
@@ -580,9 +580,9 @@ void startSerialTerminal() {
 bool commandMode = false;
 void loopSerialTerminal() {
 
-  // copy from USB-CDC to UART
+  // copy from USB-C®DC to UART
 
-  int c = SERIAL_PORT_USBVIRTUAL.read();    // read from USB-CDC
+  int c = SERIAL_PORT_USBVIRTUAL.read();    // read from USB-C®DC
 
   if (c != -1) {                            // got anything?
 
@@ -644,13 +644,13 @@ void loopSerialTerminal() {
 
   }
 
-  // copy from UART to USB-CDC
+  // copy from UART to USB-C®DC
 
   c = SERIAL_PORT_HARDWARE.read();          // read from UART
 
   if (c != -1) {                            // got anything?
 
-    SERIAL_PORT_USBVIRTUAL.write(c);        //    write to USB-CDC
+    SERIAL_PORT_USBVIRTUAL.write(c);        //    write to USB-C®DC
 
   }
 }

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
@@ -644,7 +644,7 @@ void loopSerialTerminal() {
 
   }
 
-  // copy from UART to USB-C®DC
+  // copy from UART to USB-CDC
 
   c = SERIAL_PORT_HARDWARE.read();          // read from UART
 

--- a/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
+++ b/content/hardware/02.hero/boards/yun-rev2/tutorials/yun-first-config/content.md
@@ -580,9 +580,9 @@ void startSerialTerminal() {
 bool commandMode = false;
 void loopSerialTerminal() {
 
-  // copy from USB-C®DC to UART
+  // copy from USB-CDC to UART
 
-  int c = SERIAL_PORT_USBVIRTUAL.read();    // read from USB-C®DC
+  int c = SERIAL_PORT_USBVIRTUAL.read();    // read from USB-CDC
 
   if (c != -1) {                            // got anything?
 
@@ -650,7 +650,7 @@ void loopSerialTerminal() {
 
   if (c != -1) {                            // got anything?
 
-    SERIAL_PORT_USBVIRTUAL.write(c);        //    write to USB-C®DC
+    SERIAL_PORT_USBVIRTUAL.write(c);        //    write to USB-CDC
 
   }
 }

--- a/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-matlab-wifi-led/nanoMatlabWiFiLED.md
+++ b/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-matlab-wifi-led/nanoMatlabWiFiLED.md
@@ -31,7 +31,7 @@ The goals of this project are:
 
 - [Arduino Nano 33 IoT](https://store.arduino.cc/products/arduino-nano-33-iot)
 - [Arduino Nano Motor Carrier](https://store.arduino.cc/products/arduino-nano-motor-carrier)
-- [Micro USB Cable](https://store.arduino.cc/products/USB-C®able-type-a-male-to-micro-type-b-male)
+- [Micro USB Cable](https://store.arduino.cc/products/USB-Cable-type-a-male-to-micro-type-b-male)
 - Single cell LiPo/Li-ion 18650 battery and holder with XT30 connector
 - Valid MATLAB® licence
 - [MATLAB® Support Package for Arduino® Hardware](https://www.mathworks.com/matlabcentral/fileexchange/47522-matlab-support-package-for-arduino-hardware)

--- a/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-matlab-wifi-led/nanoMatlabWiFiLED.md
+++ b/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-matlab-wifi-led/nanoMatlabWiFiLED.md
@@ -31,7 +31,7 @@ The goals of this project are:
 
 - [Arduino Nano 33 IoT](https://store.arduino.cc/products/arduino-nano-33-iot)
 - [Arduino Nano Motor Carrier](https://store.arduino.cc/products/arduino-nano-motor-carrier)
-- [Micro USB Cable](https://store.arduino.cc/products/usb-cable-type-a-male-to-micro-type-b-male)
+- [Micro USB Cable](https://store.arduino.cc/products/USB-C®able-type-a-male-to-micro-type-b-male)
 - Single cell LiPo/Li-ion 18650 battery and holder with XT30 connector
 - Valid MATLAB® licence
 - [MATLAB® Support Package for Arduino® Hardware](https://www.mathworks.com/matlabcentral/fileexchange/47522-matlab-support-package-for-arduino-hardware)

--- a/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
+++ b/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
@@ -33,7 +33,7 @@ The goals of this project are:
 
 - [Arduino Nano 33 IoT](https://store.arduino.cc/products/arduino-nano-33-iot)
 - [Arduino Nano Motor Carrier](https://store.arduino.cc/products/arduino-nano-motor-carrier)
-- [Micro USB Cable](https://store.arduino.cc/products/USB-C®able-type-a-male-to-micro-type-b-male)
+- [Micro USB Cable](https://store.arduino.cc/products/USB-Cable-type-a-male-to-micro-type-b-male)
 - Single cell LiPo/Li-ion 18650 battery and holder with XT30 connector
 - Valid MATLAB® and Simulink® license
 - [Simulink® Support Package for Arduino® Hardware](https://www.mathworks.com/matlabcentral/fileexchange/40312-simulink-support-package-for-arduino-hardware)

--- a/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
+++ b/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
@@ -33,7 +33,7 @@ The goals of this project are:
 
 - [Arduino Nano 33 IoT](https://store.arduino.cc/products/arduino-nano-33-iot)
 - [Arduino Nano Motor Carrier](https://store.arduino.cc/products/arduino-nano-motor-carrier)
-- [Micro USB Cable](https://store.arduino.cc/products/USB-Cable-type-a-male-to-micro-type-b-male)
+- [Micro USB Cable](https://store.arduino.cc/products/usb-cable-type-a-male-to-micro-type-b-male)
 - Single cell LiPo/Li-ion 18650 battery and holder with XT30 connector
 - Valid MATLAB® and Simulink® license
 - [Simulink® Support Package for Arduino® Hardware](https://www.mathworks.com/matlabcentral/fileexchange/40312-simulink-support-package-for-arduino-hardware)

--- a/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
+++ b/content/hardware/03.nano/carriers/nano-motor-carrier/tutorials/nano-simulink-wifi-led/nanoSimulinkWiFiLED.md
@@ -33,7 +33,7 @@ The goals of this project are:
 
 - [Arduino Nano 33 IoT](https://store.arduino.cc/products/arduino-nano-33-iot)
 - [Arduino Nano Motor Carrier](https://store.arduino.cc/products/arduino-nano-motor-carrier)
-- [Micro USB Cable](https://store.arduino.cc/products/usb-cable-type-a-male-to-micro-type-b-male)
+- [Micro USB Cable](https://store.arduino.cc/products/USB-C®able-type-a-male-to-micro-type-b-male)
 - Single cell LiPo/Li-ion 18650 battery and holder with XT30 connector
 - Valid MATLAB® and Simulink® license
 - [Simulink® Support Package for Arduino® Hardware](https://www.mathworks.com/matlabcentral/fileexchange/40312-simulink-support-package-for-arduino-hardware)

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -262,7 +262,7 @@ Laboratory equipment, Computer vision
          <td>Up to 128 MByte</td>
       </tr>
       <tr>
-         <td rowspan="4" style="vertical-align: top;" >USB-C</td>
+         <td rowspan="4" style="vertical-align: top;" >USB-C®</td>
          <td>High speed (optional/FUll Speed USB)</td>
          <td></td>
          <td rowspan="3"></td>
@@ -500,9 +500,9 @@ Laboratory equipment, Computer vision
 
 ## Connector Pinouts
 
-![USB-C Pinout](assets/portentaH7_PinoutUSB-C.png)
+![USB-C® Pinout](assets/portentaH7_PinoutUSB-C.png)
 
-### USB-C
+### USB-C®
 
 | Pin     | **Description**                                              | **Pin**         | **Description**                                          |
 | ------- | ------------------------------------------------------------ | --------------- | -------------------------------------------------------- |
@@ -556,7 +556,7 @@ Depending on the variant, some of the components does not apply. The image below
 | U3       | USB HS PHY                           | U12, U13, U14    | ESD protection*             |
 | U4       | SDRAM                                | U16              | Crypto Chip (Microchip)     |
 | U5       | Ethernet PHY                         | J1, J2           | High Density Connectors     |
-| U6       | MIPI to USB-C/DisplayPort converter* | ANT1             | Antenna or U.FL Connector** |
+| U6       | MIPI to USB-C®/DisplayPort converter* | ANT1             | Antenna or U.FL Connector** |
 | U7       | Level Shifter*                       | JANALOG JDIGITAL | MKR Compatible headers      |
 | U8       | I2C level shifter*                   | J4               | Battery Connector           |
 | U9       | Wifi/BT Module**                     | J5               | ESLOV Connector             |

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/ble-connectivity/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/ble-connectivity/content.md
@@ -50,9 +50,9 @@ To communicate with the Portenta H7 via Bluetooth®, you need to upload a pre-bu
 
 ### 1. The Basic Setup
 
-Begin by plugging in your Portenta board to the computer using a USB-C cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](setting-up-portenta) before you proceed.
+Begin by plugging in your Portenta board to the computer using a USB-C® cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](setting-up-portenta) before you proceed.
 
-![The Portenta H7 can be connected to the computer using an appropriate USB-C cable](assets/por_ard_ble_basic_setup.svg)
+![The Portenta H7 can be connected to the computer using an appropriate USB-C® cable](assets/por_ard_ble_basic_setup.svg)
 
 ### 2. Install the ArduinoBLE Library 
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/creating-gui-with-lvgl/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/creating-gui-with-lvgl/content.md
@@ -34,9 +34,9 @@ In this tutorial you will learn to use [LVGL](https://lvgl.io/) to create a simp
 ### Required Hardware and Software
 
 -   [Portenta H7 (ABX00042)](https://store.arduino.cc/products/portenta-h7)
--   USB-C cable (either USB-A to USB-C or USB-C to USB-C)
+-   USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 -   Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4+ 
--   USB-C hub with HDMI
+-   USB-C® hub with HDMI
 -   External monitor 
 -   HDMI cable 
 
@@ -54,9 +54,9 @@ This tutorial will guide you through building a basic user interface using the L
 
 ### 1. The Basic Setup
 
-Begin by plugging your Portenta board into the computer using a USB-C cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](setting-up-portenta) before you proceed.
+Begin by plugging your Portenta board into the computer using a USB-C® cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](setting-up-portenta) before you proceed.
 
-![The Portenta H7 can be connected to the computer using an appropriate USB-C cable](assets/por_ard_lvgl_basic_setup.svg)
+![The Portenta H7 can be connected to the computer using an appropriate USB-C® cable](assets/por_ard_lvgl_basic_setup.svg)
 
 ### 2. Download the LVGL Library
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/dual-core-processing/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/dual-core-processing/content.md
@@ -48,7 +48,7 @@ To best illustrate the idea of dual core processing, you will be running two sep
 ![Running two different sketch files on the different cores.](assets/por_ard_dcp_tutorial_overview.svg)
 
 ### 1. The Basic Setup
-Begin by plugging-in your Portenta board to your computer using an appropriate USB-C cable and have the  Arduino IDE open. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [Setting Up Portenta H7 For Arduino](setting-up-portenta) before you proceed.
+Begin by plugging-in your Portenta board to your computer using an appropriate USB-C® cable and have the  Arduino IDE open. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [Setting Up Portenta H7 For Arduino](setting-up-portenta) before you proceed.
 
 ![A Basic setup of the board attached to your computer](../setting-up-portenta/assets/por_ard_gs_basic_setup.svg)
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
@@ -44,7 +44,7 @@ In this tutorial, you are going to save a value persistently inside the Flash me
 ***Important: The TBStore API optimizes for access speed, reduce [wearing of the flash](https://en.wikipedia.org/wiki/Flash_memory#Memory_wear) and minimize storage overhead. TBStore is also resilient to power failures. If you want to use the Flash memory of the microcontroller, always prefer the TDBStore approach over a direct access to the FlashIAP block device.***
 
 ### 1. The Basic Setup
-Begin by plugging in your Portenta board to the computer using a USB-C cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](https://docs.arduino.cc/tutorials/portenta-h7/setting-up-portenta) before you proceed.
+Begin by plugging in your Portenta board to the computer using a USB-C® cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](https://docs.arduino.cc/tutorials/portenta-h7/setting-up-portenta) before you proceed.
 
 ### 2. Create the Structure of the Program
 Let's program the Portenta with a sketch. You will also define a few helper functions in a supporting header file.

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/getting-started-openmv-micropython/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/getting-started-openmv-micropython/content.md
@@ -32,7 +32,7 @@ The OpenMV IDE is meant to provide an Arduino like experience for simple machine
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/products/portenta-h7), [Portenta H7 Lite (ABX00045)](https://store.arduino.cc/products/portenta-h7-lite) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB-C cable (either USB-A to USB-C or USB-C to USB-C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Portenta Bootloader Version 20+
 - OpenMV IDE 2.6.4+
 
@@ -51,7 +51,7 @@ Open the [OpenMV download](https://openmv.io/pages/download) page in your browse
 
 ### 2. Flashing the OpenMV Firmware
 
-Connect the Portenta to your computer via the USB-C cable if you haven't done so yet. Make sure you first update the bootloader to the latest version using the **STM32H747_updateBootloader** sketch in the examples menu in the Arduino IDE.
+Connect the Portenta to your computer via the USB-C® cable if you haven't done so yet. Make sure you first update the bootloader to the latest version using the **STM32H747_updateBootloader** sketch in the examples menu in the Arduino IDE.
 
 Instructions on how to update the bootloader can be found in the ["Updating the Portenta Bootloader" tutorial](https://docs.arduino.cc/tutorials/portenta-h7/updating-the-bootloader).
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -35,7 +35,7 @@ The goals of this tutorial are:
 ## Hardware and Software Needed 
 - [Arduino Portenta H7](https://store.arduino.cc/portenta-h7)
 - Arduino IDE 1.8.10+ or Arduino Pro IDE 0.0.4+
-- USB-C type cable (either USB-A to USB-C or USB-C to USB-C)
+- USB-C® type cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IoT Cloud and Arduino_Portenta_OTA libraries
 - SD card (optional, you can use QSPI instead)
 - Carrier or shield compatible with the Portenta H7 with a SD Card slot, in case you choose to use the SD Card.

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/reading-writing-flash-memory/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/reading-writing-flash-memory/content.md
@@ -30,7 +30,7 @@ This tutorial demonstrates how to use the on-board Flash memory of the Portenta 
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/portenta-h7) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB-C cable (either USB-A to USB-C or USB-C to USB-C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+ or Arduino Pro IDE 0.0.4+ or Arduino CLI 0.13.0+
 
 ## Mbed OS APIs for Flash Storage

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
@@ -56,7 +56,7 @@ In this section, we will guide you through a step-by-step process of setting up 
 ### 1. The Basic Setup
 Let's begin by Plug-in your Portenta to your computer using the appropriate USB C cable. Next, open your IDE and make sure that you have the right version of the Arduino IDE downloaded on to your computer.
 
-![The Portenta H7 can be connected to the computer using an appropriate USB-C cable](assets/por_ard_gs_basic_setup.svg)
+![The Portenta H7 can be connected to the computer using an appropriate USB-C® cable](assets/por_ard_gs_basic_setup.svg)
 
 ### 2. Adding the Portenta to the List of Available Boards
 In your Arduino IDE, open the board manager and search for "portenta". Find the Arduino mbed-enabled Boards library and click on "Install" to install the latest version of the mbed core (1.2.3 at the time of writing this tutorial).

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/usb-host/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/usb-host/content.md
@@ -34,8 +34,8 @@ It is possible to configure the Portenta H7 to act as a USB host in a way that a
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/products/portenta-h7), [Portenta H7 Lite (ABX00045)](https://store.arduino.cc/products/portenta-h7-lite) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB-C cable (either USB-A to USB-C or USB-C to USB-C)
-- Active USB-C hub (optional)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- Active USB-C® hub (optional)
 - External keyboard
 - Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4+
 - Power supply for the USB hub (if a USB hub is used)
@@ -75,9 +75,9 @@ Thanks to USB OTG (On The Go) specification the Portenta H7 can switch between h
 
 ### 1. The Basic Setup
 
-Begin by plugging in your Portenta board to the computer using a USB-C  cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you to check out how to [set up the Portenta H7 for Arduino](https://docs.arduino.cc/tutorials/portenta-h7/setting-up-portenta) before you proceed.
+Begin by plugging in your Portenta board to the computer using a USB-C®  cable and open the Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you to check out how to [set up the Portenta H7 for Arduino](https://docs.arduino.cc/tutorials/portenta-h7/setting-up-portenta) before you proceed.
 
-![The Portenta H7 can be connected to the computer using an appropriate USB-C cable](assets/por_ard_usbh_basic_setup.svg)
+![The Portenta H7 can be connected to the computer using an appropriate USB-C® cable](assets/por_ard_usbh_basic_setup.svg)
 
 ### 2. Creating the Keyboard Controller
 
@@ -178,16 +178,16 @@ When you connect the Portenta board to the computer to program it, the computer 
 
 In the image above you can see that:
 
-- The Portenta is connected to the "HOST" port of the USB hub (USB-C adapter)
-- The USB Hub (USB-C adapter) needs to be powered externally with a power supply. This is required to provide power to Portenta.
-- You should connect the keyboard to the USB Hub (USB-C adapter) in the same way you would connect it to your PC.
+- The Portenta is connected to the "HOST" port of the USB hub (USB-C® adapter)
+- The USB Hub (USB-C® adapter) needs to be powered externally with a power supply. This is required to provide power to Portenta.
+- You should connect the keyboard to the USB Hub (USB-C® adapter) in the same way you would connect it to your PC.
 
 ### Alternative Configuration (No USB Hub Required)
 
-If you do not have a USB-C type hub, you may complete this tutorial with a USB-C type keyboard or with a USB A type keyboard and a USB A to C adapter. To do so, proceed as follows:
+If you do not have a USB-C® type hub, you may complete this tutorial with a USB-C® type keyboard or with a USB A type keyboard and a USB A to C adapter. To do so, proceed as follows:
 
 - Power the Portenta H7 through the VIN pin with 5V. (Check [pinout diagram](https://content.arduino.cc/assets/Pinout-PortentaH7_latest.pdf))
-- Connect the keyboard directly to the Portenta's USB-C connector (use a USB-A to USB-C adapter if your keyboard's connector is USB type A)
+- Connect the keyboard directly to the Portenta's USB-C® connector (use a USB-A to USB-C® adapter if your keyboard's connector is USB type A)
 - Add the following line of code in your sketch to enable power supply through Portenta's USB connector: `usb.supplyPowerOnVBUS(true);`
 
 ### 7. Toggling the LEDs

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/wifi-access-point/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/wifi-access-point/content.md
@@ -53,9 +53,9 @@ In this tutorial you are going to convert the board into an access point and use
 ![A mobile device controlling the different LEDs on the board ](assets/por_ard_ap_tutorial_overview.svg)
 
 ### 1. The Basic Setup
-Begin by plugging in your Portenta board to your computer using a USB-C cable and open the  Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](https://docs.arduino.cc/tutorials/portenta-h7/setting-up-portenta) before you proceed. 
+Begin by plugging in your Portenta board to your computer using a USB-C® cable and open the  Arduino IDE. If this is your first time running Arduino sketch files on the board, we suggest you check out how to [set up the Portenta H7 for Arduino](https://docs.arduino.cc/tutorials/portenta-h7/setting-up-portenta) before you proceed. 
 
-![The Portenta H7 can be connected to the computer using an appropriate USB-C cable](assets/por_tut1_im1.png)
+![The Portenta H7 can be connected to the computer using an appropriate USB-C® cable](assets/por_tut1_im1.png)
 
 ### 2. Create the Web Server Sketch
 Next you need to create a web server sketch that will handle the HTTP GET requests and provide the client devices with the HTML web page. The [Wi-Fi](https://www.arduino.cc/en/Reference/WiFi) library provides all necessary methods that allows Arduino boards to use their Wi-Fi features provided by the on-board Wi-Fi module. To set up the web server copy the following code, paste it into a new sketch file and name it **SimpleWebServer.ino**. 

--- a/content/hardware/04.pro/boards/portenta-x8/datasheet/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-x8/datasheet/datasheet.md
@@ -318,7 +318,7 @@ The use of a USB 3.0 compatible port will ensure that current requirements for t
 | **Ref.** | **Description**                                | **Ref.**        | **Description**                                              |
 | -------- | ---------------------------------------------- | --------------- | ------------------------------------------------------------ |
 | U1       | BD71847AMWV i.MX 8M Mini  PMIC                 | U2              | MIMX8MM6CVTKZAA i.MX 8M Mini Quad IC                         |
-| U4       | NCP383LMUAJAATXG Current-Limiting Power Switch | U6              | ANX7625 MIPI-DSI/DPI to USB Type-C®™ Bridge IC                |
+| U4       | NCP383LMUAJAATXG Current-Limiting Power Switch | U6              | ANX7625 MIPI-DSI/DPI to USB Type-C® Bridge IC                |
 | U7       | MP28210 Step Down IC                           | U9              | LBEE5KL1DX-883 WLAN+Bluetooth® Combo IC                      |
 | U12      | PCMF2USB3B/CZ Bidirectional EMI Protection IC  | U16,U21,U22,U23 | FXL4TD245UMX 4-Bit Bidirectional Voltage-level Translator IC |
 | U17      | DSC6151HI2B 25MHz MEMS Oscillator              | U18             | DSC6151HI2B 27MHz MEMS Oscillator                            |

--- a/content/hardware/04.pro/boards/portenta-x8/datasheet/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-x8/datasheet/datasheet.md
@@ -120,7 +120,7 @@ Edge computing, industrial internet of things, system on module, artificial inte
          <td>16GB Foresee® eMMC Flash module</td>
       </tr>
       <tr>
-         <td rowspan="4" ><strong>USB-C</strong></td>
+         <td rowspan="4" ><strong>USB-C®</strong></td>
          <td>High Speed USB</td>
          <td></td>
       </tr>
@@ -274,8 +274,8 @@ The Arduino® Portenta X8 has been designed for high performance embedded comput
 - **High speed modular embedded development:** The Arduino® Portenta X8 is a great unit for developing a wide range of custom solutions. The high density connector provides access to many functions, including PCIe connectivity, CAN, SAI and MIPI. Alternatively, use the Arduino ecosystem of professionally designed boards as a reference for your own designs. Low-code software containers allow for rapid deployment.
 
 ## Accessories (Not Included)
-- USB-C Hub
-- USB-C to HDMI Adapter
+- USB-C® Hub
+- USB-C® to HDMI Adapter
 
 ## Related Products
 - Arduino® Portenta Breakout Board (ASX00031)
@@ -318,14 +318,14 @@ The use of a USB 3.0 compatible port will ensure that current requirements for t
 | **Ref.** | **Description**                                | **Ref.**        | **Description**                                              |
 | -------- | ---------------------------------------------- | --------------- | ------------------------------------------------------------ |
 | U1       | BD71847AMWV i.MX 8M Mini  PMIC                 | U2              | MIMX8MM6CVTKZAA i.MX 8M Mini Quad IC                         |
-| U4       | NCP383LMUAJAATXG Current-Limiting Power Switch | U6              | ANX7625 MIPI-DSI/DPI to USB Type-C™ Bridge IC                |
+| U4       | NCP383LMUAJAATXG Current-Limiting Power Switch | U6              | ANX7625 MIPI-DSI/DPI to USB Type-C®™ Bridge IC                |
 | U7       | MP28210 Step Down IC                           | U9              | LBEE5KL1DX-883 WLAN+Bluetooth® Combo IC                      |
 | U12      | PCMF2USB3B/CZ Bidirectional EMI Protection IC  | U16,U21,U22,U23 | FXL4TD245UMX 4-Bit Bidirectional Voltage-level Translator IC |
 | U17      | DSC6151HI2B 25MHz MEMS Oscillator              | U18             | DSC6151HI2B 27MHz MEMS Oscillator                            |
 | U19      | NT6AN512T32AV 2GB LP-DDR4 DRAM                 | IC1,IC2,IC3,IC4 | SN74LVC1G125DCKR 3-state 1.65-V to 5.5-V buffer IC           |
 | PB1      | PTS820J25KSMTRLFS Reset Push Button            | Dl1             | KPHHS-1005SURCK Power On SMD LED                             |
 | DL2      | SMLP34RGB2W3 RGB Common Anode SMD LED          | Y1              | CX3225GB24000P0HPQCC 24MHz crystal                           |
-| Y3       | DSC2311KI2-R0012 Dual-Output MEMS Oscillator   | J3              | CX90B1-24P USB Type-C connector                              |
+| Y3       | DSC2311KI2-R0012 Dual-Output MEMS Oscillator   | J3              | CX90B1-24P USB Type-C® connector                              |
 | J4       | U.FL-R-SMT-1(60) UFL Connector                 |
 
 
@@ -362,14 +362,14 @@ The Arduino® Portenta X8 enables IC level edge-to-cloud security capability thr
 ## Gigabit Ethernet
 The NXP® i.MX 8M Mini Quad includes a 10/100/1000 Ethernet controller with support for Energy Efficient Ethernet (EEE), Ethernet AVB, and IEEE 1588. An external physical connector is required to complete the interface. This can be accessed via a high density connector with an external component such as the Arduino® Portenta Breakout board.
 
-## USB-C Connector
-![USB-C Pinout](assets/usbCPinout.png)
-The USB-C connector provides multiple connectivity options over a single physical interface:
+## USB-C® Connector
+![USB-C® Pinout](assets/usbCPinout.png)
+The USB-C® connector provides multiple connectivity options over a single physical interface:
 - Provide board power supply in both DFP and DRP mode
 - Source power to external peripherals when board is powered through VIN
 - Expose High Speed (480 Mbps) or Full Speed (12 Mbps) USB Host/Device interface
 - Expose Displayport output interface 
-The Displayport interface is usable in conjunction with USB and can be either used with a simple cable adapter when board is powered via VIN or with dongles able to provide power to the board while simultaneously outputting Displayport and USB. Such dongles usually provide an ethernet over USB port, a 2 port USB hub and a USB-C port that can be used to provide power to the system.
+The Displayport interface is usable in conjunction with USB and can be either used with a simple cable adapter when board is powered via VIN or with dongles able to provide power to the board while simultaneously outputting Displayport and USB. Such dongles usually provide an ethernet over USB port, a 2 port USB hub and a USB-C® port that can be used to provide power to the system.
 
 ## Real Time Clock
 The Real Time clock allows keeping time of day with a very low power consumption.

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/custom-container/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/custom-container/content.md
@@ -23,7 +23,7 @@ In this tutorial we will create a simple container that we can then upload to th
 
 - [Portenta X8](https://store.arduino.cc/portenta-x8)
 - ADB
-- USB-C cable (either USB-C to USB-A or USB-C to USB-C)
+- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
 - Arduino Pro Cloud Subscription. [Learn more about the Pro Cloud](https://www.arduino.cc/pro/hardware/product/portenta-x8#pro-cloud).
 
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/datalogging-iot/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/datalogging-iot/content.md
@@ -41,7 +41,7 @@ These four blocks will be running locally on the [Arduino® Portenta X8](https:/
 
 - [Arduino® Portenta X8](https://store.arduino.cc/products/portenta-x8)
 - [Arduino® MKR WiFi 1010](https://store.arduino.cc/products/arduino-mkr-wifi-1010)
-- USB-C cable (either USB-C to USB-A or USB-C to USB-C)
+- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
 - Wi-Fi Access Point (AP) with Internet access
 - ADB or SSH
 - Command-line interface

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/display-output-webgl/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/display-output-webgl/content.md
@@ -29,8 +29,8 @@ The Arduino Portenta X8's processor **NXP® i.MX 8M Mini Processor** can be used
 ### Required Hardware and Software
 
 - [Arduino Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C cable (either USB-C to USB-A or USB-C to USB-C)
-- USB-C hub with HDMI
+- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- USB-C® hub with HDMI
 - External monitor 
 - HDMI cable
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/docker-container/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/docker-container/content.md
@@ -32,7 +32,7 @@ In this tutorial we will go through the steps of how to install, run and remove 
 ### Required Hardware and Software
 
 - [Arduino Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C cable (either USB-C to USB-A or USB-C to USB-C)
+- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
 - Wi-Fi Access Point with Internet Access
 - ADB or SSH. [Check how to connect to your Portenta X8](/tutorials/portenta-x8/out-of-the-box#controlling-portenta-x8-through-the-terminal)
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/image-flashing/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/image-flashing/content.md
@@ -27,7 +27,7 @@ The instructions below are meant to be used with a Windows Operating System.
 
 ### Required Hardware and Software
 
-- USB-C to USB-A or USB-C to USB-C
+- USB-C® to USB-A or USB-C® to USB-C®
 - Portenta X8
 - Portenta Breakout Board or Portenta Max Carrier
     
@@ -84,7 +84,7 @@ On the Portenta Breakout the DIP switches are identified by a label `BT_SEL` and
 
 ![Breakout DIP switches](assets/breakout-dip-switches.png)
 
-Plug one USB-C end into the Portenta X8 and the other end (USB-C or USB-A) to your computer.
+Plug one USB-C® end into the Portenta X8 and the other end (USB-C® or USB-A) to your computer.
 
 You will see a new connected device called `SE Blank M845S`.
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/multi-protocol-gateway/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/multi-protocol-gateway/content.md
@@ -32,7 +32,7 @@ In this tutorial we will go through the steps on how to setup both the Linux and
 
 - [Arduino Portenta X8](https://store.arduino.cc/products/portenta-x8)
 - [Arduino Portenta Max Carrier](https://store.arduino.cc/products/portenta-max-carrier)
-- USB-C cable (either USB-C to USB-A or USB-C to USB-C)
+- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
 - Wi-Fi Access Point with Internet Access
 - 868-915 MHz antenna with SMA connector
 - ADB or SSH. [Check how to connect to your Portenta X8](https://docs.arduino.cc/tutorials/portenta-x8/out-of-the-box#controlling-portenta-x8-through-the-terminal)
@@ -526,7 +526,7 @@ In this tutorial you have learned how to set up a Multi-Protocol Gateway compose
 You might encounter some errors or misbehaviors while working on the code, preventing you from progressing on the development. You can try the following troubleshooting tips to solve the commonly known issues:
 
 * If the sketch upload process fails, check if your Portenta X8 is in bootloader mode. To put the Portenta X8 into Bootloader mode, double-press its RESET button and verify that the green LED is blinking. After this, you can try re-uploading the sketch for the Arduino layer.
-* Check the position of the BOOT DIP switch of the Portenta Max Carrier. If the Portenta X8 gets into bootloader mode immediately after powering-on, including when connected via USB-C, change the position of the BOOT DIP switch to OFF. This case applies to the Arduino layer.
+* Check the position of the BOOT DIP switch of the Portenta Max Carrier. If the Portenta X8 gets into bootloader mode immediately after powering-on, including when connected via USB-C®, change the position of the BOOT DIP switch to OFF. This case applies to the Arduino layer.
 * If you encounter an issue regarding terminal input inconvenience, please enter `export TERM=xterm` as the command in the terminal to get readable inputs. 
 * In case internal Wi-Fi connection cannot be established through the command input due to "unavailable" SSID, although it is in range. Please try using different SSID if available or hotspot from a different device to host network connectivity.  
 * If you encounter docker image conflict when running after building, please make sure you have used name tag that matches the one from the `docker-compose.yml` file. 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/waves-fleet-managment/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/waves-fleet-managment/content.md
@@ -23,7 +23,7 @@ In a production environment it is convenient to plan updates and have control ov
 
 ### Required Hardware and Software
 
-- USB-C to USB-A or USB-C to USB-C
+- USB-C® to USB-A or USB-C® to USB-C®
 - Portenta X8
 - Arduino Create account
 - Arduino Cloud for business subscription with Portenta X8 Manager add-on. [Learn more about it](https://cloud.arduino.cc/plans#business).

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/wordpress-webserver/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/wordpress-webserver/content.md
@@ -27,7 +27,7 @@ The Arduino Portenta X8 is a powerful board that has many features that can be e
 ### Required Hardware and Software
 
 - [Arduino Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C cable (either USB-C to USB-A or USB-C to USB-C)
+- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
 
 ## Instructions
 

--- a/content/hardware/04.pro/carriers/portenta-breakout/datasheet/datasheet.md
+++ b/content/hardware/04.pro/carriers/portenta-breakout/datasheet/datasheet.md
@@ -125,7 +125,7 @@ Some nets/pins are electrically shared in the board and precaution must be taken
 ### DIP Switch
 The DIP switch allows for boot mode configuration:
 *   **BOOT SEL**: When set to ON, keeps the Portenta in Boot mode.
-*   **BOOT**: When set to ON enables the embedded bootloader. Firmware can be uploaded via the USB port on the breakout board (DFU). USB-A to USB-A  (non-crossover) cable required. The Portenta H7 has to be powered through the USB-C connector or VIN.
+*   **BOOT**: When set to ON enables the embedded bootloader. Firmware can be uploaded via the USB port on the breakout board (DFU). USB-A to USB-A  (non-crossover) cable required. The Portenta H7 has to be powered through the USB-C® connector or VIN.
 
 ### RJ-45 Connector
 The RJ-45 Connector allows to plug-in an ethernet cable and connect to your network.

--- a/content/hardware/04.pro/carriers/portenta-breakout/tutorials/getting-started/content.md
+++ b/content/hardware/04.pro/carriers/portenta-breakout/tutorials/getting-started/content.md
@@ -49,7 +49,7 @@ In order to build this example circuit, we need our Portenta Breakout with the P
 
 For the LED we can use any of the Portenta Breakout's 10 PWM Pins, in this case **PWM 9**. For the potentiometer, on the other hand, we can use one of the analog pins (A0 to A7) in order to read the potentiometer current value, in this example we use **A7**. The potentiometer also needs a 3.3V power source, which we take from the GPIO section on the Portenta Breakout, considering it being located most conveniently and close by. Eventually, potentiometer and LED have to be connected to GND to finilize the circuit. 
 
-After having connected everything, the Portenta H7 can be plugged into the computer using a USB-C cable and we can start with the code.
+After having connected everything, the Portenta H7 can be plugged into the computer using a USB-C® cable and we can start with the code.
 
 ### 4. The Arduino_PortentaBreakout Library
 In the Arduino IDE we create a new Sketch and make sure we have selected the Arduino Portenta H7 on the M7 core. If you haven't used the Portenta H7 before, [here](/tutorials/portenta-h7/setting-up-portenta) you can find a detailed tutorial on how to get started with it. 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
@@ -43,7 +43,7 @@ The goals of this project are:
 
 ### Circuit
 
-For this tutorial we need to plug the Portenta H7 into the Max Carrier, like shown in the image below. By attaching the Portenta H7 board to the HD connectors on top of the carrier, press firmly to let it snap in. Once attached, plug the Portenta H7 into your computer using a USB-C cable.
+For this tutorial we need to plug the Portenta H7 into the Max Carrier, like shown in the image below. By attaching the Portenta H7 board to the HD connectors on top of the carrier, press firmly to let it snap in. Once attached, plug the Portenta H7 into your computer using a USB-C® cable.
 
 ![Connecting the Portenta H7 and Max Carrier](assets/Connect-H7-to-Max-carrier.svg)
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/connecting-to-ttn/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/connecting-to-ttn/content.md
@@ -30,7 +30,7 @@ This tutorial explains how to connect your [Arduino® Max Carrier](http://store.
 - [Portena H7](https://store.arduino.cc/products/portenta-h7).
 - [Portenta Max Carrier](http://store.arduino.cc/portenta-max-carrier).
 - 868-915 MHz antenna with SMA connector.
-- USB-C cable (either USB-A to USB-C or USB-C to USB-C).
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®).
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software)).
 - [Arduino MKRWAN library](https://github.com/arduino-libraries/MKRWAN).  
 - An active account in [TTN](https://www.thethingsnetwork.org/).
@@ -65,13 +65,13 @@ Begin by attaching the Arduino® Portenta H7 board to the high-density connector
 
 ![CMWX1ZZABZ-078 LoRaWAN® module in the Portenta Max Carrier.](assets/mc_ard_hd_ttn_connectors.png)
 
-To power the CMWX1ZZABZ-078 LoRaWAN® module of the Portenta Max Carrier, you can use the **DC power jack** (with a 4.5V to 36V external DC power supply) of the Portenta Max Carrier or a **18650 3.7V Li-Ion battery**, connected to the Portenta Max Carrier battery clips; you can power the module also directly from the USB-C connector of the Portenta H7 board. **Also, do not forget to attach an 868-915 MHz antenna to the SMA connector (J9) on the Max Carrier**.
+To power the CMWX1ZZABZ-078 LoRaWAN® module of the Portenta Max Carrier, you can use the **DC power jack** (with a 4.5V to 36V external DC power supply) of the Portenta Max Carrier or a **18650 3.7V Li-Ion battery**, connected to the Portenta Max Carrier battery clips; you can power the module also directly from the USB-C® connector of the Portenta H7 board. **Also, do not forget to attach an 868-915 MHz antenna to the SMA connector (J9) on the Max Carrier**.
 
 ![Power sources and LoRa® antenna connector in the Portenta Max Carrier.](assets/mc_ard_ttn_power.png)
 
 ***Using the LoRaWAN® module of the Portenta Max Carrier without an antenna may damage it. Please, do not forget to connect a suitable antenna to the dedicated SMA connector (J9) on the Portenta Max Carrier.***
 
-Now you can connect the Portenta H7 board to your computer using a USB-C cable. **Don't forget to change the position of the BOOT DIP switch (SW1) to OFF** ; otherwise, you will not be able to program your Portenta H7 board when attached to the Portenta Max Carrier.
+Now you can connect the Portenta H7 board to your computer using a USB-C® cable. **Don't forget to change the position of the BOOT DIP switch (SW1) to OFF** ; otherwise, you will not be able to program your Portenta H7 board when attached to the Portenta Max Carrier.
 
 ![Power sources and LoRa® antenna connector in the Portenta Max Carrier.](assets/mc_ard_ttn_boot_sel.png)
 
@@ -276,5 +276,5 @@ You have now successfully configured and used the onboard LoRaWAN® module of yo
 While working on the sketch or when tried to upload the sketch, the Arduino IDE might show some errors preventing to proceed on the development. You can try the following troubleshooting tips to solve the commonly known issues:
 
 * If the sketch upload process fails, check if your Portenta H7 is in bootloader mode. To put the Portenta H7 into Bootloader mode, double-press its RESET button and verify that the green LED is waving. After this, you can try re-uploading the sketch.
-* Check the position of the BOOT DIP switch of the Portenta Max Carrier. If the Portenta H7 gets into bootloader mode immediately after power-on, including when connected via USB-C, change the position of the BOOT DIP switch to OFF.
+* Check the position of the BOOT DIP switch of the Portenta Max Carrier. If the Portenta H7 gets into bootloader mode immediately after power-on, including when connected via USB-C®, change the position of the BOOT DIP switch to OFF.
 * If the Arduino IDE fails to compile the sketch, check if you have defined `PORTENTA_CARRIER` before the MKRWAN library inclusion.

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/getting-started/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/getting-started/content.md
@@ -27,7 +27,7 @@ The Arduino® Portenta Max Carrier provides developers an unlimited range of app
 
 - [Portenta H7](https://store.arduino.cc/products/portenta-h7).
 - [Portenta Max Carrier](http://store.arduino.cc/portenta-max-carrier).
-- USB-C cable (either USB-A to USB-C or USB-C to USB-C).
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®).
 - LoRa® antenna (868-915MHz) with SMA connector.
 - LTE antenna (698-960/1710-2690MHz) with SMA connector. 
 - 3.7V 2600mAh 18650 Li-Ion battery.
@@ -52,7 +52,7 @@ In this tutorial, we will describe the following features of the Portenta Max Ca
 
 #### 1.1. Power Distribution
 
-The Portenta Max Carrier provides several peripherals and modules to cover a wide spectrum of applications. For these peripherals and modules to be powered up and run, the Portenta Max Carrier bases on a sophisticated electric power distribution architecture. To power the Portenta Max Carrier, you can use the **barrel jack** connector (X1) or a **3.7V 18650 Li-Ion battery** connected to the Portenta Max Carrier's battery clips (J16 and J18). You can also power the Portenta Max Carrier directly from the USB-C connector of the Portenta H7 board.
+The Portenta Max Carrier provides several peripherals and modules to cover a wide spectrum of applications. For these peripherals and modules to be powered up and run, the Portenta Max Carrier bases on a sophisticated electric power distribution architecture. To power the Portenta Max Carrier, you can use the **barrel jack** connector (X1) or a **3.7V 18650 Li-Ion battery** connected to the Portenta Max Carrier's battery clips (J16 and J18). You can also power the Portenta Max Carrier directly from the USB-C® connector of the Portenta H7 board.
 
 You can see the detailed Portenta Max Carrier's power tree in the image below:
 
@@ -62,7 +62,7 @@ The Portenta Max Carrier's power inputs are indicated in the following image:
 
 ![Portenta Max Carrier Power Input](assets/mc_ard_power.png)
 
-These power feed line options power up different peripherals and modules depending on the line configuration. The Portenta H7 powered by USB-C cable while attached to Portenta Max Carrier enables Audio, LoRa, USB Hub, SD ports, Camera, and Fieldbus including the Debugger while it is also possible to upload the Code. This power line use case will be useful to develop and debug the code.
+These power feed line options power up different peripherals and modules depending on the line configuration. The Portenta H7 powered by USB-C® cable while attached to Portenta Max Carrier enables Audio, LoRa, USB Hub, SD ports, Camera, and Fieldbus including the Debugger while it is also possible to upload the Code. This power line use case will be useful to develop and debug the code.
 
 **If the Arduino IDE throws an error failing to upload the Code, please put the Portenta H7 in Bootloader Mode before uploading.**
 
@@ -209,7 +209,7 @@ For all the information detailed as above for it to be used, we will need to dev
 
 #### 4.1. Using Arduino® IDE 2
 
-The Arduino® IDE 2 allows the developers to design and upload the code to Portenta H7 in offline. It will also help you with organizing packages needed to program the Portenta H7. It will require a USB-C Type cable that will allow to connect and program the Portenta H7. In [here](https://www.arduino.cc/en/software), you will be able to find the latest version of the Arduino IDE 2.
+The Arduino® IDE 2 allows the developers to design and upload the code to Portenta H7 in offline. It will also help you with organizing packages needed to program the Portenta H7. It will require a USB-C® Type cable that will allow to connect and program the Portenta H7. In [here](https://www.arduino.cc/en/software), you will be able to find the latest version of the Arduino IDE 2.
 
 ***If you want to know how to setup the Arduino® IDE 2 adequately, please look into [Quick Guide to Arduino® IDE 2.0](https://docs.arduino.cc/software/ide-v2/tutorials/getting-started/ide-v2-downloading-and-installing).***
 

--- a/content/hardware/04.pro/shields/portenta-cat-m1-nb-iot-gnss-shield/tutorials/getting-started/getting-started.md
+++ b/content/hardware/04.pro/shields/portenta-cat-m1-nb-iot-gnss-shield/tutorials/getting-started/getting-started.md
@@ -48,7 +48,7 @@ First insert the SIM card into the SIM card slot at the bottom of the Portenta C
 
 ![Connect the antenna to the Portenta Cat. M1 shield](assets/Antenna_Cat_M1.svg)
 
-Now connect the shield to the Portenta H7. Do this by attaching it to the HD connectors at the bottom of the Portenta H7 board. Like the image shows below, the top and bottom high density connectors on the shield are connected to the corresponding ones on the lower side of the H7 board. Press firmly to let it snap in. Once attached, plug the Portenta H7 into your computer using a USB-C cable.
+Now connect the shield to the Portenta H7. Do this by attaching it to the HD connectors at the bottom of the Portenta H7 board. Like the image shows below, the top and bottom high density connectors on the shield are connected to the corresponding ones on the lower side of the H7 board. Press firmly to let it snap in. Once attached, plug the Portenta H7 into your computer using a USB-C® cable.
 
 ![Connect the Portenta Cat. M1 shield with the Portenta H7](assets/Connect_Cat_M1_to_Portenta_H7.svg)
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/blob-detection/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/blob-detection/content.md
@@ -60,7 +60,7 @@ Follow the instructions of the installer.
 
 ### 2. Flashing the OpenMV Firmware
 
-Connect the Portenta to your computer via the USB-C cable if you haven't done so yet. Make sure you first update the bootloader to the latest version using the **STM32H747_updateBootloader** sketch in the examples menu in the Arduino IDE. 
+Connect the Portenta to your computer via the USB-C® cable if you haven't done so yet. Make sure you first update the bootloader to the latest version using the **STM32H747_updateBootloader** sketch in the examples menu in the Arduino IDE. 
 
 Instructions on how to update the bootloader can be found in the [Updating the Portenta Bootloader](https://docs.arduino.cc/tutorials/portenta-h7/updating-the-bootloader) tutorial.
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/camera-to-bitmap-sd-card/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/camera-to-bitmap-sd-card/content.md
@@ -31,7 +31,7 @@ This tutorial shows you how to capture a frame from the Portenta Vision Shield C
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - Portenta Vision Shield ([LoRa](https://store.arduino.cc/portenta-vision-shield-lora) or [Ethernet](https://store.arduino.cc/portenta-vision-shield))
-- 1x USB-C cable (either USB-A to USB-C or USB-C to USB-C)
+- 1x USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Micro SD card
 - Arduino IDE or Arduino-cli
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/custom-machine-learning-model/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/custom-machine-learning-model/content.md
@@ -26,7 +26,7 @@ This tutorial teaches you how to train a custom machine learning model with Edge
 
 - [Portenta H7 board](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield - LoRa®](https://store.arduino.cc/portenta-vision-shield-lora) or [Portenta Vision Shield - Ethernet](https://store.arduino.cc/usa/portenta-vision-shield)
-- USB-C cable (either USB-A to USB-C or USB-C to USB-C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - An [Edge Impulse](https://studio.edgeimpulse.com/) account for training the ML model
 - Fruits (or other objects) to create the classification model 🍏🍌🍐
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-ide/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-ide/content.md
@@ -36,7 +36,7 @@ The goals of this project are:
 - [Portenta Vision Shield - Ethernet](https://store.arduino.cc/products/arduino-portenta-vision-shield-ethernet)
 - Arduino [offline IDE](https://www.arduino.cc/en/main/software) or Arduino [Web Editor](https://create.arduino.cc/)
 - Ethernet cable
-- USB-C cable
+- USB-C® cable
 
 ## Ethernet Connection
 
@@ -52,7 +52,7 @@ Now let's look at how to connect everything we need.
 
 ### Connecting the Board
 
-Connect the Portenta Vision Shield Ethernet to the Portenta H7. Now connect the USB-C cable to the Portenta H7 and your computer. Lastly connect the Ethernet cable to the Portenta Vision Shield's Ethernet port and your router or modem.
+Connect the Portenta Vision Shield Ethernet to the Portenta H7. Now connect the USB-C® cable to the Portenta H7 and your computer. Lastly connect the Ethernet cable to the Portenta Vision Shield's Ethernet port and your router or modem.
 
 ### Programming the Board
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-openmv/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-openmv/content.md
@@ -32,7 +32,7 @@ With the Ethernet version of the Arduino Portenta Vision Shield it is possible t
 - [Portenta Vision Shield - Ethernet](https://store.arduino.cc/usa/portenta-vision-shield)
 - [OpenMV](https://openmv.io/pages/download)
 - Ethernet cable
-- USB-C cable
+- USB-C® cable
 
 ***If you want to know more about the ethernet connection please go to the [Arduino IDE ethernet tutorial](https://docs.arduino.cc/tutorials/portenta-vision-shield/ethernet-with-ide#ethernet-connection)***
 
@@ -40,7 +40,7 @@ With the Ethernet version of the Arduino Portenta Vision Shield it is possible t
 
 ### Connecting the Board
 
-Connect the Portenta Vision Shield Ethernet to the Portenta H7. Now connect the USB-C cable to the Portenta H7 and your computer. Lastly connect the Ethernet cable to the Portenta Vision Shield's Ethernet port and your router or modem.
+Connect the Portenta Vision Shield Ethernet to the Portenta H7. Now connect the USB-C® cable to the Portenta H7 and your computer. Lastly connect the Ethernet cable to the Portenta Vision Shield's Ethernet port and your router or modem.
 
 ### Programming the Board
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/getting-started-camera/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/getting-started-camera/content.md
@@ -23,7 +23,7 @@ This tutorial shows you how to capture frames from the Arduino Portenta Vision S
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - Portenta Vision Shield ([LoRa](https://store.arduino.cc/portenta-vision-shield-lora) or [Ethernet](https://store.arduino.cc/portenta-vision-shield))
-- 1x USB-C cable (either USB-A to USB-C or USB-C to USB-C)
+- 1x USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+
 - Processing 3.5.4+
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/things-network-openmv/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/things-network-openmv/content.md
@@ -31,7 +31,7 @@ This tutorial explains how to connect your Portenta H7 to The Things Network (TT
 - 1x [Dipole Pentaband antenna](https://store.arduino.cc/antenna) or a UFL Antenna of the H7 
 - [OpenMV IDE](https://openmv.io/pages/download)
 - Arduino IDE 1.8.10+ or Arduino Pro IDE 0.0.4+ or Arduino CLI 0.13.0+
-- 1x USB-C cable (either USB-A to USB-C or USB-C to USB-C)
+- 1x USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - An account on [The Things Network](https://console.cloud.thethings.network/)
 
 ## Instructions

--- a/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/connecting-to-iot-cloud/content.md
+++ b/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/connecting-to-iot-cloud/content.md
@@ -33,7 +33,7 @@ In this tutorial you will learn how to upload data from the Nicla module to the 
 - [Portenta H7](https://store.arduino.cc/products/portenta-h7)
 - [Nicla Sense ME](https://store.arduino.cc/products/nicla-sense-me)
 - ESLOV cable (included with the Nicla Sense ME)
-- USB-C to USB-A / C depending on your hardware (Portenta H7)
+- USB-C® to USB-A / C depending on your hardware (Portenta H7)
 - USB-A to micro USB-A (Nicla Sense ME)
 - Wi-Fi Access point with access to the internet
 - [Arduino Cloud](https://create.arduino.cc/) account
@@ -42,7 +42,7 @@ In this tutorial you will learn how to upload data from the Nicla module to the 
 
 ### Hardware Connection
 
-For the hardware setup, just connect the Nicla board to the Portenta H7 using the ESLOV cable like in the illustration below. Then connect the Portenta H7 to your computer using an USB-C cable.
+For the hardware setup, just connect the Nicla board to the Portenta H7 using the ESLOV cable like in the illustration below. Then connect the Portenta H7 to your computer using an USB-C® cable.
 
 ![Nicla connection](assets/eslov-connection.svg)
 

--- a/content/hardware/07.edu/carriers/braccio-carrier/datasheet/datasheet.md
+++ b/content/hardware/07.edu/carriers/braccio-carrier/datasheet/datasheet.md
@@ -26,7 +26,7 @@ Robotics, Automation, Education, Gaming, Communication
   - Right angle mounting
   - Plastic tape packaging
 - **Mini Joystick Connector**
-- **Programmable USB Type-C Connector**
+- **Programmable USB Type-C® Connector**
 - **ESD Protection**
   - 4- and 5-line unidirectional transil function for electrostatic discharge protection
   - Low-leakage current: < 500 nA
@@ -78,8 +78,8 @@ Following information outlines the technical overview of the Arduino® Braccio C
     | No. Connectors   | Maximum Electrical Operating Range   | Maximum Temperature Operating Range   |
     | ---------------- | ------------------------------------ | ------------------------------------- |
     |  6               |  250VAC @ 3A                         |  -25°C ~ +85°C                        |
-- **USB-C Port**
-  - USB Type C port available to enable programming, and power supply source port under USB PD 3.0 for Arduino® Braccio Carrier.
+- **USB-C® Port**
+  - USB Type-C® port available to enable programming, and power supply source port under USB PD 3.0 for Arduino® Braccio Carrier.
     | USB Standard    | USB Power Delivery Rev.    | USB Type               | Purpose                           |
     | --------------- | -------------------------- | ---------------------- | --------------------------------- |
     |  3.1            |  3.0                       |  Type C (Reversible)   |  Power Supply                     |
@@ -99,7 +99,7 @@ Following information outlines the technical overview of the Arduino® Braccio C
 ### Block Diagram
 ![Arduino Braccio Carrier System Block Diagram](assets/System_Block_Diagram_Braccio_Carrier.jpg)
 
-The USB powers the Arduino® Nano RP2040 Connect which is the heart of the Braccio Carrier as it stores the programs responsible for the functioning of the whole system. The Nano is connected to the joystick which is the input peripheral and LED display screen which is the output peripheral of the microcontroller. Another power supply via USB-C powers the connected motors which constitute the entire robotics functionality the system. RS485 Transceiver signals the motor connector for the precise motihe motors according to the input given by the user.
+The USB powers the Arduino® Nano RP2040 Connect which is the heart of the Braccio Carrier as it stores the programs responsible for the functioning of the whole system. The Nano is connected to the joystick which is the input peripheral and LED display screen which is the output peripheral of the microcontroller. Another power supply via USB-C® powers the connected motors which constitute the entire robotics functionality the system. RS485 Transceiver signals the motor connector for the precise motihe motors according to the input given by the user.
 
 ![Arduino® Braccio Carrier Block Diagram](assets/Block_Diagram_Braccio_Carrier.svg)
 

--- a/content/hardware/_unlisted/old-datasheets/portenta-h7-full/datasheet.md
+++ b/content/hardware/_unlisted/old-datasheets/portenta-h7-full/datasheet.md
@@ -13,7 +13,7 @@ type: pro
 # Description
 The Portenta H7 is the first member of the Portenta family, dedicated to industrial use cases but with the traditional Arduino openness and ready for the most demanding Pro applications. The Portenta H7 is ready for machine learning and real-time applications thanks to the dual core STM32H747 processor including a Cortex® M7 running at 480 MHz and a Cortex® M4 running at 240 MHz. The two cores communicate via a Remote Procedure Call mechanism that allows calling functions on the other processor seamlessly for real multitasking. By harnessing the computational power of both Portenta H7's cores, machine learning algorithms can run simultaneously alongside low latency sensor/actuator interaction. 
 
-Arduino's expertise in producing high quality PCB in house has been leveraged to ensure that the Portenta H7 can meet the vibrations and temperatures met in daily industrial, automotive and agriculture applications. The various interfaces give the developers freedom in how they interact with the Portenta H7 and include MKR-compatible pins, USB-C enabled HDMI output and Arduino's open connector (ESLOV). Developers will receive the support they need from Arduino to build their custom solution.
+Arduino's expertise in producing high quality PCB in house has been leveraged to ensure that the Portenta H7 can meet the vibrations and temperatures met in daily industrial, automotive and agriculture applications. The various interfaces give the developers freedom in how they interact with the Portenta H7 and include MKR-compatible pins, USB-C® enabled HDMI output and Arduino's open connector (ESLOV). Developers will receive the support they need from Arduino to build their custom solution.
 
 Portenta H7 offers several customization possibilities that allow tailoring board functionality to specific applications for high volume use cases.
 
@@ -29,7 +29,7 @@ Available assembly options that can be configured for high volume applications a
 | Crypto     | Crypto Chip                   | 0 - NoneM - ATECC608AN - SE050C2B - Both                        |
 | Wireless   | Wireless Module               | 0 - NoneW - Fitted                                              |
 | Antenna    | Antenna option                | 0 - NoneA - on board ceramic antennaC - U.FL connector          |
-| Video      | DisplayPort output over USB-C | 0 - NoneD - Fitted                                              |
+| Video      | DisplayPort output over USB-C® | 0 - NoneD - Fitted                                              |
 
 Standard configurations are:
 *   Arduino Portenta H7-0000000 (barebones version)
@@ -41,7 +41,7 @@ Standard configurations are:
     *   NXP SE050C2 Crypto
     *   Wi-Fi/BT Module
     *   U.FL Antenna
-    *   DisplayPort over USB-C
+    *   DisplayPort over USB-C®
 
 
 # Target Areas
@@ -103,7 +103,7 @@ Standard configurations are:
 *   **External Memories**
     *   up to 64 MByte SDRAM (optional)
     *   up to 128 MByte QSPI Flash (optional)
-*   **USB-C**
+*   **USB-C®**
     *   High Speed (optional)/Full Speed USB 
     *   DisplayPort output (optional)
     *   Host and Device operation
@@ -233,7 +233,7 @@ The [Portenta H7 Vision Shield](https://www.arduino.cc/pro/hardware/product/port
 | U3       | USB HS PHY                          | U12, U13, U14   | ESD protection            |
 | U4       | SDRAM                               | U16             | Crypto Chip (Microchip)   |
 | U5       | Ethernet PHY                        | J1, J2          | High Density Connectors   |
-| U6       | MIPI to USB-C/DisplayPort converter | ANT1            | Antenna or U.FL Connector |
+| U6       | MIPI to USB-C®/DisplayPort converter | ANT1            | Antenna or U.FL Connector |
 | U7       | Level Shifter                       | JANALOGJDIGITAL | MKR compatible headers    |
 | U8       | I2C level shifter                   | J4              | Battery connector         |
 | U9       | Wi-Fi/BT Module                     | J5              | ESLOV connector           |
@@ -277,21 +277,21 @@ Portenta H7 provides two different optional Crypto Chip choices. The classic ATE
 The optional 10/100 Ethernet physical interface is directly connected to the internal Ethernet MAC and provides full duplex communication with automatic MDIX support. The Wake On Lan functionality allows reducing power consumption when in sleep mode.  
 
 ### High Speed USB Phy
-The optional High Speed USB Phy is one of the two USB interfaces available on the high speed connectors and is also available on the USB-C connector. High Speed USB PHY allows transfer rates of up to 480 Mbps and can be used both as a host and as a device.
+The optional High Speed USB Phy is one of the two USB interfaces available on the high speed connectors and is also available on the USB-C® connector. High Speed USB PHY allows transfer rates of up to 480 Mbps and can be used both as a host and as a device.
 
-When using the USB-C connector only one USB port is usable on high speed connectors.
+When using the USB-C® connector only one USB port is usable on high speed connectors.
 
-When the High Speed USB Phy option is not assembled the USB-C port only one Full Speed port is available and is shared between USB-C and High Density connectors  
+When the High Speed USB Phy option is not assembled the USB-C® port only one Full Speed port is available and is shared between USB-C® and High Density connectors  
 
-### USB-C Connector 
-USB-C connector supports multiple use case scenarios and provides the following functions:
+### USB-C® Connector 
+USB-C® connector supports multiple use case scenarios and provides the following functions:
 
 *   Provide board power supply in both DFP and DRP mode
 *   Source power to external peripherals when board is powered through VIN
 *   expose High Speed (480Mbps) or Full Speed (12 Mbps) USB Host/Device interface
 *   expose DisplayPort output interface (optional)
 
-The DisplayPort interface is usable in conjunction with USB and can be either used with a simple cable adapter when board is powered via VIN or with dongles able to provide power to the board while simultaneously outputting DisplayPort and USB. Such dongles usually provide an ethernet over USB port, a 2 port USB hub and a USB-C port that can be used to provide power to the system. 
+The DisplayPort interface is usable in conjunction with USB and can be either used with a simple cable adapter when board is powered via VIN or with dongles able to provide power to the board while simultaneously outputting DisplayPort and USB. Such dongles usually provide an ethernet over USB port, a 2 port USB hub and a USB-C® port that can be used to provide power to the system. 
 
 ### Power Tree
 All power conversion on the Portenta H7 is handled by the PF1550 PMIC. Current is drawn by VUSB, VIN or VBATT automatically according to rules specified by the PMIC. The VCC is driven by a buck converter configured to provide 3V3 that is accessible on both the MKR headers and the HDR connector. Two other buck converters provide 3V1 and 2V8 outputs. Additionally, three precision LDO provide low-ripple outputs of 1V0, 1V2 and 1V8.  Voltage range and max current are provided as a general guideline only. Consult the PF1550 datasheet for specific details.
@@ -301,7 +301,7 @@ All power conversion on the Portenta H7 is handled by the PF1550 PMIC. Current i
 ## Board Operation
 ### Getting Started – IDE
 
-If you want to program your Arduino Portenta H7 while offline you need to install the Arduino Desktop IDE **[1].** To connect the Arduino Portenta H7 to your computer, you’ll need a USB-C cable. This also provides power to the board, as indicated by the LED.  
+If you want to program your Arduino Portenta H7 while offline you need to install the Arduino Desktop IDE **[1].** To connect the Arduino Portenta H7 to your computer, you’ll need a USB-C® cable. This also provides power to the board, as indicated by the LED.  
 
 ### Getting Started – Arduino Web Editor (Create) 
 All Arduino and Genuino boards, including this one, work out-of-the-box on the Arduino Web Editor **[2]**, by just installing a simple plugin.
@@ -321,8 +321,8 @@ Now that you have gone through the basics of what you can do with the board you 
 All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.  
 
 ## Connector Pinouts
-### USB-C
-![USB-C Pinout](assets/portentaH7_PinoutUSB-C.png)
+### USB-C®
+![USB-C® Pinout](assets/portentaH7_PinoutUSB-C.png)
 
 ### High Density Connector
 

--- a/content/hardware/_unlisted/old-datasheets/portenta-h7-lite-connected/datasheet.md
+++ b/content/hardware/_unlisted/old-datasheets/portenta-h7-lite-connected/datasheet.md
@@ -13,7 +13,7 @@ type: pro
 # Description
 The Portenta H7 Lite Connected is dedicated to industrial use cases but with the traditional Arduino openness and ready for the most demanding Pro applications. The Portenta H7 Lite Connected is ready for machine learning and real-time applications thanks to the dual core STM32H747 processor including a Cortex® M7 running at 480 MHz and a Cortex® M4 running at 240 MHz. The two cores communicate via a Remote Procedure Call mechanism that allows calling functions on the other processor seamlessly for real multitasking. By harnessing the computational power of both Portenta H7's cores, machine learning algorithms can run simultaneously alongside low latency sensor/actuator interaction. 
 
-Arduino's expertise in producing high quality PCB in house has been leveraged to ensure that the Portenta H7 Lite Connected can meet the vibrations and temperatures met in daily industrial, automotive and agriculture applications. The various interfaces give the developers freedom in how they interact with the Portenta H7 and include MKR-compatible pins, USB-C enabled HDMI output and Arduino's open connector (ESLOV). As a pioneer in Open Source electronics, developers will receive the support they need from Arduino to build their solution free from technological lock-in.  
+Arduino's expertise in producing high quality PCB in house has been leveraged to ensure that the Portenta H7 Lite Connected can meet the vibrations and temperatures met in daily industrial, automotive and agriculture applications. The various interfaces give the developers freedom in how they interact with the Portenta H7 and include MKR-compatible pins, USB-C® enabled HDMI output and Arduino's open connector (ESLOV). As a pioneer in Open Source electronics, developers will receive the support they need from Arduino to build their solution free from technological lock-in.  
 
 Portenta H7 Lite Connected offers several customization possibilities that allow tailoring board functionality to specific applications for high volume use cases.
 
@@ -102,7 +102,7 @@ AI applications, low-latency control solutions
 *   **External Memories**
     *   up to 64 MByte SDRAM (optional)
     *   up to 128 MByte QSPI Flash (optional)
-*   **USB-C**
+*   **USB-C®**
     *   High Speed (optional)/Full Speed USB 
     *   Host and Device operation
     *   Power Delivery support (optional)
@@ -264,14 +264,14 @@ Portenta H7 Lite Connected runs the classic ATECC608A.
 The optional 10/100 Ethernet physical interface is directly connected to the internal Ethernet MAC and provides full duplex communication with automatic MDIX support. The Wake On Lan functionality allows reducing power consumption when in sleep mode.  
 
 ### High Speed USB Phy
-The optional High Speed USB Phy is one of the two USB interfaces available on the high speed connectors and is also available on the USB-C connector. High Speed USB PHY allows transfer rates of up to 480 Mbps and can be used both as a host and as a device.
+The optional High Speed USB Phy is one of the two USB interfaces available on the high speed connectors and is also available on the USB-C® connector. High Speed USB PHY allows transfer rates of up to 480 Mbps and can be used both as a host and as a device.
 
-When using the USB-C connector only one USB port is usable on high speed connectors.
+When using the USB-C® connector only one USB port is usable on high speed connectors.
 
-When the High Speed USB Phy option is not assembled the USB-C port only one Full Speed port is available and is shared between USB-C and High Density connectors  
+When the High Speed USB Phy option is not assembled the USB-C® port only one Full Speed port is available and is shared between USB-C® and High Density connectors  
 
-### USB-C Connector 
-USB-C connector supports multiple use case scenarios and provides the following functions:
+### USB-C® Connector 
+USB-C® connector supports multiple use case scenarios and provides the following functions:
 
 *   Provide board power supply in both DFP and DRP mode
 *   Source power to external peripherals when board is powered through VIN
@@ -285,7 +285,7 @@ All power conversion on the Portenta H7 Lite Connected is handled by the PF1550 
 ## Board Operation
 ### Getting Started – IDE
 
-If you want to program your Arduino Portenta H7 while offline you need to install the Arduino Desktop IDE **[1].** To connect the Arduino Portenta H7 to your computer, you’ll need a USB-C cable. This also provides power to the board, as indicated by the LED.  
+If you want to program your Arduino Portenta H7 while offline you need to install the Arduino Desktop IDE **[1].** To connect the Arduino Portenta H7 to your computer, you’ll need a USB-C® cable. This also provides power to the board, as indicated by the LED.  
 
 ### Getting Started – Arduino Web Editor (Create) 
 All Arduino and Genuino boards, including this one, work out-of-the-box on the Arduino Web Editor **[2]**, by just installing a simple plugin.
@@ -305,7 +305,7 @@ Now that you have gone through the basics of what you can do with the board you 
 All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.  
 
 ## Connector Pinouts
-### USB-C
+### USB-C®
 ![alt_text](assets/portentaH7_PinoutUSB-C.png)
 
 ### High Density Connector

--- a/content/hardware/_unlisted/old-datasheets/portenta-h7-lite/datasheet.md
+++ b/content/hardware/_unlisted/old-datasheets/portenta-h7-lite/datasheet.md
@@ -184,7 +184,7 @@ The [Portenta H7 Vision Shield](https://www.arduino.cc/pro/hardware/product/port
 | U3       | USB HS PHY                          | U12, U13, U14   | ESD protection            |
 | U4       | SDRAM                               | U16             | Crypto Chip (Microchip)   |
 | U5       | Ethernet PHY                        | J1, J2          | High Density Connectors   |
-| U6       | MIPI to USB-C                       | ANT1            | Antenna or U.FL Connector |
+| U6       | MIPI to USB-C®                       | ANT1            | Antenna or U.FL Connector |
 | U7       | Level Shifter                       | JANALOGJDIGITAL | MKR compatible headers    |
 | U8       | I2C level shifter                   | J4              | Battery connector         |
 | U9       | WiFi/BT Module                      | J5              | ESLOV connector           |
@@ -226,14 +226,14 @@ Portenta H7 lite provides the classic ATECC608A from Microchip that provides low
 The optional 10/100 Ethernet physical interface is directly connected to the internal Ethernet MAC and provides full duplex communication with automatic MDIX support. The Wake On Lan functionality allows reducing power consumption when in sleep mode.  
 
 ### High Speed USB Phy
-The optional High Speed USB Phy is one of the two USB interfaces available on the high speed connectors and is also available on the USB-C connector. High Speed USB PHY allows transfer rates of up to 480 Mbps and can be used both as a host and as a device.
+The optional High Speed USB Phy is one of the two USB interfaces available on the high speed connectors and is also available on the USB-C® connector. High Speed USB PHY allows transfer rates of up to 480 Mbps and can be used both as a host and as a device.
 
-When using the USB-C connector only one USB port is usable on high speed connectors.
+When using the USB-C® connector only one USB port is usable on high speed connectors.
 
-When the High Speed USB Phy option is not assembled the USB-C port only one Full Speed port is available and is shared between USB-C and High Density connectors  
+When the High Speed USB Phy option is not assembled the USB-C® port only one Full Speed port is available and is shared between USB-C® and High Density connectors  
 
-### USB-C Connector 
-USB-C connector supports multiple use case scenarios and provides the following functions:
+### USB-C® Connector 
+USB-C® connector supports multiple use case scenarios and provides the following functions:
 
 *   Provide board power supply in both DFP and DRP mode
 *   Source power to external peripherals when board is powered through VIN
@@ -247,7 +247,7 @@ All power conversion on the Portenta H7 lite is handled by the PF1550 PMIC. Curr
 ## Board Operation
 ### Getting Started – IDE
 
-If you want to program your Arduino Portenta H7 Lite while offline you need to install the Arduino Desktop IDE **[1].** To connect the Arduino Portenta H7 Lite to your computer, you’ll need a USB-C cable. This also provides power to the board, as indicated by the LED.  
+If you want to program your Arduino Portenta H7 Lite while offline you need to install the Arduino Desktop IDE **[1].** To connect the Arduino Portenta H7 Lite to your computer, you’ll need a USB-C® cable. This also provides power to the board, as indicated by the LED.  
 
 ### Getting Started – Arduino Web Editor (Create) 
 All Arduino and Genuino boards, including this one, work out-of-the-box on the Arduino Web Editor **[2]**, by just installing a simple plugin.
@@ -267,7 +267,7 @@ Now that you have gone through the basics of what you can do with the board you 
 All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.  
 
 ## Connector Pinouts
-### USB-C
+### USB-C®
 ![alt_text](assets/portentaH7_PinoutUSB-C.png)
 
 ### High Density Connector

--- a/content/learn/04.electronics/06.power-tree/power-tree-style-guide.md
+++ b/content/learn/04.electronics/06.power-tree/power-tree-style-guide.md
@@ -17,13 +17,13 @@ Lets take a look together at one of our power trees. The Portenta H7 was one of 
 
 ![Portenta H7 Power Tree](assets/Power_Tree_Portenta_H7.svg)
 
-To the left, you will see three grey boxes. Each one of these represents a voltage input. In the case of the Arduino Portenta H7, we can either provide power via the USB-C cable, the VIN pin on the high density connector or a battery.
+To the left, you will see three grey boxes. Each one of these represents a voltage input. In the case of the Arduino Portenta H7, we can either provide power via the USB-C® cable, the VIN pin on the high density connector or a battery.
 
 ![Portenta H7 Input Sources](assets/Power_Inputs_Portenta_H7.svg)
 
 ***You can see more information about the precise schematic location and pins in the schematic diagram and pinout graphics respectively. The Power Tree is there to provide a visual aid to better understanding the product and some intermediate components may not be displayed. If in doubt, refer to the schematics or contact us.***
 
-We can also see that the USB-C and the VIN are connected together. Under each grey box, we can see that the voltage is listed as 5V. This is the nominal value (see the datasheet for the allowed voltage ranges). In general, you can expect there to be no difference in the operation between each approach. 
+We can also see that the USB-C® and the VIN are connected together. Under each grey box, we can see that the voltage is listed as 5V. This is the nominal value (see the datasheet for the allowed voltage ranges). In general, you can expect there to be no difference in the operation between each approach. 
 
 A bit further down, we can see another grey component titled `VBATT`. In this case, we see two distinct features: first of all, the arrows are bi-directional. Secondly, the voltage (in the turquoise box underneath it) is lower. While this can be difficult to understand from a text based table, having this information can be beneficial to the user when trying to understand the product from a Model-Based Design approach.
 
@@ -39,7 +39,7 @@ Next, let us take a look at the block representing the MC34PF1550A0EP component.
 
 ![Portenta H7 Power Management IC](assets/PMIC_Portenta_H7.svg)
 
-The input of the power component, as stated previously, can come from either the 5V power source or the battery. The voltage and net of these two (as seen in the schematic view) is written on the turquoise box on the connecting lines. Recall that since the USB-C and VIN voltage inputs are connected (as denoted by the black dot connecting the lines together). The 5V voltage is fed to a LDO that has a maximum current capacity of 2A, producing a 4.5V rail. LDO stands for a **L**ow **D**rop**o**ut linear regulator. These are a type of linear regulator that are designed to work when the input voltage is slightly above the output voltage. The output of this LDO is a voltage rail (shown again in a turquoise box) with a voltage of 4.5V. Given that this is slightly lower than 5V input, it is important that the input voltage is stable since, if it drops below 4.7V the stability of the Portenta board may be compromised.
+The input of the power component, as stated previously, can come from either the 5V power source or the battery. The voltage and net of these two (as seen in the schematic view) is written on the turquoise box on the connecting lines. Recall that since the USB-C® and VIN voltage inputs are connected (as denoted by the black dot connecting the lines together). The 5V voltage is fed to a LDO that has a maximum current capacity of 2A, producing a 4.5V rail. LDO stands for a **L**ow **D**rop**o**ut linear regulator. These are a type of linear regulator that are designed to work when the input voltage is slightly above the output voltage. The output of this LDO is a voltage rail (shown again in a turquoise box) with a voltage of 4.5V. Given that this is slightly lower than 5V input, it is important that the input voltage is stable since, if it drops below 4.7V the stability of the Portenta board may be compromised.
 
 ***Since all other system voltages go through the noted LDO, the maximum current that can pass through the PMIC is at most 2A. Losses in subsequent voltage conversion will reduce the real current available to the user. For further details, please refer to the MC34PF1550A0EP datasheet. ***
 

--- a/content/tutorials/projects/iot-air-quality-checker/iot-air-quality-checker.md
+++ b/content/tutorials/projects/iot-air-quality-checker/iot-air-quality-checker.md
@@ -15,7 +15,7 @@ source: "https://create.arduino.cc/projecthub/407590/iot-air-quality-checker-c8d
 - [Seeed Grove - Dust Sensor（PPD42NS）](https://www.seeedstudio.com/Grove-Dust-Sensor%EF%BC%88PPD42NS%EF%BC%89-p-1050.html)
 - [Arduino Seeed Seed - Grove - Oled Display 0.96"](https://store.arduino.cc/grove-oled-display-0-96)
 - [Seeed Grove - Air quality sensor v1.3](https://www.seeedstudio.com/Grove-Air-quality-sensor-v1.3-p-2439.html)
-- [Arduino USB cable type A male to micro type B male](https://store.arduino.cc/USB-Cable-type-a-male-to-micro-type-b-male)
+- [Arduino USB cable type A male to micro type B male](https://store.arduino.cc/usb-cable-type-a-male-to-micro-type-b-male)
 
 ## About This Project
 

--- a/content/tutorials/projects/iot-air-quality-checker/iot-air-quality-checker.md
+++ b/content/tutorials/projects/iot-air-quality-checker/iot-air-quality-checker.md
@@ -15,7 +15,7 @@ source: "https://create.arduino.cc/projecthub/407590/iot-air-quality-checker-c8d
 - [Seeed Grove - Dust Sensor（PPD42NS）](https://www.seeedstudio.com/Grove-Dust-Sensor%EF%BC%88PPD42NS%EF%BC%89-p-1050.html)
 - [Arduino Seeed Seed - Grove - Oled Display 0.96"](https://store.arduino.cc/grove-oled-display-0-96)
 - [Seeed Grove - Air quality sensor v1.3](https://www.seeedstudio.com/Grove-Air-quality-sensor-v1.3-p-2439.html)
-- [Arduino USB cable type A male to micro type B male](https://store.arduino.cc/USB-C®able-type-a-male-to-micro-type-b-male)
+- [Arduino USB cable type A male to micro type B male](https://store.arduino.cc/USB-Cable-type-a-male-to-micro-type-b-male)
 
 ## About This Project
 

--- a/content/tutorials/projects/iot-air-quality-checker/iot-air-quality-checker.md
+++ b/content/tutorials/projects/iot-air-quality-checker/iot-air-quality-checker.md
@@ -15,7 +15,7 @@ source: "https://create.arduino.cc/projecthub/407590/iot-air-quality-checker-c8d
 - [Seeed Grove - Dust Sensor（PPD42NS）](https://www.seeedstudio.com/Grove-Dust-Sensor%EF%BC%88PPD42NS%EF%BC%89-p-1050.html)
 - [Arduino Seeed Seed - Grove - Oled Display 0.96"](https://store.arduino.cc/grove-oled-display-0-96)
 - [Seeed Grove - Air quality sensor v1.3](https://www.seeedstudio.com/Grove-Air-quality-sensor-v1.3-p-2439.html)
-- [Arduino USB cable type A male to micro type B male](https://store.arduino.cc/usb-cable-type-a-male-to-micro-type-b-male)
+- [Arduino USB cable type A male to micro type B male](https://store.arduino.cc/USB-C®able-type-a-male-to-micro-type-b-male)
 
 ## About This Project
 

--- a/scripts/validation/rules/rules-trademarks.yml
+++ b/scripts/validation/rules/rules-trademarks.yml
@@ -1,11 +1,11 @@
----
+# Bluetooth® rule
 - regex: "(?:[bB]luetooth(?!®)|bluetooth)(?![-\\/]|\\.?\\S)"
   shouldMatch: false
   format: markdown
   type: warning
   errorMessage: The Bluetooth® trademark is not used correctly.
-  
 
+# LoRa® / LoRaWAN® rule
 # Avoids false positives by excluding the word in conjunction with a dash (e.g. URLs) and as part of code)
 - regex: "(?<![-\\/])([lL]o[rR]a(?:WAN| Alliance)?)(?!®)(?![-\\/]|\\.?\\S)\\b"
   shouldMatch: false
@@ -13,3 +13,11 @@
   format: markdown
   type: warning
   errorMessage: The LoRa® / LoRaWAN® trademark is not used correctly.
+
+# USB-C® / USB Type-C® / USB4® rule
+- regex: "(?:[uU][sS][bB]-[cC]|[uU][sS][bB] [tT]ype[ -cC][cC]|[uU][sS][bB][4](?!®)|usb-c)(?![-\\/]|\\.?\\S)"
+  shouldMatch: false
+  includeCodeBlocks: false
+  format: markdown
+  type: warning
+  errorMessage: The USB-C® / USB Type-C® / USB4® trademark is not used correctly.

--- a/scripts/validation/rules/rules-trademarks.yml
+++ b/scripts/validation/rules/rules-trademarks.yml
@@ -15,7 +15,8 @@
   errorMessage: The LoRa® / LoRaWAN® trademark is not used correctly.
 
 # USB-C® / USB Type-C® / USB4® rule
-- regex: "(?:[uU][sS][bB]-[cC]|[uU][sS][bB] [tT]ype[ -cC][cC]|[uU][sS][bB][4](?!®)|usb-c)(?![-\\/]|\\.?\\S)"
+- regex: "(?<!http[s]?:\\/\\/\\S*)(?:USB-C|USB Type[ -]C|USB4)(?!®)\\b"
+  regexModifiers: "gi"
   shouldMatch: false
   includeCodeBlocks: false
   format: markdown


### PR DESCRIPTION
## What This PR Changes
- Linter: New rule to highlight the USB-C typos
  - Fix USB-C trademark miss-spells