### PR TITLE
[PC-1178] Portenta H7 Family Tech Specs Update

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -5,7 +5,7 @@ Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 
 USB connector: USB-C®
 High-Density pins:
   Digital I/O pins: 78
-  Analog pins: 10
+  Analog input pins: 8
   PWM pins: 10
   SPI pins: 4 
   I2C pins: 6
@@ -15,7 +15,7 @@ High-Density pins:
   USB: 6
 MKR-styled pins:
   Digital I/O pins: 22
-  Analog pins: 8
+  Analog input pins: 7
   PWM pins: 7
   SPI pins: 4
   I2C pins: 2
@@ -28,11 +28,11 @@ Ethernet connectivity:
   Chipset: LAN8742AI
   Interface and rates: RMII 10/100 Mbps
 Secure element: Microchip® ATECC608
-Analog-to-digital converter:
+Analog-to-digital converter (ADC):
   Channels: 8
   Resolution: 16 bits
-Digital-to-analog converter:
-  Channels: 2 (only one accessible through A6 pin)
+Digital-to-analog converter (DAC):
+  Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication:
   I2C: 3
@@ -41,7 +41,7 @@ Communication:
   I2S: 1
   SPI: 1
   PWM: 10
-  USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
+  USB: USB 1.0/Full-Speed (x1) USB 2.0/Hi-Speed (x1)
 Power:
   Board operating voltage: 3.3 V
   Board input voltage (VIN): 5 V

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -12,7 +12,7 @@ High-Density pins:
   UART pins: 16
   CAN pins: 4
   I2S pins: 4
-  USB: 2
+  USB: 6
 MKR-styled pins:
   Digital I/O pins: 22
   Analog pins: 8

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -41,7 +41,7 @@ Communication:
   I2S: 1
   SPI: 1
   PWM: 10
-  USB: USB 1.0/Full-Speed (x1) USB 2.0/Hi-Speed (x1)
+  USB: USB 1.0/Full-Speed (x1), USB 2.0/Hi-Speed (x1)
 Power:
   Board operating voltage: 3.3 V
   Board input voltage (VIN): 5 V

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -1,27 +1,56 @@
 Board:
-  Name: Arduino® Portenta H7 Lite Connected
+  Name: Arduino® Portenta H7 Connected
   SKU: ABX00046
-Microcontroller: STM32H747XI dual Cortex®-M7+M4 32bit low power Arm® MCU
+Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 and Cortex®-M4
 USB connector: USB-C®
-Pins:
-  Digital I/O Pins: 22
-  Analog input pins: 8
+High-Density pins:
+  Digital I/O pins: 78
+  Analog pins: 10
   PWM pins: 10
-Connectivity: Murata Type 1DX shielded ultra small Wi-Fi® 11b/g/n + Bluetooth® 5.1 module
-Secure element: ATECC608
+  SPI pins: 4 
+  I2C pins: 6
+  UART pins: 16
+  CAN pins: 4
+  I2S pins: 4
+  USB: 2
+MKR-styled pins:
+  Digital I/O pins: 22
+  Analog pins: 8
+  PWM pins: 7
+  SPI pins: 4
+  I2C pins: 2
+  UART pins: 2
+Wireless connectivity:
+  Chipset: Murata® LBEE5KL1DX
+  Wi-Fi®: 2.4 GHz 802.11 b/g/n
+  Bluetooth®: Bluetooth® 4.1
+Ethernet connectivity:
+  Chipset: LAN8742AI
+  Interface and rates: RMII 10/100 Mbps
+Secure element: Microchip® ATECC608
+Analog-to-digital converter:
+  Channels: 8
+  Resolution: 16 bits
+Digital-to-analog converter:
+  Channels: 1
+  Resolution: 12 bits 
 Communication:
-  UART: Yes
-  I2C: Yes
-  SPI: Yes
+  I2C: 3
+  UART: 4
+  CAN: 2
+  I2S: 1
+  SPI: 2
+  PWM: 10
+  USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
 Power:
