### PR TITLE
Remove superfluous url_guide properties

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-1000-wifi/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-1000-wifi/product.md
@@ -1,7 +1,6 @@
 ---
 title: MKR 1000 WiFi
 url_shop: https://store.arduino.cc/arduino-mkr1000-wifi
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkr1000/137'
 certifications: [CE]

--- a/content/hardware/01.mkr/01.boards/mkr-fox-1200/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-fox-1200/product.md
@@ -1,6 +1,5 @@
 ---
 title: MKR FOX 1200
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/mkr-boards/mkrfox1200/142'
 certifications: [CE]

--- a/content/hardware/01.mkr/01.boards/mkr-gsm-1400/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-gsm-1400/product.md
@@ -1,6 +1,5 @@
 ---
 title: MKR GSM 1400
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrgsm1400/146'
 status: end-of-life

--- a/content/hardware/01.mkr/01.boards/mkr-nb-1500/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-nb-1500/product.md
@@ -1,7 +1,6 @@
 ---
 title: MKR NB 1500
 url_shop: https://store.arduino.cc/arduino-mkr-nb-1500
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrnb1500/156'
 certifications: [RCM, CE, UKCA]

--- a/content/hardware/01.mkr/01.boards/mkr-vidor-4000/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-vidor-4000/product.md
@@ -1,7 +1,6 @@
 ---
 title: MKR Vidor 4000
 url_shop: https://store.arduino.cc/arduino-mkr-vidor-4000
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrvidor4000/150'
 certifications: [CE]

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/product.md
@@ -1,7 +1,6 @@
 ---
 title: MKR WAN 1300
 url_shop: https://store.arduino.cc/arduino-mkr-wan-1300
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrwan1310/161'
 certifications: [CE]

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1310/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1310/product.md
@@ -1,7 +1,6 @@
 ---
 title: MKR WAN 1310
 url_shop: https://store.arduino.cc/arduino-mkr-wan-1310
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrwan1310/161'
 certifications: [FCC, REACH, CE, RoHS, IC, UKCA, WEEE, GB4943, RCM, MIC]

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/product.md
@@ -1,7 +1,6 @@
 ---
 title: MKR WiFi 1010
 url_shop: https://store.arduino.cc/arduino-mkr-wifi-1010
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 draft: true
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrwifi1010/147'

--- a/content/hardware/01.mkr/01.boards/mkr-zero/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-zero/product.md
@@ -1,7 +1,6 @@
 ---
 title: MKR Zero
 url_shop: https://store.arduino.cc/arduino-mkr-zero-i2s-bus-sd-for-sound-music-digital-audio-data
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrzero/140'
 productCode: '016'

--- a/content/hardware/02.hero/boards/uno-wifi-rev2/product.md
+++ b/content/hardware/02.hero/boards/uno-wifi-rev2/product.md
@@ -1,7 +1,6 @@
 ---
 title: UNO WiFi Rev2
 url_shop: https://store.arduino.cc/arduino-uno-wifi-rev2
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-megaavr
 core: arduino:megaavr
 certifications: [CE]
 productCode: '023'

--- a/content/hardware/02.hero/boards/zero/product.md
+++ b/content/hardware/02.hero/boards/zero/product.md
@@ -1,7 +1,6 @@
 ---
 title: Zero
 url_shop: https://store.arduino.cc/arduino-zero
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/arduino-zero/74'
 certifications: [CE]

--- a/content/hardware/03.nano/boards/nano-33-ble-sense/product.md
+++ b/content/hardware/03.nano/boards/nano-33-ble-sense/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nano 33 BLE Sense
 url_shop: https://store.arduino.cc/arduino-nano-33-ble-sense
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_nano
 core: arduino:mbed_nano
 forumCategorySlug: '/hardware/nano-family/nano-33-ble-sense/160'
 certifications: [FCC, IC, REACH, CE, RoHS, WEEE, RCM, UKCA, MIC]

--- a/content/hardware/03.nano/boards/nano-33-ble/product.md
+++ b/content/hardware/03.nano/boards/nano-33-ble/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nano 33 BLE
 url_shop: https://store.arduino.cc/arduino-nano-33-ble
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_nano
 core: arduino:mbed_nano
 forumCategorySlug: '/hardware/nano-family/nano-33-ble/159'
 certifications: [FCC, IC, REACH, CE, RoHS, WEEE, RCM, UKCA, MIC]

