### PR TITLE
Update link to Ethernet library

### DIFF
--- a/content/hardware/01.mkr/02.shields/mkr-eth-shield/tutorials/mkr-eth-shield-webserver/mkr-eth-shield-webserver.md
+++ b/content/hardware/01.mkr/02.shields/mkr-eth-shield/tutorials/mkr-eth-shield-webserver/mkr-eth-shield-webserver.md
@@ -9,7 +9,7 @@ tags:
 author: 'Karl Söderby'
 libraries: 
   - name: Ethernet
-    url: https://www.arduino.cc/en/Reference/ArduinoMKRENV
+    url: https://www.arduino.cc/reference/en/libraries/ethernet/
 hardware:
   - hardware/01.mkr/01.boards/mkr-zero
   - hardware/01.mkr/02.shields/mkr-eth-shield


### PR DESCRIPTION
## What This PR Changes
The link inside the tutorial for MKR ETH Shield Web Server was pointing to the Arduino_MKRENV library instead of the Ethernet library.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