-  Circuit operating voltage: 3.3V
-  Input voltage (VIN): 5V
-  DC Current per I/O Pin: 8 mA
+  Board operating voltage: 3.3 V
+  Board input voltage (VIN): 5 V
 Clock speed:
-  Main core: 480 MHz
-  Second core: 240 MHz
+  M4 core: 240 MHz
+  M7 core: 480 MHz
 Memory:
-  ST STM32H747XI: 2MB Flash, 1MB RAM
+  Internal: 2 MB Flash, 1 MB RAM
+  External: 16 MB NOR Flash, 8 MB SDRAM
 Dimensions:
-  Width: 25 mm
-  Length: 66 mm
+  Width: 25.40 mm
+  Length: 66.04 mm

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -34,7 +34,7 @@ Analog-to-digital converter (ADC):
 Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
-Communication:
+Communication Interfaces:
   I2C: 3
   UART: 4
   CAN: 2

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -51,6 +51,7 @@ Clock speed:
 Memory:
   Internal: 2 MB Flash, 1 MB RAM
   External: 16 MB NOR Flash, 8 MB SDRAM
+Hardware debugging interface: JTAG/SWD
 Dimensions:
   Width: 25.40 mm
   Length: 66.04 mm

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -1,5 +1,5 @@
 Board:
-  Name: Arduino® Portenta H7 Connected
+  Name: Arduino® Portenta H7 Lite Connected
   SKU: ABX00046
 Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 and Cortex®-M4
 USB connector: USB-C®

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -32,14 +32,14 @@ Analog-to-digital converter:
   Channels: 8
   Resolution: 16 bits
 Digital-to-analog converter:
-  Channels: 1
+  Channels: 2 (only one accessible through A6 pin)
   Resolution: 12 bits 
 Communication:
   I2C: 3
   UART: 4
   CAN: 2
   I2S: 1
-  SPI: 2
+  SPI: 1
   PWM: 10
   USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
 Power:

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -12,7 +12,7 @@ High-Density pins:
   UART pins: 16
   CAN pins: 4
   I2S pins: 4
-  USB: 2
+  USB: 6
 MKR-styled pins:
   Digital I/O pins: 22
   Analog pins: 8

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -5,7 +5,7 @@ Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 
 USB connector: USB-C®
 High-Density pins:
   Digital I/O pins: 78
-  Analog pins: 10
+  Analog input pins: 8
   PWM pins: 10
   SPI pins: 4 
   I2C pins: 6
@@ -13,9 +13,10 @@ High-Density pins:
   CAN pins: 4
   I2S pins: 4
   USB: 6
+  JTAG/SWD: 4
 MKR-styled pins:
   Digital I/O pins: 22
-  Analog pins: 8
+  Analog input pins: 7
   PWM pins: 7
   SPI pins: 4
   I2C pins: 2
@@ -23,11 +24,11 @@ MKR-styled pins:
 Ethernet connectivity:
   Chipset: LAN8742AI
   Interface and rates: RMII 10/100 Mbps
-Analog-to-digital converter:
+Analog-to-digital converter (ADC):
   Channels: 8
   Resolution: 16 bits
-Digital-to-analog converter:
-  Channels: 2 (only one accessible through A6 pin)
+Digital-to-analog converter (DAC):
+  Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication:
   I2C: 3
@@ -36,7 +37,7 @@ Communication:
   I2S: 1
   SPI: 1
   PWM: 10
-  USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
+  USB: USB 1.0/Full-Speed (x1) USB 2.0/Hi-Speed (x1)
 Power:
   Board operating voltage: 3.3 V
   Board input voltage (VIN): 5 V

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -1,26 +1,51 @@
 Board:
   Name: Arduino® Portenta H7 Lite
   SKU: ABX00045
-Microcontroller: STM32H747XI dual Cortex®-M7+M4 32bit low power Arm® MCU
+Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 and Cortex®-M4
 USB connector: USB-C®
