### PR TITLE
Adding Python Trademark

### DIFF
--- a/content/hardware/03.nano/boards/nano-33-ble-sense-rev2/features.md
+++ b/content/hardware/03.nano/boards/nano-33-ble-sense-rev2/features.md
@@ -21,9 +21,9 @@ The Arduino Nano 33 BLE Sense Rev2 is a great choice for any beginner, maker or 
   <FeatureLink title="Library" url="https://www.arduino.cc/reference/en/libraries/arduino_bmi270_bmm150/"/>
 </Feature>
 
-<Feature title="Python Support" image="python">
+<Feature title="Python® Support" image="python">
 
-  This board can be programmed with the Python programming language via the OpenMV IDE.
+  This board can be programmed with the Python® programming language via the OpenMV IDE.
 
   <FeatureLink title="Learn More" url="/learn/programming/arduino-and-python"/>
 </Feature>


### PR DESCRIPTION
## What This PR Changes
- The trademark symbol was missing inside the main feature section for the Nano BLE Sense Rev2. This PR adds it.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
