### PR TITLE
Fixed quaternion syntax example error

### DIFF
--- a/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/getting-started/getting-started.md
+++ b/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/getting-started/getting-started.md
@@ -163,7 +163,7 @@ The **Arduino_BHY2** library contains these sensors:
     BHY2.update();
     
     Serial.print("quaternion w :");
-    Serial.println(orientation.w());
+    Serial.println(quaternion.w());
     delay(500);
   }
 ```


### PR DESCRIPTION
There’s a syntax example that shows how to print the quaternion rotation scalar, but it mistakenly uses the orientation object instead of the quaternion object.

[x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
