### PR TITLE
Update mkr-iot-carrier-01-technical-reference.md-MKC-805

### DIFF
--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
@@ -192,9 +192,9 @@ The underlying library used to read the sensor is **[Arduino_LSM6DS3](https://ww
 
 ## RGB and Gesture Sensor
 
-![The APDS-9660 sensor on the MKR IoT Carrier](assets/mkrIotCarrier-sensor-rgb.png)
+![The APDS-9960 sensor on the MKR IoT Carrier](assets/mkrIotCarrier-sensor-rgb.png)
 
-The MKR IoT Carrier contains a Broadcom **APDS-9660 RGB and Gesture sensors**, situated under the display and marked with a bulb icon. The sensor is useful for **ambient light** and **RGB** color sensing, **proximity** sensing, and **gesture** detection.
+The MKR IoT Carrier contains a Broadcom **APDS-9960 RGB and Gesture sensors**, situated under the display and marked with a bulb icon. The sensor is useful for **ambient light** and **RGB** color sensing, **proximity** sensing, and **gesture** detection.
 
 ### Code
 


### PR DESCRIPTION
## What This PR Changes
Inside the MKR IoT Cheat Sheet the RGB and Gesture Sensor "APDS-9960" is misspelled and currently says "APDS-9660". 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