--- a/content/hardware/03.nano/boards/nano-33-iot/product.md
+++ b/content/hardware/03.nano/boards/nano-33-iot/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nano 33 IoT
 url_shop: https://store.arduino.cc/arduino-nano-33-iot
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-samd
 core: arduino:samd
 forumCategorySlug: '/hardware/nano-family/nano-33-iot/157'
 certifications: [REACH, RoHS, WEEE, UKCA, CE, IC, MIC, RCM, FCC]

--- a/content/hardware/03.nano/boards/nano-every/product.md
+++ b/content/hardware/03.nano/boards/nano-every/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nano Every
 url_shop: https://store.arduino.cc/products/arduino-nano-every
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-megaavr
 core: arduino:megaavr
 forumCategorySlug: '/hardware/nano-family/nano-every/158'
 certifications: [UKCA, WEEE, REACH, RoHS, CE, GB4943, RCM, UKCA, FCC]

--- a/content/hardware/03.nano/boards/nano-rp2040-connect/product.md
+++ b/content/hardware/03.nano/boards/nano-rp2040-connect/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nano RP2040 Connect
 url_shop: https://store.arduino.cc/nano-rp2040-connect
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_nano
 core: arduino:mbed_nano
 forumCategorySlug: '/hardware/nano-family/nano-rp2040-connect/165'
 certifications: [REACH, WEEE, RoHS, UKCA, RCM, CE, FCC, RCM]

--- a/content/hardware/03.nano/boards/nano/product.md
+++ b/content/hardware/03.nano/boards/nano/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nano
 url_shop: https://store.arduino.cc/arduino-nano
-url_guide: https://www.arduino.cc/en/Guide/ArduinoNano
 core: arduino:avr
 forumCategorySlug: '/hardware/nano-family/nano/166'
 productCode: '003'

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/product.md
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/product.md
@@ -1,7 +1,6 @@
 ---
 title: Portenta H7 Lite Connected
 url_shop: https://store.arduino.cc/products/portenta-h7-lite-connected
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_portenta
 core: arduino:mbed_portenta
 forumCategorySlug: '/hardware/portenta/91'
 productCode: '116'

--- a/content/hardware/04.pro/boards/portenta-h7-lite/product.md
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/product.md
@@ -1,7 +1,6 @@
 ---
 title: Portenta H7 Lite
 url_shop: https://store.arduino.cc/products/portenta-h7-lite
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_portenta
 core: arduino:mbed_portenta
 forumCategorySlug: '/hardware/portenta/91'
 productCode: '115'

--- a/content/hardware/04.pro/boards/portenta-h7/product.md
+++ b/content/hardware/04.pro/boards/portenta-h7/product.md
@@ -1,7 +1,6 @@
 ---
 title: Portenta H7
 url_shop: https://store.arduino.cc/portenta-h7
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_portenta
 core: arduino:mbed_portenta
 forumCategorySlug: '/hardware/portenta/91'
 certifications: [CE, FCC, MIC, RCM, UKCA]

--- a/content/hardware/04.pro/boards/portenta-x8/product.md
+++ b/content/hardware/04.pro/boards/portenta-x8/product.md
@@ -1,7 +1,6 @@
 ---
 title: Portenta X8
 url_shop: https://store.arduino.cc/portenta-x8
-url_guide: /tutorials/portenta-x8/user-manual
 core: arduino:mbed_portenta
 certifications: [CE]
 productCode: '125'

--- a/content/hardware/06.nicla/boards/nicla-sense-me/product.md
+++ b/content/hardware/06.nicla/boards/nicla-sense-me/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nicla Sense ME
 url_shop: https://store.arduino.cc/products/nicla-sense-me
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_nicla
 core: arduino:mbed_nicla
 certifications: [CE, FCC, UKCA, WEEE, RoHS, IC, MIC, RCM]
 productCode: '043'

--- a/content/hardware/06.nicla/boards/nicla-vision/product.md
+++ b/content/hardware/06.nicla/boards/nicla-vision/product.md
@@ -1,7 +1,6 @@
 ---
 title: Nicla Vision
 url_shop: https://store.arduino.cc/products/nicla-vision
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_nicla
 core: arduino:mbed_nicla
 certifications: [CE]
 productCode: '120'

--- a/content/hardware/10.mega/boards/due/product.md
+++ b/content/hardware/10.mega/boards/due/product.md
@@ -1,7 +1,6 @@
 ---
 title: Due
 url_shop: https://store.arduino.cc/arduino-due
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-sam
 core: arduino:sam
 forumCategorySlug: '/hardware/arduino-due/64'
 productCode: '009'


### PR DESCRIPTION
## What This PR Changes
- This PR removes all the superfluous url_guide properties in the product files. These articles are used in the setup guide but are inferred by the specified core.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
