### PR TITLE
[PC-1116] Adding some information to the Portenta H7 over-the-air tutorial

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -182,7 +182,6 @@ This line is in **line 87** for the **"OTA_Qspi_Flash"** sketch or in **line 88*
 
 If you are going to use the example OTA file used in this tutorial you don't need to follow the steps in this section, just execute the sketch with the default file location.
 
-<br>
 
 ***Now you have two options to choose, use QSPI or use an SD Card to storage your OTA file. You can use the left side index to jump to the option that you may need.***
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -139,7 +139,7 @@ Convert your encoded file into `.ota` format
 You can use `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name for facilitated identification of the file. After this, you will have the `.ota` file of the sketch that you will use with the OTA process. 
 
 ### Installing Python 3 on Ubuntu and the necessary modules
-If you recently installed Ubuntu maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://phoenixnap.com/kb/how-to-install-python-3-ubuntu). To do it execute the next command on Ubuntu´s terminal: 
+If you recently installed Ubuntu maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://phoenixnap.com/kb/how-to-install-python-3-ubuntu). To do it execute the next command on **Ubuntu´s terminal**: 
 
 ```cpp 
 sudo apt install python-is-python3
@@ -158,18 +158,28 @@ sudo apt install python3-pip
 //Necessary to run the script:
 pip install crccheck
 ```
-Once you have done it, you should be able to run the bin2ota.py script successfully.
+Once you have done it, you should be able to run the bin2ota.py script successfully. 
 
-Now you have to upload the .OTA file to a network reachable location, e.g. *OTA_Usage_Portenta.ino.PORTENTA_H7_M7.ota*  has been uploaded to: 
+### Uploading OTA file to the net ###
+
+Now you can upload your .OTA file to an online reachable location, e.g. *OTA_Usage_Portenta.ino.PORTENTA_H7_M7.ota*  has been uploaded to: 
 
 http://downloads.arduino.cc/ota/OTA_Usage_Portenta.ino.PORTENTA_H7_M7.ota
 
-You can change the file location on the code by modifying the next line:
+You can change the default file location on the code by modifying the next line on the ***"OTA_Qspi_Flash"** sketch or in the **"OTA_SD_Portenta"** sketch depending on which method are you going to follow:
 
 ```cpp
 static char const OTA_FILE_LOCATION[] = "Introduce here your online OTA file location";
 
 ```
+It is important to know that if your OTA file is uploaded to an HTTPS website you will need to modify the next line in the code:
+
+```cpp
+  int const ota_download = ota.download(OTA_FILE_LOCATION, true /* is_https */);
+```
+This line is in **line 87** for the **"OTA_Qspi_Flash"** sketch or in **line 88** on the **"OTA_SD_Portenta"** sketch.
+
+If you are going to use the example OTA file used in this tutorial you don't need to follow the steps in this section, just execute the sketch with the default file location.
 
 <br>
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -138,7 +138,7 @@ Convert your encoded file into `.ota` format
 
 You can use `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name for facilitated identification of the file. After this, you will have the `.ota` file of the sketch that you will use with the OTA process. 
 
-### Installing Python 3 On Ubuntu 
+### Installing Python 3 On Linux 
 
 If you recently installed Ubuntu maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://phoenixnap.com/kb/how-to-install-python-3-ubuntu) and the necessary modules. To do it execute the next command on **Ubuntu´s terminal**: 
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -139,8 +139,9 @@ Convert your encoded file into `.ota` format
 You can use `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name for facilitated identification of the file. After this, you will have the `.ota` file of the sketch that you will use with the OTA process. 
 
 ### Installing Python 3 On Linux 
+### Installing Python 3 On Linux
 
-If you recently installed Ubuntu maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://phoenixnap.com/kb/how-to-install-python-3-ubuntu) and the necessary modules. To do it execute the next command on **Ubuntu´s terminal**: 
+If you recently installed a Linux distribution, maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://www.python.org/) and the necessary modules. To do it execute the next command on your **Linux terminal**: 
 
 ```cpp 
 sudo apt install python-is-python3
@@ -148,12 +149,12 @@ sudo apt install python-is-python3
 
 You will also need to install the **crccheck** module on python by following the next instructions:
 
-1. Installing pip on python:
+Installing pip on python:
 ```cpp
-//Necessary to installpython modules:
+//Necessary to install python modules:
 sudo apt install python3-pip 
 ```
-2. Installing the crccheck necessary module on python:
+Installing the crccheck necessary module on python:
 
 ```cpp
 //Necessary to run the script:
@@ -171,7 +172,6 @@ You can change the default file location on the code by modifying the next line 
 
 ```cpp
 static char const OTA_FILE_LOCATION[] = "Introduce here your online OTA file location";
