### PR TITLE
Fix broken URLs and links

### DIFF
--- a/content/built-in-examples/02.digital/toneMelody/toneMelody.md
+++ b/content/built-in-examples/02.digital/toneMelody/toneMelody.md
@@ -54,7 +54,7 @@ The main sketch is as follows:
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/Tone
+  https://www.arduino.cc/en/Tutorial/Tone
 
 */
 

--- a/content/built-in-examples/02.digital/toneMultiple/toneMultiple.md
+++ b/content/built-in-examples/02.digital/toneMultiple/toneMultiple.md
@@ -64,7 +64,7 @@ Here's the main sketch:
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/Tone4
+  https://www.arduino.cc/en/Tutorial/Tone4
 
 */
 

--- a/content/built-in-examples/02.digital/tonePitchFollower/tonePitchFollower.md
+++ b/content/built-in-examples/02.digital/tonePitchFollower/tonePitchFollower.md
@@ -74,7 +74,7 @@ The sketch is as follows:
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/Tone2
+  https://www.arduino.cc/en/Tutorial/Tone2
 
 */
 

--- a/content/built-in-examples/03.analog/AnalogInOutSerial/AnalogInOutSerial.md
+++ b/content/built-in-examples/03.analog/AnalogInOutSerial/AnalogInOutSerial.md
@@ -79,7 +79,7 @@ The newly mapped sensor data is then output to the `analogOutPin` dimming or bri
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/AnalogInOutSerial
+  https://www.arduino.cc/en/Tutorial/AnalogInOutSerial
 
 */
 

--- a/content/built-in-examples/03.analog/AnalogWriteMega/AnalogWriteMega.md
+++ b/content/built-in-examples/03.analog/AnalogWriteMega/AnalogWriteMega.md
@@ -81,7 +81,7 @@ This loop subtracts a point from the brightness variable, dimming the LED back d
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/AnalogWriteMega
+  https://www.arduino.cc/en/Tutorial/AnalogWriteMega
 
 */
 

--- a/content/built-in-examples/03.analog/Fading/Fading.md
+++ b/content/built-in-examples/03.analog/Fading/Fading.md
@@ -64,7 +64,7 @@ In this example two loops are executed one after the other to increase and then 
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/Fading
+  https://www.arduino.cc/en/Tutorial/Fading
 
 */
 

--- a/content/built-in-examples/04.communication/Dimmer/Dimmer.md
+++ b/content/built-in-examples/04.communication/Dimmer/Dimmer.md
@@ -72,7 +72,7 @@ Connect the 220 ohm current limiting resistor to digital pin 9, with an LED in s
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/Dimmer
+  https://www.arduino.cc/en/Tutorial/Dimmer
 
 */
 

--- a/content/built-in-examples/04.communication/PhysicalPixel/PhysicalPixel.md
+++ b/content/built-in-examples/04.communication/PhysicalPixel/PhysicalPixel.md
@@ -73,7 +73,7 @@ Many Arduino boards have a built-in LED connected to pin 13; if your board has n
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/PhysicalPixel
+  https://www.arduino.cc/en/Tutorial/PhysicalPixel
 
 */
 

--- a/content/built-in-examples/04.communication/SerialCallResponse/SerialCallResponse.md
+++ b/content/built-in-examples/04.communication/SerialCallResponse/SerialCallResponse.md
@@ -84,7 +84,7 @@ Connect analog sensors to analog input pin 0 and 1 with 10K ohm resistors used a
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/SerialCallResponse
+  https://www.arduino.cc/en/Tutorial/SerialCallResponse
 
 */
 

