### PR TITLE
[TC-423] Add 'or later" to MKR IoT Carrier Rev 2 DS

### DIFF
--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier-rev2/datasheet/datasheet.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier-rev2/datasheet/datasheet.md
@@ -20,7 +20,7 @@ IoT applications, MKR hobbyists
 
 ***Note: This board is passive and requires a MKR board to function.***
 
-***Requirements: This device require the library Arduino_MKRIoTCarrier version to be 2.0.0 in order to function***
+***Requirements: This device require the library Arduino_MKRIoTCarrier version to be 2.0.0 or later in order to function***
 
 * **Grove Connectors**
   * Easy interface with wide range of Grove modules and sensors


### PR DESCRIPTION
## What This PR Changes
- Add 'or later' to MKR IoT Carrier Rev 2 DS for Arduino_MKRIoTCarrier library

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
