### PR TITLE
Fixed wrong link in Webhook page

### DIFF
--- a/content/arduino-cloud/02.features/06.webhooks/iot-cloud-webhooks.md
+++ b/content/arduino-cloud/02.features/06.webhooks/iot-cloud-webhooks.md
@@ -53,7 +53,7 @@ The first step is to create an Applet on the IFTTT platform using the following 
 
 ![Creating an Applet](assets/creating-an-applet.gif)
 
-**1.** Go to [IFTTT website](maker.ifttt.com) and sign in.
+**1.** Go to [IFTTT website](https://maker.ifttt.com) and sign in.
 
 **2.** Click **Create** in the top right, then select **If This**.
 


### PR DESCRIPTION
Closes issue #711

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)
The Webhook page contains a wrong URL to IFTTT website.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
