### PR TITLE
[PC-1069] Portenta C33 - Fixing Datasheet 

### DIFF
--- a/content/hardware/04.pro/boards/portenta-c33/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-c33/datasheets/datasheet.md
@@ -384,6 +384,8 @@ castellated/through-hole pins around the two long edges and two High-Density con
 The Portenta C33 is designed to be usable as a surface-mount module as well as presenting a dual inline package (DIP) format with the MKR-styled connectors on a 2.54 mm pitch grid with 1 mm holes. The Portenta C33 also has four 1.12 mm drilled mounting holes to provide for mechanical fixing.
 </p>
 
+<div style="page-break-after: always;"></div>
+
 ### Board Dimensions
 
 Portenta C33 board main dimensions can be seen in Figure 2.
@@ -436,6 +438,8 @@ Arduino boards are in compliance with RoHS 2 Directive 2011/65/EU of the Europea
 | Benzyl butyl phthalate (BBP)           | 1000                    |
 | Dibutyl phthalate (DBP)                | 1000                    |
 | Diisobutyl phthalate (DIBP)            | 1000                    |
+
+<div style="page-break-after: always;"></div>
 
 Exemptions: No exemptions are claimed.
 

--- a/content/hardware/04.pro/boards/portenta-c33/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-c33/datasheets/datasheet.md
@@ -424,18 +424,18 @@ We declare under our sole responsibility that the products above are in conformi
 
 Arduino boards are in compliance with RoHS 2 Directive 2011/65/EU of the European Parliament and RoHS 3 Directive 2015/863/EU of the Council of 4 June 2015 on the restriction of the use of certain hazardous substances in electrical and electronic equipment.
 
-|              **Substance**             | **Maximum Limit (ppm)** |
-|:--------------------------------------:|:-----------------------:|
-|                Lead (Pb)               |           1000          |
-|              Cadmium (Cd)              |           100           |
-|              Mercury (Hg)              |           1000          |
-|       Hexavalent chromium (Cr6+)       |           1000          |
-|     Poly brominated biphenyls (PBB)    |           1000          |
-| Poly brominated diphenyl ethers (PBDE) |           1000          |
-|   Bis(2-Ethylhexyl) phthalate (DEHP)   |           1000          |
-|      Benzyl butyl phthalate (BBP)      |           1000          |
-|         Dibutyl phthalate (DBP)        |           1000          |
-|       Diisobutyl phthalate (DIBP)      |           1000          |
+| **Substance**                          | **Maximum Limit (ppm)** |
+|----------------------------------------|-------------------------|
+| Lead (Pb)                              | 1000                    |
+| Cadmium (Cd)                           | 100                     |
+| Mercury (Hg)                           | 1000                    |
+| Hexavalent Chromium (Cr6+)             | 1000                    |
+| Poly Brominated Biphenyls (PBB)        | 1000                    |
+| Poly Brominated Diphenyl ethers (PBDE) | 1000                    |
+| Bis(2-Ethylhexyl} phthalate (DEHP)     | 1000                    |
+| Benzyl butyl phthalate (BBP)           | 1000                    |
+| Dibutyl phthalate (DBP)                | 1000                    |
+| Diisobutyl phthalate (DIBP)            | 1000                    |
 
 Exemptions: No exemptions are claimed.
 


### PR DESCRIPTION
## What This PR Changes
- [Jira task](https://arduino.atlassian.net/browse/PC-1069)
- Centring the minerals table on the "RoHS 2 Directive 2011/65/EU of the European Parliament and RoHS 3 Directive 2015/863/EU of the Council of 4 June 2015 on the restriction of the use of certain hazardous substances in electrical and electronic equipment." section to make it similar to the others Datasheets.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
