### PR TITLE
Correction of udev rules in the Ubuntu Chapter

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
@@ -125,12 +125,12 @@ If you're having troubles getting your Portenta to work on Ubuntu you can try th
 - Make sure **modemmanager** is not installed. Otherwise remove it with `sudo apt-get remove modemmanager`
 - Add the following rules to you udev rules 
 ```cpp
-SUBSYSTEM=="usb", ATTRS{idVendor}=="2341", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1fc9", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0525", MODE="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1fc9", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0525", MODE:="0666"
 ```
 
 - Reboot your PC
 - You may use the following commands to create a new udev rule from scratch:
-`echo 'SUBSYSTEMS=="usb", ATTR{idVendor}=="2341", MODE:="0666"' > 20-portenta.rules` 
+`echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", MODE:="0666"' > 20-portenta.rules` 
 `sudo mv 20-portenta.rules /etc/udev/rules.d/`


### PR DESCRIPTION
I have troubled with this problem for 3 month. But after a step by step debug I have found a solution. 

The two steps with the text for the udev rule were both incorrect and the rule was not applied.

You can debug the udev tree with this command: `sudo udevadm info -a -p $(udevadm info -q path -n /dev/ttyACM0)` (asuming that your device is mounted as `/dev/ttyACM0`).

I am not shure if it is the only page were this suggestion is present.

## What This PR Changes
- it correct the udev rules in the chapter ***Ubuntu Issues Troubleshooting***, both steps contains errors

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