-Pins:
-  Digital I/O Pins: 22
-  Analog input pins: 8
+High-Density pins:
+  Digital I/O pins: 78
+  Analog pins: 10
   PWM pins: 10
-Secure element: ATECC608
+  SPI pins: 4 
+  I2C pins: 6
+  UART pins: 16
+  CAN pins: 4
+  I2S pins: 4
+  USB: 2
+MKR-styled pins:
+  Digital I/O pins: 22
+  Analog pins: 8
+  PWM pins: 7
+  SPI pins: 4
+  I2C pins: 2
+  UART pins: 2
+Ethernet connectivity:
+  Chipset: LAN8742AI
+  Interface and rates: RMII 10/100 Mbps
+Analog-to-digital converter:
+  Channels: 8
+  Resolution: 16 bits
+Digital-to-analog converter:
+  Channels: 1
+  Resolution: 12 bits 
 Communication:
-  UART: Yes
-  I2C: Yes
-  SPI: Yes
+  I2C: 3
+  UART: 4
+  CAN: 2
+  I2S: 1
+  SPI: 2
+  PWM: 10
+  USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
 Power:
-  Circuit operating voltage: 3.3V
-  Input voltage (VIN): 5V
-  DC Current per I/O Pin: 8 mA
+  Board operating voltage: 3.3 V
+  Board input voltage (VIN): 5 V
 Clock speed:
-  Main core: 480 MHz
-  Second core: 240 MHz
+  M4 core: 240 MHz
+  M7 core: 480 MHz
 Memory:
-  ST STM32H747XI: 2MB Flash, 1MB RAM
+  Internal: 2 MB Flash, 1 MB RAM
+  External: 16 MB NOR Flash, 8 MB SDRAM
 Dimensions:
-  Width: 25 mm
-  Length: 66 mm
+  Width: 25.40 mm
+  Length: 66.04 mm

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -37,7 +37,7 @@ Communication:
   I2S: 1
   SPI: 1
   PWM: 10
-  USB: USB 1.0/Full-Speed (x1) USB 2.0/Hi-Speed (x1)
+  USB: USB 1.0/Full-Speed (x1), USB 2.0/Hi-Speed (x1)
 Power:
   Board operating voltage: 3.3 V
   Board input voltage (VIN): 5 V

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -46,6 +46,7 @@ Clock speed:
 Memory:
   Internal: 2 MB Flash, 1 MB RAM
   External: 16 MB NOR Flash, 8 MB SDRAM
+Hardware debugging interface: JTAG/SWD
 Dimensions:
   Width: 25.40 mm
   Length: 66.04 mm

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -27,14 +27,14 @@ Analog-to-digital converter:
   Channels: 8
   Resolution: 16 bits
 Digital-to-analog converter:
-  Channels: 1
+  Channels: 2 (only one accessible through A6 pin)
   Resolution: 12 bits 
 Communication:
   I2C: 3
   UART: 4
   CAN: 2
   I2S: 1
-  SPI: 2
+  SPI: 1
   PWM: 10
   USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
 Power:

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -30,7 +30,7 @@ Analog-to-digital converter (ADC):
 Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
-Communication:
+Communication Interfaces:
   I2C: 3
   UART: 4
   CAN: 2

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -12,7 +12,7 @@ High-Density pins:
   UART pins: 16
   CAN pins: 4
   I2S pins: 4
-  USB: 2
+  USB: 6
 MKR-styled pins:
   Digital I/O pins: 22
   Analog pins: 8

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -5,7 +5,7 @@ Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 
 USB connector: USB-C®
 High-Density pins:
   Digital I/O pins: 78
-  Analog pins: 10
+  Analog input pins: 8
   PWM pins: 10
   SPI pins: 4 
   I2C pins: 6
@@ -16,7 +16,7 @@ High-Density pins:
   JTAG/SWD: 4
 MKR-styled pins:
   Digital I/O pins: 22
