### PR TITLE
Fix Serial Plotter sketches for compatibility with all IDE versions

### DIFF
--- a/content/software/ide-v2/tutorials/ide-v2-serial-plotter/ide-v2-serial-plotter.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-plotter/ide-v2-serial-plotter.md
@@ -54,10 +54,10 @@ void setup() {
 void loop() {
   potentiometer = analogRead(A1);
 
-  Serial.print("Variable 1:");
+  Serial.print("Variable_1:");
   Serial.print(potentiometer);
   Serial.print(",");
-  Serial.print("Variable 2:");
+  Serial.print("Variable_2:");
   Serial.println(static_variable);
 }
 ```
@@ -78,10 +78,10 @@ void setup() {
 void loop() {
   random_variable = random(0, 1000);
 
-  Serial.print("Variable 1:");
+  Serial.print("Variable_1:");
   Serial.print(random_variable);
   Serial.print(",");
-  Serial.print("Variable 2:");
+  Serial.print("Variable_2:");
   Serial.println(static_variable);
 }
 ```


### PR DESCRIPTION
The sketches provided in the Arduino IDE 2.x Serial Plotter documentation used variable labels that contained spaces.

Support for spaces in labels has been intentionally dropped in order to enable fixes for critical bugs in Serial Plotter that made it incompatible with the data formats established for years by the Arduino IDE 1.x Serial Plotter. Since that Serial Plotter never supported spaces in labels, and thus the existing body of sketches did not use them in labels, it was determined an acceptable trade-off.

It may be that this enhancement will be implemented at some point in the future, but for now the example sketches in the docs must use the currently supported data format.

## What This PR Changes

Use the supported variable label format in the Serial Plotter demonstration sketches.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
