### PR TITLE
Add GA step to copy static files

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Render Datasheets
         run: cd ${GITHUB_WORKSPACE}/scripts/datasheet-rendering;./render-datasheets.sh
 
+      - name: Copy Static Files
+        run: | 
+          mkdir -p static/resources/datasheets static/resources/schematics static/resources/pinouts
+          find ./content/hardware -type f -name "*-schematics.pdf" -exec cp {} ./static/resources/schematics/ \;
+          find ./content/hardware -type f -name "*-datasheet.pdf" -exec cp {} ./static/resources/datasheets/ \;
+          find ./content/hardware -type f -name "*-full-pinout.pdf" -exec cp {} ./static/resources/pinouts/ \;
+          find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
+
       - name: Gatsby main cache
         uses: actions/cache@v2
         id: gatsby-cache-folder

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Render Datasheets
         run: cd ${GITHUB_WORKSPACE}/scripts/datasheet-rendering;./render-datasheets.sh
 
+      - name: Copy Static Files
+        run: | 
+          mkdir -p static/resources/datasheets static/resources/schematics static/resources/pinouts
+          find ./content/hardware -type f -name "*-schematics.pdf" -exec cp {} ./static/resources/schematics/ \;
+          find ./content/hardware -type f -name "*-datasheet.pdf" -exec cp {} ./static/resources/datasheets/ \;
+          find ./content/hardware -type f -name "*-full-pinout.pdf" -exec cp {} ./static/resources/pinouts/ \;
+          find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
+
       - name: Gatsby main cache
         uses: actions/cache@v2
         id: gatsby-cache-folder


### PR DESCRIPTION
## What This PR Changes
- Adds a step to the Github action that deploys static assets like schematics, pinouts and datasheets

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