-  Analog pins: 8
+  Analog input pins: 7
   PWM pins: 7
   SPI pins: 4
   I2C pins: 2
@@ -29,11 +29,11 @@ Ethernet connectivity:
   Chipset: LAN8742AI
   Interface and rates: RMII 10/100 Mbps
 Secure element: NXP® SE050C2 and Microchip® ATECC608
-Analog-to-digital converter:
+Analog-to-digital converter (ADC):
   Channels: 8
   Resolution: 16 bits
-Digital-to-analog converter:
-  Channels: 2 (only one accessible through A6 pin)
+Digital-to-analog converter (DAC):
+  Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication:
   I2C: 3
@@ -42,7 +42,7 @@ Communication:
   I2S: 1
   SPI: 1
   PWM: 10
-  USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
+  USB: USB 1.0/Full-Speed (x1) USB 2.0/Hi-Speed (x1)
 Power:
   Board operating voltage: 3.3 V
   Board input voltage (VIN): 5 V

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -52,7 +52,7 @@ Clock speed:
 Memory:
   Internal: 2 MB Flash, 1 MB RAM
   External: 16 MB NOR Flash, 8 MB SDRAM
-HD transmitter: Analogix® ANX7625
+High-Definition transmitter: Analogix® ANX7625
 Hardware debugging interface: JTAG/SWD
 Dimensions:
   Width: 25.40 mm

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -31,7 +31,7 @@ Wireless connectivity:
 Ethernet connectivity:
   Chipset: LAN8742AI
   Interface and rates: RMII 10/100 Mbps
-Secure element: NXP® SE050C2 and Micochip® ATECC608
+Secure element: NXP® SE050C2 and Microchip® ATECC608
 Communication:
   I2C: 3
   UART: 4
@@ -48,7 +48,7 @@ Clock speed:
   M7 core: 480 MHz
 Memory:
   Internal: 2 MB Flash, 1 MB RAM
-  External: 16 MB (QSPI Flash)
+  External: 16 MB NOR Flash, 8 MB SDRAM
 Dimensions:
   Width: 25.40 mm
   Length: 66.04 mm

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -35,7 +35,7 @@ Analog-to-digital converter (ADC):
 Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
-Communication:
+Communication Interfaces:
   I2C: 3
   UART: 4
   CAN: 2

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -13,6 +13,7 @@ High-Density pins:
   CAN pins: 4
   I2S pins: 4
   USB: 6
+  JTAG/SWD: 4
 MKR-styled pins:
   Digital I/O pins: 22
   Analog pins: 8
@@ -51,6 +52,8 @@ Clock speed:
 Memory:
   Internal: 2 MB Flash, 1 MB RAM
   External: 16 MB NOR Flash, 8 MB SDRAM
+HD transmitter: Analogix® ANX7625
+Hardware debugging interface: JTAG/SWD
 Dimensions:
   Width: 25.40 mm
   Length: 66.04 mm

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -33,14 +33,14 @@ Analog-to-digital converter:
   Channels: 8
   Resolution: 16 bits
 Digital-to-analog converter:
-  Channels: 1
+  Channels: 2 (only one accessible through A6 pin)
   Resolution: 12 bits 
 Communication:
   I2C: 3
   UART: 4
   CAN: 2
   I2S: 1
-  SPI: 2
+  SPI: 1
   PWM: 10
   USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
 Power:

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -5,11 +5,9 @@ Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 
 USB connector: USB-C®
 High-Density pins:
   Digital I/O pins: 78
-  Analog input pins: 8
-  ADC resolution: 16 bits
-  DAC resolution: 12 bits
+  Analog pins: 10
   PWM pins: 10
-  SPI pins: 8 
+  SPI pins: 4 
   I2C pins: 6
   UART pins: 16
   CAN pins: 4
@@ -17,9 +15,7 @@ High-Density pins:
   USB: 2
 MKR-styled pins:
   Digital I/O pins: 22
