### PR TITLE
Update content.md

### DIFF
--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/image-building/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/image-building/content.md
@@ -53,7 +53,7 @@ First, clone the lmp-manifest repository with this command:
 Then build the Docker Image using:
   ```
   cd lmp-manifest
-  docker build -t yocto-build ./lmp-manifest
+  docker build -t yocto-build .
   ```
   ![Building a Docker Image](assets/docker_build.png)
 


### PR DESCRIPTION
line 56 -- suggest deletion of recursive reference to directory 'lmp-manifest'.  Can be fixed as suggested with this revision by replacing './lmp-manifest' with '.' in line 56, or alternately by removing line 55 ('cd lmp-manifest').

## What This PR Changes
- fixes error caused by referring to a directory the user has already cd'd into
- 
## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
