### PR TITLE
[AE-13] Correct 'edit this page' redirect for Nicla Dashboard tutorial

### DIFF
--- a/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/web-ble-dashboard/content.md
+++ b/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/web-ble-dashboard/content.md
@@ -14,7 +14,7 @@ libraries:
   - name: Arduino BLE
     url: https://www.github.com/Arduino-libraries/ArduinoBLE
 hardware:
-  - hardware/05.nicla/boards/nicla-sense-me
+  - hardware/06.nicla/boards/nicla-sense-me
 software:
   - ide-v1
   - ide-v2


### PR DESCRIPTION
## What This PR Changes
- When you click on the 'Edit this page' button, user is redirected to the wrong location. The Nicla folder was changed from '05.nicla` to `06.nicla` but this is not reflected in `content.md` metadata.
- 
![bild](https://user-images.githubusercontent.com/75624145/223200472-3a965836-3e34-4852-a739-43c1e813fc29.png)


## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
