### PR TITLE
Linter: USB-C trademark regex fix [PC-1014]

### DIFF
--- a/content/hardware/02.hero/boards/uno-mini-le/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-mini-le/datasheet/datasheet.md
@@ -115,7 +115,7 @@ The UNO Mini is a smaller version of the Arduino UNO - to celebrate a successful
 
 | Ref.  | Description                    | Ref.  | Description                           |
 | ----- | ------------------------------ | ----- | ------------------------------------- |
-| J1    | USB C Connector                | J7    | Ground                                |
+| J1    | USB C® Connector               | J7    | Ground                                |
 | J2    | 6x Connector pin (female)      | U1    | ATMEGA16U2 Module                     |
 | J3    | 8x Connector pin (female)      | U2    | ATMEGA328P Module                     |
 | J4    | 8x Connector pin (female)      | U5    | MPM3610AGQV-PIC StpDwn-CONV.21V 1.2A  |

--- a/content/hardware/02.hero/boards/uno-mini-le/tech-specs.yml
+++ b/content/hardware/02.hero/boards/uno-mini-le/tech-specs.yml
@@ -2,7 +2,7 @@ Board:
   Name: Arduino UNO Mini Limited Edition
   SKU: ABX00062
 Microcontroller: ATmega328P
-USB connector: USB-C
+USB connector: USB-C®
 Pins:
   Built-in LED Pin: 13
   Digital I/O Pins: 14

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -2,7 +2,7 @@ Board:
   Name: Arduino® Portenta H7 Lite Connected
   SKU: ABX00046
 Microcontroller: STM32H747XI dual Cortex®-M7+M4 32bit low power Arm® MCU
-USB connector: USB-C
+USB connector: USB-C®
 Pins:
   Digital I/O Pins: 22
   Analog input pins: 8

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -2,7 +2,7 @@ Board:
   Name: Arduino® Portenta H7 Lite
   SKU: ABX00045
 Microcontroller: STM32H747XI dual Cortex®-M7+M4 32bit low power Arm® MCU
-USB connector: USB-C
+USB connector: USB-C®
 Pins:
   Digital I/O Pins: 22
   Analog input pins: 8

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -2,7 +2,7 @@ Board:
   Name: Arduino® Portenta H7
   SKU: ABX00042
 Microcontroller: STM32H747XI dual Cortex®-M7+M4 32bit low power Arm® MCU
-USB connector: USB-C
+USB connector: USB-C®
 Pins:
   Digital I/O Pins: 22
   Analog input pins: 8

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/ble-connectivity/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/ble-connectivity/content.md
@@ -27,13 +27,13 @@ In this tutorial we will enable low energy Bluetooth® on the Portenta H7 to all
 
 ## Goals
 
--   Enabling Bluetooth® Low Energy connectivity on the Portenta H7.
--   Connecting the Portenta to an external Bluetooth® Low Energy Mobile Application (In this case [nRF Connect](https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Connect-for-mobile) by Nordic Semiconductor).
+- Enabling Bluetooth® Low Energy connectivity on the Portenta H7.
+- Connecting the Portenta to an external Bluetooth® Low Energy Mobile Application (In this case [nRF Connect](https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Connect-for-mobile) by Nordic Semiconductor).
 
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/portenta-h7) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.13+  or Arduino Pro IDE 0.0.4+ 
 - Mobile device, phone or tablet
 - [nRFconnect](https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Connect-for-mobile) or equivalent tool downloaded on your mobile device: [nRF Connect for iOS](https://itunes.apple.com/us/app/nrf-connect/id1054362403?ls=1&mt=8) or [nRF Connect for android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp)

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/dual-core-processing/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/dual-core-processing/content.md
@@ -32,7 +32,7 @@ The Portenta H7 is equipped with a processor that has two processing units calle
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/portenta-h7) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+ 
 
 ## Cortex® M7 & M4 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
