### PR TITLE
Remove "Board Recovery" section from datasheets of boards without feature

### DIFF
--- a/content/hardware/02.hero/boards/mega-2560/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/mega-2560/datasheet/datasheet.md
@@ -129,9 +129,6 @@ Sample sketches for the Arduino® MEGA 2560 can be found either in the “Exampl
 ### Online Resources
 Now that you have gone through the basics of what you can do with the board you can explore the endless possibilities it provides by checking exciting projects on ProjectHub **[5]**, the Arduino® Library Reference **[6]** and the online store **[7]** where you will be able to complement your board with sensors, actuators and more.
 
-### Board Recovery
-All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.
-
 ## Connector Pinouts
 
 ![Arduino Mega Pinout](./assets/ArduinoMEGAPinOut.png)

--- a/content/hardware/02.hero/boards/uno-mini-le/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-mini-le/datasheet/datasheet.md
@@ -153,9 +153,6 @@ Sample sketches for the Arduino UNO Mini can be found either in the â€œExamplesâ
 ### Online Resources
 Now that you have gone through the basics of what you can do with the board you can explore the endless possibilities it provides by checking exciting projects on ProjectHub **[5]**, the Arduino Library Reference **[6]** and the online store **[7]** where you will be able to complement your board with sensors, actuators and more
 
-### Board Recovery 
-All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.
-
 <div class="breakPage"> </div>
 
 ## Connector Pinouts

--- a/content/hardware/02.hero/boards/uno-rev3/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-rev3/datasheet/datasheet.md
@@ -126,9 +126,6 @@ Sample sketches for the Arduino XXX can be found either in the “Examples” me
 ### Online Resources
 Now that you have gone through the basics of what you can do with the board you can explore the endless possibilities it provides by checking exciting projects on ProjectHub **[5]**, the Arduino Library Reference **[6]** and the online store **[7]** where you will be able to complement your board with sensors, actuators and more
 
-### Board Recovery 
-All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.
-
 ## Connector Pinouts
 ![Pinout](assets/pinout.png)
 

--- a/content/hardware/03.nano/boards/nano-every/datasheet/datasheet.md
+++ b/content/hardware/03.nano/boards/nano-every/datasheet/datasheet.md
@@ -138,9 +138,6 @@ All Arduino IoT enabled products are supported on Arduino IoT Cloud which allows
 ### Online Resources
 Now that you have gone through the basics of what you can do with the board you can explore the endless possibilities it provides by checking exciting projects on ProjectHub **[13]**, the Arduino Library Reference **[14]** and the on line store **[15]** where you will be able to complement your board with sensors, actuators and more.
 
-### Board Recovery
-All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.
-
 ## Connector Pinouts
 ![Pinout](assets/pinout.png)
     

--- a/content/hardware/03.nano/boards/nano/datasheet/datasheet.md
+++ b/content/hardware/03.nano/boards/nano/datasheet/datasheet.md
@@ -104,9 +104,6 @@ Sample sketches for the Arduino® can be found either in the “Examples” menu
 ### Online Resources
 Now that you have gone through the basics of what you can do with the board you can explore the endless possibilities it provides by checking exciting projects on ProjectHub **[5]**, the Arduino® Library Reference **[6]** and the online store **[7]** where you will be able to complement your board with sensors, actuators and more.
 
-### Board Recovery
-All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after power up.
-
 ## Connector Pinouts
 
 ![Power Tree of Arduino Nano](./assets/nano_connector_pinout.png)

--- a/content/hardware/08.kits/maker/make-your-uno-kit/datasheet/datasheet.md
+++ b/content/hardware/08.kits/maker/make-your-uno-kit/datasheet/datasheet.md
@@ -238,9 +238,6 @@ Sample sketches for the **UNO** can be found either in the “Examples” menu i
 #### Online Resources
 Now that you have gone through the basics of what you can do with the board you can explore the endless possibilities it provides by checking exciting projects on ProjectHub [4], the Arduino Library Reference [5] and the online store [6] where you will be able to complement your board with sensors, actuators and more.
 
-#### Board Recovery
-All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by double-tapping the reset button right after a power-up.
-
 ### Connector Pinouts
 ![Make Your UNO main board pinout](assets/pinout.png)
 


### PR DESCRIPTION
## What This PR Changes

Some Arduino boards have a bootloader that allows them to be recovered from a "soft bricked" state by pressing the reset button twice.

The bootloader on the boards which do not have a native USB capability don't recognize this double reset. The reason is because the "soft bricked" state is specific to the native USB boards, so boards without native USB have no need for this recovery capability.

Previously, bootloader support for double reset was claimed for several boards which do not have such a bootloader. Since these boards do not have or need any sort of "board recovery" system, the "Board Recovery" section is removed entirely from their datasheets.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
