### PR TITLE
Update link to WiFI101 library

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/mkr-1000-connect-to-wifi/mkr-1000-connect-to-wifi.md
+++ b/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/mkr-1000-connect-to-wifi/mkr-1000-connect-to-wifi.md
@@ -29,7 +29,7 @@ ___
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software)).
-- [WiFi101](https://www.arduino.cc/reference/en/libraries/rtczero/) library.
+- [WiFi101]https://www.arduino.cc/reference/en/libraries/wifi101/) library.
 - Arduino MKR 1000 WiFi ([link to store](https://store.arduino.cc/arduino-mkr1000-wifi)).
 
 ## What Is Wi-Fi?


### PR DESCRIPTION
## What This PR Changes
- Link inside the tutorial for connecting MKR 1000 to a WiFi network was pointing to the RTCZero library instead of the WiFI101 library.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
