### PR TITLE
Update debugger tutorial for Arduino IDE >=2.0.3

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -78,7 +78,12 @@ Now go to the folder where the sketch is located. Add a `.json` file in the same
 }
 ```
 
-The `"serverpath"` needs to be changed to the location where you installed the J-link package in the previous step. When this is done, click on the debugging icon.
+The `"serverpath"` field needs to be set to the path of the "J-Link GDB Server CL" tool executable file that is located under the folder of the J-Link package you installed in the previous step. The file is named:
+
+- **If you are using Windows:** `JLinkGDBServerCL.exe`
+- **If you are using Linux or macOS:** `JLinkGDBServer`
+
+When you have finished creating the `debug_custom.json` file, click on the debugging icon.
 
 ![Start debug feature in Arduino IDE 2.0](assets/mkr_jlink_IDE_debugging_button.png)
 

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -67,14 +67,14 @@ Now we are ready to start debugging our sketch. Connect the power to the MKR boa
 
 Then create or open the sketch that you want to debug. If you don't already have a sketch in mind, feel free to use the example sketch found at the end of this tutorial.
 
-Now go to the folder where the sketch is located. Add a `.json` file in the same folder as your sketch and name it `debug_custom.json`. The easiest way would be to create a text file and rename it `debug_custom.json`. In the `.json` file, add the following lines: 
+Now go to the folder where the sketch is located. Add a `.json` file in the same folder as your sketch and name it `debug_custom.json`. The easiest way would be to create a text file and rename it `debug_custom.json`. In the `.json` file, add the following lines:
 
 ```arduino
 {
-      "servertype": "jlink",     
-      "device": "ATSAMD21G18",
-      "interface": "SWD",
-      "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServer"
+  "servertype": "jlink",
+  "device": "ATSAMD21G18",
+  "interface": "SWD",
+  "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServer"
 }
 ```
 

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -74,7 +74,7 @@ Now go to the folder where the sketch is located. Add a `.json` file in the same
   "servertype": "jlink",
   "device": "ATSAMD21G18",
   "interface": "SWD",
-  "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServer"
+  "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServerCL"
 }
 ```
 

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -74,7 +74,7 @@ Now go to the folder where the sketch is located. Add a `.json` file in the same
       "servertype": "jlink",     
       "device": "ATSAMD21G18",
       "interface": "SWD",
-      "serverpath": "C:/Program Files (x86)/SEGGER/JLink/JLinkGDBServer"
+      "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServer"
 }
 ```
 

--- a/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
+++ b/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
@@ -102,14 +102,14 @@ Once your program has been uploaded, we can start using the debugger.
 
 Let's begin by creating something called a **breakpoint**. Breakpoints are used to stop the program execution at a specific line (or when a specific condition is verified). We can use multiple of these in a program (the number is variable depending on the processor). 
 
-In this example, we are going to set a breakpoint for **line 33** and **line 36**. These are set by clicking to the left of the line numbering in the editor. 
+In this example, we are going to set a breakpoint for **line 33** and **line 35**. These are set by clicking to the left of the line numbering in the editor. 
 
 ![Navigating the Debugger.](assets/debugger-img03.png)
 
 We can now go through our code, step by step.
 The first (automatic) stop will be triggered by the **Debugger** itself, and it will be a standard entry-point, ignore that for now.
 
-Let's continue, by clicking on the **Play/pause** button (**Continue**). The program will now run to the first breakpoint, line 33. If we click it again, it will jump to line 36 (the lines 34 and 35 will still be executed but we won't see that). Clicking the **Play/pause** button again will continue running the program which will pause at its next breakpoint, line 33. We're in the main loop, after all.
+Let's continue, by clicking on the **Play/pause** button (**Continue**). The program will now run to the first breakpoint, line 33. If we click it again, it will jump to line 35 (line 34 will still be executed but we won't see that). Clicking the **Play/pause** button again will continue running the program which will pause at its next breakpoint, line 33. We're in the main loop, after all.
 
 ![Going between breakpoints.](assets/playpause.gif)
 

--- a/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
+++ b/content/software/ide-v2/tutorials/ide-v2-debugger/ide-v2-debugger.md
@@ -107,9 +107,9 @@ In this example, we are going to set a breakpoint for **line 33** and **line 35*
 ![Navigating the Debugger.](assets/debugger-img03.png)
 
 We can now go through our code, step by step.
-The first (automatic) stop will be triggered by the **Debugger** itself, and it will be a standard entry-point, ignore that for now.
+The debugger will automatically stop at the first breakpoint it reached.
 
-Let's continue, by clicking on the **Play/pause** button (**Continue**). The program will now run to the first breakpoint, line 33. If we click it again, it will jump to line 35 (line 34 will still be executed but we won't see that). Clicking the **Play/pause** button again will continue running the program which will pause at its next breakpoint, line 33. We're in the main loop, after all.
+Let's continue, by clicking on the **Play/pause** button (**Continue**). The program will now run to the next breakpoint (e.g., line 35). If we click it again, it will jump to line 33 (the other lines in the program sequence will still be executed but we won't see that). Clicking the **Play/pause** button again will continue running the program which will pause at its next breakpoint, line 35. We're in the main loop, after all.
 
 ![Going between breakpoints.](assets/playpause.gif)
 


### PR DESCRIPTION
## What This PR Changes

The version of the ["**Cortex-Debug**" VS Code extension](https://github.com/Marus/cortex-debug) that provides the integrated sketch debugger for Arduino IDE 2.x was updated for the Arduino IDE 2.0.3 release (https://github.com/arduino/arduino-ide/pull/1706).

This significant update caused some changes in the way the debugger works. Some of the tutorial content, which was written for the older debugger version used by Arduino IDE 2.0.2 and older is no longer correct.

Updates are provided here for that outdated content. See the individual commit messages for details.

References:

- J-Link configuration change: https://github.com/arduino/arduino-ide/pull/1706#pullrequestreview-1196489544
- "J-Link GDB Server" filenames: https://wiki.segger.com/J-Link_GDB_Server#Debugging_with_J-Link_GDB_Server

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.