-  Analog input pins: 7
-  ADC resolution: 16 bits
-  DAC resolution: 12 bits
+  Analog pins: 8
   PWM pins: 7
   SPI pins: 4
   I2C pins: 2
@@ -32,6 +28,12 @@ Ethernet connectivity:
   Chipset: LAN8742AI
   Interface and rates: RMII 10/100 Mbps
 Secure element: NXP® SE050C2 and Microchip® ATECC608
+Analog-to-digital converter:
+  Channels: 8
+  Resolution: 16 bits
+Digital-to-analog converter:
+  Channels: 1
+  Resolution: 12 bits 
 Communication:
   I2C: 3
   UART: 4

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -1,27 +1,54 @@
 Board:
   Name: Arduino® Portenta H7
   SKU: ABX00042
-Microcontroller: STM32H747XI dual Cortex®-M7+M4 32bit low power Arm® MCU
+Microcontroller: STMicroelectronics® STM32H747XI Dual 32-bit Arm® Cortex®-M7 and Cortex®-M4
 USB connector: USB-C®
-Pins:
-  Digital I/O Pins: 22
+High-Density pins:
+  Digital I/O pins: 78
   Analog input pins: 8
+  ADC resolution: 16 bits
+  DAC resolution: 12 bits
   PWM pins: 10
-Connectivity: Murata Type 1DX shielded ultra small Wi-Fi® 11b/g/n + Bluetooth® 5.1 module
-Secure element: NXP SE050C2 and ATECC608
+  SPI pins: 8 
+  I2C pins: 6
+  UART pins: 16
+  CAN pins: 4
+  I2S pins: 4
+  USB: 2
+MKR-styled pins:
+  Digital I/O pins: 22
+  Analog input pins: 7
+  ADC resolution: 16 bits
+  DAC resolution: 12 bits
+  PWM pins: 7
+  SPI pins: 4
+  I2C pins: 2
+  UART pins: 2
+Wireless connectivity:
+  Chipset: Murata® LBEE5KL1DX
+  Wi-Fi®: 2.4 GHz 802.11 b/g/n
+  Bluetooth®: Bluetooth® 4.1
+Ethernet connectivity:
+  Chipset: LAN8742AI
+  Interface and rates: RMII 10/100 Mbps
+Secure element: NXP® SE050C2 and Micochip® ATECC608
 Communication:
-  UART: Yes
-  I2C: Yes
-  SPI: Yes
+  I2C: 3
+  UART: 4
+  CAN: 2
+  I2S: 1
+  SPI: 2
+  PWM: 10
+  USB: USB 1.0/Full-Speed (x1) and USB 2.0/Hi-Speed (x1)
 Power:
-  Circuit operating voltage: 3.3V
-  Input voltage (VIN): 5V
-  DC Current per I/O Pin: 8 mA
+  Board operating voltage: 3.3 V
+  Board input voltage (VIN): 5 V
 Clock speed:
-  Main core: 480 MHz
-  Second core: 240 MHz
+  M4 core: 240 MHz
+  M7 core: 480 MHz
 Memory:
-  ST STM32H747XI: 2MB Flash, 1MB RAM
+  Internal: 2 MB Flash, 1 MB RAM
+  External: 16 MB (QSPI Flash)
 Dimensions:
-  Width: 25 mm
-  Length: 66 mm
+  Width: 25.40 mm
+  Length: 66.04 mm

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -42,7 +42,7 @@ Communication:
   I2S: 1
   SPI: 1
   PWM: 10
-  USB: USB 1.0/Full-Speed (x1) USB 2.0/Hi-Speed (x1)
+  USB: USB 1.0/Full-Speed (x1), USB 2.0/Hi-Speed (x1)
 Power:
   Board operating voltage: 3.3 V
   Board input voltage (VIN): 5 V


### PR DESCRIPTION
## What This PR Changes
- This PR changes the tech specs tables of the Portenta H7 family boards, standardizing them with the Portenta C33 board. 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
