### PR TITLE
Update datasheet links for Nano BLE Sense Rev 2 IMU

### DIFF
--- a/content/hardware/03.nano/boards/nano-33-ble-sense-rev2/tutorials/imu-accelerometer/content.md
+++ b/content/hardware/03.nano/boards/nano-33-ble-sense-rev2/tutorials/imu-accelerometer/content.md
@@ -55,7 +55,7 @@ The Arduino BMI270_BMM150 library allows us to use the Arduino Nano 33 BLE Rev2 
 - **Gyroscope** Output data rate is fixed at 104 Hz.
 - **Magnetometer** Output data rate is fixed at 20 Hz.
 
-If you want to read more about the sensor modules that make up the IMU system, find the datasheet for the <a href="https://content.arduino.cc/assets/bst-bmi270-ds000.pdf" target="_blank">BMI270</a> and the <a href="https://content.arduino.cc/assets/bst-bmm150-ds001.pdf" target="_blank">BMM150</a> here.
+If you want to read more about the sensor modules that make up the IMU system, find the datasheet for the <a href="https://download.mikroe.com/documents/datasheets/bst-bmi270-ds000-2_datasheet.pdf" target="_blank">BMI270</a> and the <a href="https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bmm150-ds001.pdf" target="_blank">BMM150</a> here.
 
 
 ### Accelerometer


### PR DESCRIPTION
## What This PR Changes
- The datasheet links for BMM150 & BMI270 were incorrect and are fixed with this PR. 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
