### PR TITLE
Remove outdated info re: Serial Monitor send trigger in IDE 2.x

### DIFF
--- a/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
@@ -44,10 +44,6 @@ A major advantage with having the Serial Monitor integrated with the editor is t
 
 You will find an example with more information on how to use this feature, further down this tutorial under the **Using multiple Serial Monitors simultaneously** section.
 
-### Different Send Trigger
-
-In the Arduino IDE 1.x Serial Monitor, data can be sent to the board by entering it in the field at the top of the window and then clicking the **Send** button or pressing the <kbd>**Enter**</kbd> key. In the Arduino IDE 2.0 Serial Monitor you must instead use the <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd> keyboard shortcut (<kbd>**Command**</kbd>+<kbd>**Enter**</kbd> for macOS users).
-
 ## Using the Serial Monitor Tool
 
 The Serial Monitor tool is a really great tool for debugging and establishing communication between a computer and an Arduino. To use it is really easy, but there are some things that we need to do first.


### PR DESCRIPTION
## What This PR Changes

In previous versions of Arduino IDE 2.x, the keyboard shortcut used to trigger the sending of a message from Serial Monitor to the board was <kbd>**Ctrl**</kbd>+<kbd>**Enter**</kbd>.

Since this was different from the shortcut used by Arduino IDE 1.x, and user reports indicated this was a significant source of confusion, a note was added to the Arduino IDE 2.x Serial Monitor tutorial about the change (https://github.com/arduino/docs-content/pull/287).

The keyboard shortcut was changed to <kbd>**Enter**</kbd> (https://github.com/arduino/arduino-ide/pull/1402) in the [Arduino IDE 2.0.1 release](https://github.com/arduino/arduino-ide/releases/tag/2.0.1), making the tutorial's information about the changed shortcut obsolete. For this reason, I propose to remove the section from the tutorial.

The removed section also documented an additional change to Serial Monitor: the loss of the "Send" button, which is still the case (https://github.com/arduino/arduino-ide/issues/348). The primary purpose for adding the section was to document the keyboard shortcut change and my impression is that there is no need to mention the removal of the button now that there is an intuitive keyboard shortcut for sending the message.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
