### PR TITLE
[PC-1071] Arduino Opta: Certification inconsistencies fix

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/opta/product.md
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/opta/product.md
@@ -2,7 +2,6 @@
 title: Opta
 url_shop: https://store.arduino.cc/pages/opta
 core: arduino:mbed_portenta
-certifications: [cULus listed, ENEC, CE]
 ---
 
 The **Arduino Opta** is a secure, easy-to-use **micro PLC** with Industrial IoT capabilities. Designed in partnership with **Finder**, leading industrial and building automation device manufacturer.


### PR DESCRIPTION
## What This PR Changes
Removes the Certifications field present in product.md of Arduino Opta. 

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