@@ -29,7 +29,7 @@ In this tutorial you will learn how to use the Mbed OS [TDBStore API](https://os
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/products/portenta-h7),  [Portenta H7 Lite (ABX00045)](https://store.arduino.cc/products/portenta-h7-lite) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+ or Arduino Pro IDE 0.0.4+ or Arduino CLI 0.13.0+
 
 ## Instructions

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/lauterbach-debugger/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/lauterbach-debugger/content.md
@@ -26,7 +26,7 @@ This tutorial will show you how to use the Lauterbach TRACE32 GDB front-end debu
 
 ### Required Hardware and Software
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/products/portenta-h7), [Portenta H7 Lite (ABX00045)](https://store.arduino.cc/products/portenta-h7-lite) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
--  USB C cable (either USB A to USB C or USB C to USB C)
+-  USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 -  Arduino IDE 1.8.13+ or Arduino Pro IDE 0.1.0+
 -  Lauterbach TRACE32 (https://www.lauterbach.com/download_demo.html)
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
@@ -37,7 +37,7 @@ This tutorial focuses on the Arduino core which allows you to benefit from the t
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/products/portenta-h7), [Portenta H7 Lite (ABX00045)](https://store.arduino.cc/products/portenta-h7-lite) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 
 ## Portenta and The Arduino Core
 The Portenta H7 is equipped with two Arm Cortex ST processors (Cortex-M4 and Cortex-M7) which run the Mbed OS. Mbed OS is an embedded real time operating system (RTOS) designed specifically for microcontrollers to run IoT applications on low power. A real-time operating system is an operating system designed to run real-time applications that process data as it comes in, typically without buffer delays. [Here you can read more about real time operating systems](https://www.ni.com/en-us/innovations/white-papers/07/what-is-a-real-time-operating-system--rtos--.html).
@@ -54,7 +54,7 @@ In this section, we will guide you through a step-by-step process of setting up 
 ***IMPORTANT: Please make sure to update the bootloader to the most recent version to benefit from the latest improvements. Follow [these steps](updating-the-bootloader) before you proceed with the next step of this tutorial.***
 
 ### 1. The Basic Setup
-Let's begin by Plug-in your Portenta to your computer using the appropriate USB C cable. Next, open your IDE and make sure that you have the right version of the Arduino IDE downloaded on to your computer.
+Let's begin by Plug-in your Portenta to your computer using the appropriate USB-C® cable. Next, open your IDE and make sure that you have the right version of the Arduino IDE downloaded on to your computer.
 
 ![The Portenta H7 can be connected to the computer using an appropriate USB-C® cable](assets/por_ard_gs_basic_setup.svg)
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/updating-the-bootloader/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/updating-the-bootloader/content.md
@@ -28,7 +28,7 @@ This tutorial will explain what a bootloader is, why you should consider keeping
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/products/portenta-h7), [Portenta H7 Lite (ABX00045)](https://store.arduino.cc/products/portenta-h7-lite) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+
 
 ## What Is a Firmware?

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/usb-host/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/usb-host/content.md
@@ -184,7 +184,7 @@ In the image above you can see that:
 
 ### Alternative Configuration (No USB Hub Required)
 
-If you do not have a USB-C® type hub, you may complete this tutorial with a USB-C® type keyboard or with a USB A type keyboard and a USB A to C adapter. To do so, proceed as follows:
+If you do not have a USB-C® type hub, you may complete this tutorial with a USB-C® type keyboard or with a USB-A type keyboard and a USB-A to USB-C® adapter. To do so, proceed as follows:
 
 - Power the Portenta H7 through the VIN pin with 5V. (Check [pinout diagram](https://content.arduino.cc/assets/Pinout-PortentaH7_latest.pdf))
 - Connect the keyboard directly to the Portenta's USB-C® connector (use a USB-A to USB-C® adapter if your keyboard's connector is USB type A)
@@ -199,7 +199,7 @@ Once you have connected your portenta board, you should be able to toggle the LE
 If it does not work as it should, try the following:
 
 1. Reset the portenta by pressing the Reset button. ![Reset Button](assets/por_ard_usbh_reset.png)
-2. Disconnect the Portenta board from the USB Hub (USB C adapter), disconnect the power from the USB Hub, connect the Portenta to the USB Hub and then connect the power to the USB Hub.
+2. Disconnect the Portenta board from the USB Hub (USB-C® adapter), disconnect the power from the USB Hub, connect the Portenta to the USB Hub and then connect the power to the USB Hub.
 
 ## Conclusion
 
@@ -270,6 +270,6 @@ In the data received on the MKR WiFi 1010 board you should see some "Enabled" me
 If in the messages received on the MKR WiFi 1010 board you see any "Disabled" message, it means that something went wrong with the communication of the USB Hub and the Portenta board. If this happens, try:
 
 1. Reset the Portenta by pressing the reset button.
-2. Disconnect the Portenta board from the USB Hub (USB C adapter), disconnect the power from the USB Hub, connect the Portenta to the USB Hub and connect the power to the USB Hub.
+2. Disconnect the Portenta board from the USB Hub (USB-C® adapter), disconnect the power from the USB Hub, connect the Portenta to the USB Hub and connect the power to the USB Hub.
 
 If, after repeating this process several times, the connection still is not working, the USB Hub you are using may not be compatible with the Portenta board and you will need a different USB Hub to complete this tutorial.

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/wifi-access-point/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/wifi-access-point/content.md
@@ -32,7 +32,7 @@ Portenta H7 comes with an on-board Wi-Fi and a Bluetooth® Module that allows to
 ### Required Hardware and Software
 
 - [Portenta H7 (ABX00042)](https://store.arduino.cc/portenta-h7) or [Portenta H7 Lite Connected (ABX00046)](https://store.arduino.cc/products/portenta-h7-lite-connected) 
-- One USB C cable (either USB A to USB C or USB C to USB C)
+- One USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4 +
 - A smart phone
 

--- a/content/hardware/04.pro/boards/portenta-x8/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-x8/tech-specs.yml
@@ -7,7 +7,7 @@ Microprocessor:
 Microcontroller: 
   1x ARM® Cortex® -M7 core up to 480MHz (for internal use)
   1x ARM® Cortex® -M4 core up to 240MHz
-USB connector: USB-C
+USB connector: USB-C®
 Pins:
   Digital I/O Pins: 22
   Analog input pins: 8

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/uploading-sketches-m4/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/uploading-sketches-m4/content.md
@@ -23,7 +23,7 @@ In this tutorial we will go through the process of uploading sketches to the M4 
 
 ### Required Hardware and Software
 - [Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+ or Arduino-cli
 - Latest "Arduino Mbed OS Portenta Boards" Core > 3.0.1
 

--- a/content/hardware/04.pro/carriers/portenta-breakout/tutorials/getting-started/content.md
+++ b/content/hardware/04.pro/carriers/portenta-breakout/tutorials/getting-started/content.md
@@ -21,7 +21,7 @@ The Arduino Portenta Breakout is a versatile tool designed for developing, testi
 
 - [Arduino Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Arduino Portenta Breakout](https://store.arduino.cc/portenta-breakout)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Breadboard & Cables
 - Pin headers for the Portenta Breakout
 - LED & Resistor

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/datasheet/datasheet.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/datasheet/datasheet.md
@@ -27,7 +27,7 @@ Industry 4.0, prototyping, robotics, data logging
     *   Murata CMWX1ZZABZ-078 LoRa® module,  SMA connector for antenna
     *   SARA-R412M-02B (4G/Cat-M1/NBIoT), micro SIM, SMA connector for antenna
 *   **Connectors**
-    *   2x USB A female connectors
+    *   2x USB-A female connectors
     *   1x Gigabit Ethernet connector (RJ45)
     *   1x FD-Can on RJ11
     *   1x mini PCIe

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/blob-detection/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/blob-detection/content.md
@@ -25,8 +25,8 @@ In this tutorial you will use the Portenta Vision Shield to detect the presence 
 
 - [Portenta H7 board](https://store.arduino.cc/portenta-h7)
 - [Arduino Portenta Vision Shield - Ethernet](https://store.arduino.cc/products/arduino-portenta-vision-shield-ethernet)
-- USB C cable (either USB A to USB C or USB C to USB C)
-- Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4+ 
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4+
 - Portenta Bootloader Version 20+
 - OpenMV IDE 2.6.4+
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/camera-to-bitmap-sd-card/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/camera-to-bitmap-sd-card/content.md
@@ -38,7 +38,7 @@ This tutorial shows you how to capture a frame from the Portenta Vision Shield C
 ## Instructions
 
 ### 1. The Setup
-Connect the Vision Shield to your Portenta H7 as shown in the figure. The top and bottom high density connectors are connected to the corresponding ones on the underside of the H7 board. Plug in the H7 to your computer using the USB C cable.
+Connect the Vision Shield to your Portenta H7 as shown in the figure. The top and bottom high density connectors are connected to the corresponding ones on the underside of the H7 board. Plug in the H7 to your computer using the USB-C® cable.
 
 ![Connecting the Vision Shield to Portenta](assets/vs_ard_gs_attach_boards.svg)
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/connecting-to-ttn/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/connecting-to-ttn/content.md
@@ -28,7 +28,7 @@ This tutorial explains how to connect your Portenta H7 to The Things Network (TT
 - [Portenta Vision Shield - LoRa®](https://store.arduino.cc/portenta-vision-shield-lora)
 - [1x Dipole Pentaband antenna](https://store.arduino.cc/antenna) or a UFL Antenna of the H7 
 - Arduino [offline](https://www.arduino.cc/en/main/software) IDE or Arduino [Web Editor](https://create.arduino.cc/)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - An [account](https://console.cloud.thethings.network/) with The Things Network
 
 ### Updating the LoRa® Module Firmware

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/creating-basic-face-filter/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/creating-basic-face-filter/content.md
@@ -26,7 +26,7 @@ In this tutorial you will build a MicroPython application with OpenMV, to use th
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield](https://store.arduino.cc/portenta-vision-shield)
-- USB C cable (either USB A to USB C or USB C to USB C)
+- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 - Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4+ 
 - Portenta Bootloader Version 20+
 - OpenMV IDE 2.6.4+

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/getting-started-camera/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/getting-started-camera/content.md
@@ -31,7 +31,7 @@ This tutorial shows you how to capture frames from the Arduino Portenta Vision S
 Accessing the Vision Shield's camera data is done with the help of both Arduino and the Processing IDE. The Arduino sketch handles the capture of image data by the on-board camera, while the java applet created with Processing helps to visualize this data with the help of a serial connection. The following steps will run you through how to capture, package the data through the serial port and visualize the output in Processing. 
 
 ### 1. The Basic Setup
-Connect the Portenta Vision Shield to your Portenta H7 as shown in the figure. The top and bottom high density connecters are connected to the corresponding ones on the underside of the H7 board. Plug in the H7 to your computer using the USB C cable. 
+Connect the Portenta Vision Shield to your Portenta H7 as shown in the figure. The top and bottom high density connecters are connected to the corresponding ones on the underside of the H7 board. Plug in the H7 to your computer using the USB-C® cable.
 
 ![Connecting the Vision Shield to Portenta](assets/vs_ard_gs_attach_boards.svg)
 

--- a/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/datasheet/datasheet.md
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/datasheet/datasheet.md
@@ -142,7 +142,7 @@ Industry 4.0,  system integrators
 | J4       | Power supply 24V                                | J11      | Analog out      |
 | J5       | HMI - Comm protocols (RS232, RS422, RS485, CAN) | J13      | Ethernet        |
 | J6       | Digital outputs                                 | J14      | WI-FI / Bluetooth® Low Energy SMA |
-| J7       | Temperature probes                              | J15      | USB A           |
+| J7       | Temperature probes                              | J15      | USB-A           |
 | J8       | Digital programmable                            | J16      | USB micro       |
 | J9       | Analog in                                       | J17      | Grove I2C       |
 
@@ -335,7 +335,7 @@ The on board transceiver is the TJA1049T/3J, which can be SW configured for RS23
 
 ### Half Speed Micro USB 
   - Portenta half speed USB is connected to the micro USB connector. 
-  - Useful to program portenta via a micro usb cable 
+  - Useful to program portenta via a micro USB cable 
   - It can be use to power Portenta while the 24V power supply is off. 
   *ESD protection
 

--- a/content/hardware/05.pro-solutions/solutions-and-kits/wisgate-edge-lite-2/tech-specs.yml
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/wisgate-edge-lite-2/tech-specs.yml
@@ -26,7 +26,7 @@ Power:
   Input: 12V 1A (Power supply Included)
   PoE (IEEE 802.3 af): 36-57 VDC
   Consumption: 12 W (typical)
-Console: Through USB-C
+Console: Through USB-C®
 Frequencies: 
   EU868: TXP00098 
   US915: TXP00099

--- a/content/hardware/05.pro-solutions/solutions-and-kits/wisgate-edge-pro/tech-specs.yml
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/wisgate-edge-pro/tech-specs.yml
@@ -26,7 +26,7 @@ Ethernet: RJ45 (10/100 Mbps)
 Power:
   DC Input: 12V or Solar panel
   PoE (IEEE 802.3 af): 36-57 VDC
-Console: Through USB-C
+Console: Through USB-C®
 Frequencies: 
   EU868: TXP00095 
   US915: TXP00096

--- a/content/hardware/06.nicla/boards/nicla-vision/tutorials/blob-detection/content.md
+++ b/content/hardware/06.nicla/boards/nicla-vision/tutorials/blob-detection/content.md
@@ -18,7 +18,7 @@ In this tutorial you will use the Arduino® Nicla Vision to detect the presence 
 ### Required Hardware and Software
 
 - [Nicla Vision](https://store.arduino.cc/products/nicla-vision)
-- Micro USB cable (either USB A to Micro USB or USB C to Micro USB)
+- Micro USB cable (either USB-A to Micro USB or USB-C® to Micro USB)
 - OpenMV IDE 2.9.0+
 
 ## Nicla Vision and the OpenMV IDE

--- a/content/hardware/06.nicla/boards/nicla-vision/tutorials/getting-started/content.md
+++ b/content/hardware/06.nicla/boards/nicla-vision/tutorials/getting-started/content.md
@@ -28,7 +28,7 @@ The OpenMV IDE is meant to provide an Arduino like experience for simple machine
 ### Required Hardware and Software
 
 - [Nicla Vision](https://store.arduino.cc/products/nicla-vision)
-- Micro USB cable (either USB A to Micro USB or USB C to Micro USB)
+- Micro USB cable (either USB-A to Micro USB or USB-C® to Micro USB)
 - OpenMV IDE 2.6.4+
 
 ## Instructions

--- a/content/hardware/07.edu/carriers/braccio-carrier/tech-specs.yml
+++ b/content/hardware/07.edu/carriers/braccio-carrier/tech-specs.yml
@@ -14,7 +14,7 @@ Communication protocols:
   Programmable Serial ports: RS232 communication protocol
 Power:
   Supply voltage: 7.4V
-  USB-C: USB Power Delivery 3.0 (PD 3.0) compliant
+  USB-C®: USB Power Delivery 3.0 (PD 3.0) compliant
 Connectors:
   6x Motors: Adam Equipment LHA-04-TS
   2x Motors: Molex 44914-0601

--- a/content/hardware/08.kits/maker/make-your-uno-kit/features.md
+++ b/content/hardware/08.kits/maker/make-your-uno-kit/features.md
@@ -1,6 +1,6 @@
 <FeatureDescription>
 
-The Make Your UNO Kit includes all components for you to make your own UNO, such as the ATmega328P chip, a USB-C module, header rows and more. This kit also features a step-by-step 3D interactive model that will guide you through the soldering steps.
+The Make Your UNO Kit includes all components for you to make your own UNO, such as the ATmega328P chip, a USB-C® module, header rows and more. This kit also features a step-by-step 3D interactive model that will guide you through the soldering steps.
 
 </FeatureDescription>
 

--- a/content/hardware/08.kits/maker/make-your-uno-kit/tech-specs.yml
+++ b/content/hardware/08.kits/maker/make-your-uno-kit/tech-specs.yml
@@ -7,7 +7,7 @@ PCB:
 Integrated Circuits:
   ATmega328P: 1x
   LM386 (amplifier): 1x
-  USB-C Module: 1x
+  USB-C® Module: 1x
 LEDs:
   Green: 1x
   Yellow: 4x

--- a/scripts/validation/rules/rules-trademarks.yml
+++ b/scripts/validation/rules/rules-trademarks.yml
@@ -15,7 +15,7 @@
   errorMessage: The LoRa® / LoRaWAN® trademark is not used correctly.
 
 # USB-C® / USB Type-C® / USB4® rule
-- regex: "(?<!http[s]?:\\/\\/\\S*)(?:USB-C|USB Type[ -]C|USB4)(?!®)\\b"
+- regex: "(?<!http[s]?:\\/\\/\\S*)(?:USB[ -]C|USB Type[ -]C|USB4)(?!®)\\b"
   regexModifiers: "gi"
   shouldMatch: false
   includeCodeBlocks: false


### PR DESCRIPTION
## What This PR Changes
- Linter: fix USB-C® trademark regex