--- a/content/built-in-examples/04.communication/VirtualColorMixer/VirtualColorMixer.md
+++ b/content/built-in-examples/04.communication/VirtualColorMixer/VirtualColorMixer.md
@@ -75,7 +75,7 @@ The sensor values are sent from the Arduino to the computer as [ASCII-encoded de
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/VirtualColorMixer
+  https://www.arduino.cc/en/Tutorial/VirtualColorMixer
 
 */
 

--- a/content/built-in-examples/05.control-structures/Arrays/Arrays.md
+++ b/content/built-in-examples/05.control-structures/Arrays/Arrays.md
@@ -76,7 +76,7 @@ Connect six LEDs, with 220 ohm resistors in series, to digital pins 2-7 on your 
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/Array
+  https://www.arduino.cc/en/Tutorial/Array
 
 */
 

--- a/content/built-in-examples/05.control-structures/SwitchCase2/SwitchCase2.md
+++ b/content/built-in-examples/05.control-structures/SwitchCase2/SwitchCase2.md
@@ -71,7 +71,7 @@ To make this sketch work, your board must be connected to your computer. In the 
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/SwitchCase2
+  https://www.arduino.cc/en/Tutorial/SwitchCase2
 
 */
 

--- a/content/built-in-examples/05.control-structures/WhileStatementConditional/WhileStatementConditional.md
+++ b/content/built-in-examples/05.control-structures/WhileStatementConditional/WhileStatementConditional.md
@@ -83,7 +83,7 @@ Connect your analog sensor (e.g. potentiometer, light sensor) on analog input 2 
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/WhileLoop
+  https://www.arduino.cc/en/Tutorial/WhileLoop
 
 */
 

--- a/content/built-in-examples/06.sensors/ADXL3xx/ADXL3xx.md
+++ b/content/built-in-examples/06.sensors/ADXL3xx/ADXL3xx.md
@@ -103,7 +103,7 @@ This solution allows the [breakout boards from Sparkfun](http://www.sparkfun.com
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/ADXL3xx
+  https://www.arduino.cc/en/Tutorial/ADXL3xx
 
 */
 

--- a/content/built-in-examples/06.sensors/Memsic2125/Memsic2125.md
+++ b/content/built-in-examples/06.sensors/Memsic2125/Memsic2125.md
@@ -73,7 +73,7 @@ Open the Serial Monitor of the Arduino Software (IDE) to see the values read fro
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/Memsic2125
+  https://www.arduino.cc/en/Tutorial/Memsic2125
 
 */
 

--- a/content/built-in-examples/08.strings/CharacterAnalysis/CharacterAnalysis.md
+++ b/content/built-in-examples/08.strings/CharacterAnalysis/CharacterAnalysis.md
@@ -86,7 +86,7 @@ Open the serial monitor window of the Arduino Software (IDE) and type in a singl
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/CharacterAnalysis
+  https://www.arduino.cc/en/Tutorial/CharacterAnalysis
 
 */
 

--- a/content/built-in-examples/08.strings/StringAdditionOperator/StringAdditionOperator.md
+++ b/content/built-in-examples/08.strings/StringAdditionOperator/StringAdditionOperator.md
@@ -110,7 +110,7 @@ Here's a working example of several different concatenation examples :
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/StringAdditionOperator
+  https://www.arduino.cc/en/Tutorial/StringAdditionOperator
 
 */
 

--- a/content/built-in-examples/08.strings/StringLength/StringLength.md
+++ b/content/built-in-examples/08.strings/StringLength/StringLength.md
@@ -38,7 +38,7 @@ There is no circuit for this example, though your board must be connected to you
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/StringLengthTrim
+  https://www.arduino.cc/en/Tutorial/StringLengthTrim
 
 */
 

--- a/content/built-in-examples/08.strings/StringLengthTrim/StringLengthTrim.md
+++ b/content/built-in-examples/08.strings/StringLengthTrim/StringLengthTrim.md
@@ -38,7 +38,7 @@ There is no circuit for this example, though your board must be connected to you
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/StringLengthTrim
+  https://www.arduino.cc/en/Tutorial/StringLengthTrim
 */
 
 void setup() {

--- a/content/built-in-examples/08.strings/StringStartsWithEndsWith/StringStartsWithEndsWith.md
+++ b/content/built-in-examples/08.strings/StringStartsWithEndsWith/StringStartsWithEndsWith.md
@@ -57,7 +57,7 @@ If you look for a position that's outside the range of the string,you'll get unp
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/StringStartsWithEndsWith
+  https://www.arduino.cc/en/Tutorial/StringStartsWithEndsWith
 */
 
 void setup() {

--- a/content/built-in-examples/09.usb/ButtonMouseControl/ButtonMouseControl.md
+++ b/content/built-in-examples/09.usb/ButtonMouseControl/ButtonMouseControl.md
@@ -74,7 +74,7 @@ Connect your board to your computer with a micro-USB cable. The buttons are conn
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/ButtonMouseControl
+  https://www.arduino.cc/en/Tutorial/ButtonMouseControl
 
 */
 

--- a/content/built-in-examples/09.usb/KeyboardLogout/KeyboardLogout.md
+++ b/content/built-in-examples/09.usb/KeyboardLogout/KeyboardLogout.md
@@ -73,7 +73,7 @@ While the sketch is running, pressing the button will connect pin 2 to ground an
 
   This example is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/KeyboardLogout
+  https://www.arduino.cc/en/Tutorial/KeyboardLogout
 
 */
 

--- a/content/built-in-examples/09.usb/KeyboardReprogram/KeyboardReprogram.md
+++ b/content/built-in-examples/09.usb/KeyboardReprogram/KeyboardReprogram.md
@@ -77,7 +77,7 @@ Connect your board to the USB port, then push the button to connect D2 with GND 
 
   This example is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/KeyboardReprogram
+  https://www.arduino.cc/en/Tutorial/KeyboardReprogram
 
 */
 

--- a/content/built-in-examples/09.usb/KeyboardSerial/KeyboardSerial.md
+++ b/content/built-in-examples/09.usb/KeyboardSerial/KeyboardSerial.md
@@ -56,7 +56,7 @@ Once programmed, open your serial monitor and send a byte. The board will reply 
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/KeyboardSerial
+  https://www.arduino.cc/en/Tutorial/KeyboardSerial
 
 */
 

--- a/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/analog-to-midi/AnalogToMidi.md
+++ b/content/hardware/01.mkr/01.boards/mkr-1000-wifi/tutorials/analog-to-midi/AnalogToMidi.md
@@ -77,7 +77,7 @@ Sends out to MIDI the event to turn off  the note of the specified pitch on the 
 
   This example code is in the public domain
 
-  http://arduino.cchttps://www.arduino.cc/en/Tutorial/AnalogToMidi
+  https://www.arduino.cc/en/Tutorial/AnalogToMidi
 
   created by Arturo Guadalupi <a.guadalupi@arduino.cc>
 

--- a/content/hardware/02.hero/boards/zero/tutorials/simple-audio-frequency-meter/simple-audio-frequency-meter.md
+++ b/content/hardware/02.hero/boards/zero/tutorials/simple-audio-frequency-meter/simple-audio-frequency-meter.md
@@ -49,7 +49,7 @@ As an alternative, you may purchase the [Electret microphone amplifier - MAX4466
 
   This example code is in the public domain
 
-  http://arduino.cchttps://www.arduino.cc/en/Tutorial/SimpleAudioFrequencyMeter
+  https://www.arduino.cc/en/Tutorial/SimpleAudioFrequencyMeter
 
   created by Arturo Guadalupi <a.guadalupi@arduino.cc>
 

--- a/content/learn/04.electronics/03.lcd-displays/lcd-displays.md
+++ b/content/learn/04.electronics/03.lcd-displays/lcd-displays.md
@@ -107,7 +107,7 @@ This example sketch prints `Hello World!` to the LCD and shows the time in secon
 
  This example code is in the public domain.
 
- http://www.arduino.cc/en/Tutorial/LiquidCrystalHelloWorld
+ https://docs.arduino.cc/learn/electronics/lcd-displays
 
 */
 
@@ -1058,7 +1058,7 @@ This potentiometer controls the `delayTime` variable.
  https://github.com/adafruit/SPI_VFD/blob/master/examples/createChar/createChar.pde
 
  This example code is in the public domain.
- http://www.arduino.cc/en/Tutorial/LiquidCrystalCustomCharacter
+ https://docs.arduino.cc/learn/electronics/lcd-displays#custom-character
 
  Also useful:
  http://icontexto.com/charactercreator/

--- a/content/learn/04.electronics/09.transistor-motor-control/09.transistor-motor-control.md
+++ b/content/learn/04.electronics/09.transistor-motor-control/09.transistor-motor-control.md
@@ -86,7 +86,7 @@ Below is the full program for controlling a DC motor with a transistor. Further 
  Created on 03 January 2013
  by Scott Fitzgerald
 
- http://www.arduino.cc/en/Tutorial/TransistorMotorControl
+ https://docs.arduino.cc/learn/electronics/transistor-motor-control
 
  This example code is in the public domain.
  */

--- a/content/library-examples/esplora-library/EsploraJoystickMouse/EsploraJoystickMouse.md
+++ b/content/library-examples/esplora-library/EsploraJoystickMouse/EsploraJoystickMouse.md
@@ -92,7 +92,7 @@ When you attach the Esplora, press Shift-Command-M in the Arduino software to op
 
  by Scott Fitzgerald
 
- http://www.arduino.ccarduino.cc/en/Reference/EsploraReadJoystickSwitch
+ http://www.arduino.cc/en/Reference/EsploraReadJoystickSwitch
 
  This example is in the public domain.
 

--- a/content/library-examples/wifi-library/WiFiRTC/WiFiRTC.md
+++ b/content/library-examples/wifi-library/WiFiRTC/WiFiRTC.md
@@ -63,7 +63,7 @@ The code is based on [Epoch](https://raw.githubusercontent.com/arduino-libraries
 
   modified 26 Sept 2018
 
-  http://arduino.cchttps://www.arduino.cc/en/Tutorial/WiFiRTC
+  https://www.arduino.cc/en/Tutorial/WiFiRTC
 
   This code is in the public domain.
 

--- a/content/library-examples/wifi-library/WiFiWebClientRepeating/WiFiWebClientRepeating.md
+++ b/content/library-examples/wifi-library/WiFiWebClientRepeating/WiFiWebClientRepeating.md
@@ -57,7 +57,7 @@ image developed using [Fritzing](http://www.fritzing.org). For more circuit exam
 
  by Federico Vanzati
 
- http://www.arduino.cc/en/Tutorial/WifiWebClientRepeating
+ https://docs.arduino.cc/library-examples/wifi-library/WiFiWebClientRepeating
 
  This code is in the public domain.
 

--- a/content/retired/06.getting-started-guides/IntelGalileoGen2/IntelGalileoGen2.md
+++ b/content/retired/06.getting-started-guides/IntelGalileoGen2/IntelGalileoGen2.md
@@ -5,7 +5,7 @@ description: 'The first steps to setting up the Intel® Galileo Gen2'
 
 **This is a retired product.**
 
-The [Intel® Galileo Gen2](http://arduino.cc/en/ArduinoCertified/IntelGalileoGen2) supports shields that operate at either 3.3v or 5v. The board is designed to be hardware and software pin-compatible with Arduino shields designed for the Uno R3. Digital pins 0 to 13 (and the adjacent AREF and GND pins), Analog inputs 0 to 5, the power header, ICSP header, and the UART port pins (0 and 1), are all in the same locations as on the Arduino Uno R3.
+The [Intel® Galileo Gen2](/retired/getting-started-guides/IntelGalileoGen2) supports shields that operate at either 3.3v or 5v. The board is designed to be hardware and software pin-compatible with Arduino shields designed for the Uno R3. Digital pins 0 to 13 (and the adjacent AREF and GND pins), Analog inputs 0 to 5, the power header, ICSP header, and the UART port pins (0 and 1), are all in the same locations as on the Arduino Uno R3.
 
 The Intel® Galileo Gen2 is programmed using the [Arduino Software (IDE)](https://arduino.cc/en/Main/Software), our Integrated Development Environment common to all our boards and running both [online](https://create.arduino.cc/editor) and offline. For more information on how to get started with the Arduino Software visit the [Getting Started page](https://arduino.cc/en/Guide/HomePage).
 

--- a/content/tutorials/communication/wifi-nina-examples/wifi-nina-examples.md
+++ b/content/tutorials/communication/wifi-nina-examples/wifi-nina-examples.md
@@ -2847,7 +2847,7 @@ WEP network passwords are hexadecimal strings known as keys. A WEP network can h
 
  by Federico Vanzati
 
- http://www.arduino.cc/en/Tutorial/WifiWebClientRepeating
+ https://docs.arduino.cc/library-examples/wifi-library/WiFiWebClientRepeating
 
  This code is in the public domain.
 

--- a/content/tutorials/generic/WiFi101ThingSpeakDataUploader/WiFi101ThingSpeakDataUploader.md
+++ b/content/tutorials/generic/WiFi101ThingSpeakDataUploader/WiFi101ThingSpeakDataUploader.md
@@ -103,7 +103,7 @@ by Helena Bisby <support@arduino.cc>
 
 This example code is in the public domain
 
-http://arduino.cchttps://www.arduino.cc/en/Tutorial/WiFi101ThingSpeakDataUploader
+https://www.arduino.cc/en/Tutorial/WiFi101ThingSpeakDataUploader
 
 */
 

--- a/content/tutorials/generic/Wifi101GoogleCalendar/Wifi101GoogleCalendar.md
+++ b/content/tutorials/generic/Wifi101GoogleCalendar/Wifi101GoogleCalendar.md
@@ -128,7 +128,7 @@ This function is used **event title** and the **event duration**  in order to un
 
   by Arturo Guadalupi <a.guadalupi@arduino.cc>
 
-  http://arduino.cchttps://www.arduino.cc/en/Tutorial/GoogleCalendarWiFi101
+  https://www.arduino.cc/en/Tutorial/GoogleCalendarWiFi101
 
   This code is in the public domain.
 

--- a/content/tutorials/generic/digital-input-pullup/digital-input-pullup.md
+++ b/content/tutorials/generic/digital-input-pullup/digital-input-pullup.md
@@ -63,7 +63,7 @@ Connect the pushbutton between pin 2 and ground, without any resistor as referen
 
   This example code is in the public domain.
 
-  http://www.arduino.cchttps://www.arduino.cc/en/Tutorial/InputPullupSerial
+  https://www.arduino.cc/en/Tutorial/InputPullupSerial
 
 */
 

--- a/content/tutorials/generic/scheduled-wifi-ssl-web-client/scheduled-wifi-ssl-web-client.md
+++ b/content/tutorials/generic/scheduled-wifi-ssl-web-client/scheduled-wifi-ssl-web-client.md
@@ -128,7 +128,7 @@ Upload the sketch below to your board:
 
   by Arturo Guadalupi <a.guadalupi@arduino.cc>
 
-  http://arduino.cc/en/Tutorial/
+  https://docs.arduino.cc/tutorials/generic/scheduled-wifi-ssl-web-client
 
   This code is in the public domain.
 

--- a/content/tutorials/generic/simple-rtc-alarm/simple-rtc-alarm.md
+++ b/content/tutorials/generic/simple-rtc-alarm/simple-rtc-alarm.md
@@ -31,7 +31,7 @@ Only your Arduino Board is needed for this example.
 
   This example code is in the public domain
 
-  http://arduino.cchttps://www.arduino.cc/en/Tutorial/SimpleRTCAlarm
+  https://www.arduino.cc/en/Tutorial/SimpleRTCAlarm
 
   created by Arturo Guadalupi <a.guadalupi@arduino.cc>
 

--- a/content/tutorials/generic/simple-rtc/simple-rtc.md
+++ b/content/tutorials/generic/simple-rtc/simple-rtc.md
@@ -29,7 +29,7 @@ Only your Arduino Board is needed for this example.
 
   This example code is in the public domain
 
-  http://arduino.cchttps://www.arduino.cc/en/Tutorial/SimpleRTC
+  https://www.arduino.cc/en/Tutorial/SimpleRTC
 
   created by Arturo Guadalupi <a.guadalupi@arduino.cc>
 

--- a/content/tutorials/generic/sleep-rtc-alarm/sleep-rtc-alarm.md
+++ b/content/tutorials/generic/sleep-rtc-alarm/sleep-rtc-alarm.md
@@ -29,7 +29,7 @@ Only your Arduino Board is needed for this example.
 
   This example code is in the public domain
 
-  http://arduino.cchttps://www.arduino.cc/en/Tutorial/SleepRTCAlarm
+  https://www.arduino.cc/en/Tutorial/SleepRTCAlarm
 
   created by Arturo Guadalupi
 


### PR DESCRIPTION
## What This PR Changes

A report was received that the URL in one of the library tutorials did not work: https://github.com/arduino-libraries/LiquidCrystal/issues/65

While I was fixing that, I did a non-comprehensive survey for other non-functional URLs and links the once I found also fixed here. They fall into two classes:

- Malformed URLs caused by a failed replace operation
- URLs for pages that have been moved without setting up a redirect

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
