### PR TITLE
Learn, ModBus article: Fix dissapearing bug [PC-1070]

### DIFF
--- a/content/learn/05.communication/07.modbus/modbus.md
+++ b/content/learn/05.communication/07.modbus/modbus.md
@@ -4,6 +4,8 @@ description: "Modbus is an open serial communication protocol used for transmitt
 author: "Hannes Siebeneicher"
 ---
 
+## Introduction
+
 This article contains information about the Modbus serial communication protocol and how it can be used together with Arduino hardware. The different elements are highlighted and compatible libraries and boards are shown together with code examples. The following section gives an overview of Modbus compatible Arduino boards and the libraries that you can use to enable Modbus protocol capability. Depending on the hardware you are using, the libraries might vary, therefore it is important to always check your device specifications.
 
 ### Modbus compatible hardware


### PR DESCRIPTION
## What This PR Changes
- Add heading to remove a bug that was causing the ToC not being rendered and getting the content to disappear.

# Issue
1 Known fix: The content needs to have the highest heading first, to be able to then have the same type of heading
## Examples:
### Working:
```md
# Heading 1
## Heading 2
# Heading 1A
## Heading 2A
```
### Not working (ToC not being rendered, and page going on loops):
```md
## Heading 2
# Heading 1A
## Heading 2A
```


cc @sebromero @Hannes7eicher 
