### PR TITLE
Stream class documentation is now added to the Arduino Style Guide for Creating Libraries

### DIFF
--- a/content/learn/08.contributions/01.arduino-library-style-guide/arduino-library-style-guide.md
+++ b/content/learn/08.contributions/01.arduino-library-style-guide/arduino-library-style-guide.md
@@ -25,7 +25,7 @@ This is a style guide to writing library APIs in an Arduino style. Some of these
 **Use the established core libraries and styles.**
 
 * Use `read()` to read inputs, and `write()` to write to outputs, e.g. `digitalRead()`, `analogWrite()`, etc.
-* Use the `Stream` and `Print` classes when dealing with byte streams. If it’s not appropriate, at least try to use its API as a model. For more on this, see below
+* Use the [`Stream`](https://www.arduino.cc/reference/en/language/functions/communication/stream/) and `Print` classes when dealing with byte streams. If it’s not appropriate, at least try to use its API as a model. For more on this, see below
 * For network applications, use the `Client` and `Server` classes as the basis.
 * Use `begin()` to initialize a library instance, usually with some settings. Use `end()` to stop it.
 * Use camel case function names, not underscore. For example, **analogRead**, not **analog_read**. Or **myNewFunction**, not **my_new_function**. We've adopted this from Processing.org for readability's sake.


### PR DESCRIPTION
## What This PR Changes
- This pull request resolves one task of the issue #773 about adding the Stream documentation link to the Style Guide for Creating Libraries on this repository. This issue hasn't any blockers by external work.
- Link to the issue: https://github.com/arduino/docs-content/issues/773

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
