### PR TITLE
Update GIGA Dimensions

### DIFF
--- a/content/hardware/09.mega/boards/giga-r1-wifi/tech-specs.yml
+++ b/content/hardware/09.mega/boards/giga-r1-wifi/tech-specs.yml
@@ -30,5 +30,5 @@ Clock speed:
 Memory:
   STM32H747XI: 2MB Flash, 1MB RAM
 Dimensions:
-  Width: 25 mm
-  Length: 66 mm
+  Width: 53.3 mm
+  Length: 101.5 mm


### PR DESCRIPTION
Dimensions for the GIGA R1 WiFi board was wrong, updated to W: 53.3 mm, L: 101.5 mm

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
