### PR TITLE
Bauds per second to baud rate

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/tutorials/modbus-setup/content.md
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/tutorials/modbus-setup/content.md
@@ -61,7 +61,7 @@ Then you can attach some functions to the Generic Modbus item, they will appear 
 
 #### Baud Rate
 
-Bauds per second of the clock, options:
+Baud rate, options:
   * 600
   * 1200
   * 2400


### PR DESCRIPTION
## What This PR Changes
Baud is a unit for symbol rate, which means that time is already taken into account (symbols per second). So “bauds per second” sounds like a unit of symbol rate acceleration, which is incorrect.

## Contribution Guidelines
I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
