### PR TITLE
Header in the wrong place

### DIFF
--- a/content/learn/05.communication/01.wire/wire.md
+++ b/content/learn/05.communication/01.wire/wire.md
@@ -216,9 +216,6 @@ Attach the SDA pin of your SRFxx to analog pin 4 of your board, and the SCL pin 
 
 ***If using two SRFxxs on the same line, you must ensure that they do not share the same address. Instructions for re-addressing the range finders can be found at the bottom of the code below.***
 
-## Example 2: Digital Potentiometer
-
-
 ```arduino
 // I2C SRF10 or SRF08 Devantech Ultrasonic Ranger Finder
 // by Nicholas Zambetti <http://www.zambetti.com>
@@ -341,6 +338,8 @@ void changeAddress(byte oldAddress, byte newAddress)
 
 */
 ```
+
+## Example 2: Digital Potentiometer
 
 ### Hardware Required
 


### PR DESCRIPTION
Code section is under the wrong header. Should be for the previous example

## What This PR Changes
- Move the "Example 2" header below the code section for the previous example (Example 1).

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
