### PR TITLE
Update software-serial.md

### DIFF
--- a/content/learn/07.built-in-libraries/04.software-serial/software-serial.md
+++ b/content/learn/07.built-in-libraries/04.software-serial/software-serial.md
@@ -60,8 +60,10 @@ None.
 ```arduino
 #include <SoftwareSerial.h>
 
-const byte rxPin = 2;
-const byte txPin = 3;
+// const byte rxPin = 2; // Obsolete example
+const byte rxPin = 10
+// const byte txPin = 3; // Obsolete example
+const byte txPin = 11;
 
 // Set up a new SoftwareSerial object
 SoftwareSerial mySerial (rxPin, txPin);


### PR DESCRIPTION
Under the heading "Limitations of This Library" the article correctly states:

"Not all pins on the Mega and Mega 2560 boards support change interrupts, so only the following can be used for RX: 10, 11, 12, 13, 14, 15, 50, 51, 52, 53, A8 (62), A9 (63), A10 (64), A11 (65), A12 (66), A13 (67), A14 (68), A15 (69). Not all pins on the Leonardo and Micro boards support change interrupts, so only the following can be used for RX: 8, 9, 10, 11, 14 (MISO), 15 (SCK), 16 (MOSI)."


Below this however, in the method example that shows how to create an instance of a SoftwareSerial object, the code reads thus:
```
#include <SoftwareSerial.h>

const byte rxPin = 2;
const byte txPin = 3;

// Set up a new SoftwareSerial object
SoftwareSerial mySerial (rxPin, txPin);
``` 

## What This PR Changes

I don't think pins 2 and 3 have been possible to use since the original and very different SoftwareSerial library version by Mellis from more than a decade ago.

So rxPin should be corrected to 10, and txPin to 11, in line we the rest of the examples.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