-
 ```
 It is important to know that if your OTA file is uploaded to an HTTPS website you will need to modify the next line in the code:
 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -150,7 +150,7 @@ You will also need to install the **crccheck** module on python by following the
 
 1. Installing pip on python:
 ```cpp
-//Neccesary to installpython modules:
+//Necessary to installpython modules:
 sudo apt install python3-pip 
 ```
 2. Installing the crccheck necessary module on python:

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -160,6 +160,17 @@ pip install crccheck
 ```
 Once you have done it, you should be able to run the bin2ota.py script successfully.
 
+Now you have to upload the .OTA file to a network reachable location, e.g. *OTA_Usage_Portenta.ino.PORTENTA_H7_M7.ota*  has been uploaded to: 
+
+http://downloads.arduino.cc/ota/OTA_Usage_Portenta.ino.PORTENTA_H7_M7.ota
+
+You can change the file location on the code by modifying the next line:
+
+```cpp
+static char const OTA_FILE_LOCATION[] = "Introduce here your online OTA file location";
+
+```
+
 <br>
 
 ***Now you have two options to choose, use QSPI or use an SD Card to storage your OTA file. You can use the left side index to jump to the option that you may need.***

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -140,7 +140,7 @@ You can use `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name for facilit
 
 ### Installing Python 3 On Linux
 
-If you recently installed a Linux distribution, maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://www.python.org/) and the necessary modules. To do it execute the next command on your **Linux terminal**: 
+If you are using Linux, maybe you cannot run the **bin2ota.py** script. This may be because you need to install [Python 3](https://www.python.org/) and the necessary modules. To do it execute the next command on your **Linux terminal**: 
 
 ```cpp 
 sudo apt install python-is-python3

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -138,8 +138,9 @@ Convert your encoded file into `.ota` format
 
 You can use `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name for facilitated identification of the file. After this, you will have the `.ota` file of the sketch that you will use with the OTA process. 
 
-### Installing Python 3 on Ubuntu and the necessary modules
-If you recently installed Ubuntu maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://phoenixnap.com/kb/how-to-install-python-3-ubuntu). To do it execute the next command on **Ubuntu´s terminal**: 
+### Installing Python 3 On Ubuntu 
+
+If you recently installed Ubuntu maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://phoenixnap.com/kb/how-to-install-python-3-ubuntu) and the necessary modules. To do it execute the next command on **Ubuntu´s terminal**: 
 
 ```cpp 
 sudo apt install python-is-python3

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -138,7 +138,6 @@ Convert your encoded file into `.ota` format
 
 You can use `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name for facilitated identification of the file. After this, you will have the `.ota` file of the sketch that you will use with the OTA process. 
 
-### Installing Python 3 On Linux 
 ### Installing Python 3 On Linux
 
 If you recently installed a Linux distribution, maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://www.python.org/) and the necessary modules. To do it execute the next command on your **Linux terminal**: 

--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/over-the-air-update/content.md
@@ -138,6 +138,30 @@ Convert your encoded file into `.ota` format
 
 You can use `OTA_Usage_Portenta.ino.PORTENTA_H7_M7` as a sketch name for facilitated identification of the file. After this, you will have the `.ota` file of the sketch that you will use with the OTA process. 
 
+### Installing Python 3 on Ubuntu and the necessary modules
+If you recently installed Ubuntu maybe you can't run the **bin2ota.py** script. This may be because you need to install [Python 3](https://phoenixnap.com/kb/how-to-install-python-3-ubuntu). To do it execute the next command on Ubuntu´s terminal: 
+
+```cpp 
+sudo apt install python-is-python3
+``````
+
+You will also need to install the **crccheck** module on python by following the next instructions:
+
+1. Installing pip on python:
+```cpp
+//Neccesary to installpython modules:
+sudo apt install python3-pip 
+```
+2. Installing the crccheck necessary module on python:
+
+```cpp
+//Necessary to run the script:
+pip install crccheck
+```
+Once you have done it, you should be able to run the bin2ota.py script successfully.
+
+<br>
+
 ***Now you have two options to choose, use QSPI or use an SD Card to storage your OTA file. You can use the left side index to jump to the option that you may need.***
 
 ### QSPI Storage Mode


### PR DESCRIPTION
-Adding some information about how to install Python 3 on Linux and the necessary libraries (Like pip and crccheck) to make the bin2ota.py script work properly.

-Explaining how to upload an OTA file to the Net and make it work if it is on an HTTPS website.