### PR TITLE
[PC-656] Mention PF1550 in Portenta H7 features

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7/features.md
+++ b/content/hardware/04.pro/boards/portenta-h7/features.md
@@ -27,6 +27,13 @@ The **Portenta H7** simultaneously runs high level code along with real time tas
   <FeatureLink title="Datasheet" url="https://content.arduino.cc/assets/Arduino-Portenta-H7_Datasheet_Murata-1dx.pdf" download blank/>
 </Feature>
 
+<Feature title="PF1550 Power Management IC" image="power">
+
+  High efficiency PMIC chip with programmable voltage regulation and battery charging.
+
+  <FeatureLink title="Library" url="https://github.com/arduino-libraries/Arduino_PF1550" download blank/>
+</Feature>
+
 <Feature title="Chrom-ART graphical hardware Accelerator™" image="mcu">
 
   Probably one of the most exciting features of the Portenta H7 is the possibility of connecting an external monitor to build your own dedicated embedded computer with a user interface. This is possible thanks to the STM32H747 processor's on-chip GPU, the Chrom-ART Accelerator™. Besides the GPU, the chip includes a dedicated JPEG encoder and decoder.


### PR DESCRIPTION
## What This PR Changes
- The PF1550 is a two in one voltage regulator and battery charging IC.
- Also, it can be configured via the https://github.com/arduino-libraries/Arduino_PF1550 library
- Added this in the features section so customers can more easily see this unique feature

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
