### PR TITLE
Add hasSetupGuide property to PMC

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/product.md
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/product.md
@@ -1,6 +1,7 @@
 ---
 title: Portenta Machine Control
 url_shop: https://store.arduino.cc/portenta-machine-control
+hasSetupGuide: true
 core: arduino:mbed_portenta
 certifications: [REACH, RoHS, WEEE, UKCA, CE, FCC, RCM]
 ---


### PR DESCRIPTION
## What This PR Changes
- Adds the hasSetupGuide to the Portenta Machine Control which enables the SETUP GUIDE button on the product page.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
