### PR TITLE
Capitalize Ethernet

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/tutorials/modbus-setup/content.md
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/tutorials/modbus-setup/content.md
@@ -99,7 +99,7 @@ Once you have configured your device as a **Modbus Master** you can attach some 
 
 ### Modbus TCP Configuration
 
-***Important: Once you use the Modbus Mode, the ethernet port will be only dedicated to Modbus, so the ethernet protocol is not accessible while using Modbus***
+***Important: Once you use the Modbus Mode, the Ethernet port will be only dedicated to Modbus, so the Ethernet protocol is not accessible while using Modbus***
 
 Inside the Arduino PLC IDE navigate to the left side panel and click on the "Resources" tab.
 


### PR DESCRIPTION
## What This PR Changes
Ethernet isn't capitalized in two places.

## Contribution Guidelines
I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
