### PR TITLE
Add Opta WiFi RS485 support in tech specs table

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/opta/tech-specs.yml
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/opta/tech-specs.yml
@@ -19,7 +19,7 @@ Connectivity:
   Bluetooth® Low Energy: Opta WiFi
   Wi-Fi: Opta WiFi
 Communication protocols:
-  RS485: Opta RS485
+  RS485: Opta RS485 & Opta WiFi
   Programmable Serial ports: RS485
 Power:
   Input voltage: 12-24V DC


### PR DESCRIPTION
## What This PR Changes
- Included Opta WiFi for RS485 support in the tech specs table. 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
