### PR TITLE
Fix typo in usb host shield article

### DIFF
--- a/content/retired/02.shields/arduino-usb-host-shield/content.md
+++ b/content/retired/02.shields/arduino-usb-host-shield/content.md
@@ -81,7 +81,7 @@ The maximum length and width of the Motor Shield PCB are 2.7 and 2.1 inches resp
 
 |                   |                                                                                               |
 | ----------------- | --------------------------------------------------------------------------------------------- |
-| Operating Voltage | 5 V                                                                                           |
+| Operating Voltage | 5V                                                                                            |
 | USB Controller    | MAX3421E                                                                                      |
 | Max Current       | 500 mA when Arduino is powered by a suitable power supply connected to the Arduino power jack |
 | Max Current       | 400 mA when Arduino is powered by its USB port                                                |


### PR DESCRIPTION
## What This PR Changes
Fixes a small typo in the usb host shield (retired) documentation

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
