### PR TITLE
Opta: Product Page Power Spec Update [PC-1052]

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/opta/tech-specs.yml
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/opta/tech-specs.yml
@@ -23,8 +23,8 @@ Communication protocols:
   Programmable Serial ports: RS485
 Power:
   Input voltage: 12-24V DC
-  Rated voltage: 250V AC
-  Maximum switching voltage: 400V AC
+  Output relay rated voltage: 250V AC
+  Output relay maximum switching voltage: 400V AC
 Memory:
   SDRAM: 1 MB
   Onboard flash memory: 2MB internal + 16MB Flash QSPI

--- a/content/hardware/05.pro-solutions/solutions-and-kits/opta/tech-specs.yml
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/opta/tech-specs.yml
@@ -23,7 +23,8 @@ Communication protocols:
   Programmable Serial ports: RS485
 Power:
   Input voltage: 12-24V DC
-  Output voltage: 24V
+  Rated voltage: 250V AC
+  Maximum switching voltage: 400V AC
 Memory:
   SDRAM: 1 MB
   Onboard flash memory: 2MB internal + 16MB Flash QSPI


### PR DESCRIPTION
## What This PR Changes
From the Tech Specs table:
- Output voltage: 24V line removed
- Rated voltage: 250V AC line added
- Maximum switching voltage: 400V AC added

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
