### PR TITLE
Removed compatibility with shield [PC-1079]

### DIFF
--- a/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
@@ -2,8 +2,6 @@ software:
   - arduino-ide
   - arduino-cli
 hardware:
-  shields:
-    - portenta-vision-shield
   boards:
     - portenta-breakout
   carriers:

--- a/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
@@ -2,7 +2,6 @@ software:
   - arduino-ide
   - arduino-cli
 hardware:
-  boards:
     - portenta-breakout
   carriers:
     - portenta-max-carrier

--- a/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
@@ -2,6 +2,5 @@ software:
   - arduino-ide
   - arduino-cli
 hardware:
-    - portenta-breakout
   carriers:
     - portenta-max-carrier


### PR DESCRIPTION
## What This PR Changes
- The X8 is not compatible with the Portenta Vision Shield, so I removed this from the compatibility section.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
