### PR TITLE
[AE-63] Arduino IDE pre-requisites in Linux

### DIFF
--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -75,3 +75,8 @@ dnf install fuse
 ```
 
 See instructions for installing FUSE on your distribution [here](https://github.com/AppImage/AppImageKit/wiki/FUSE).
+
+To enable the Arduino IDE to access the serial port and upload code to your board, the following rule can be added to `/etc/udev/rules.d/99-arduino.rules`. 
+```
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", GROUP="plugdev", MODE="0666"
+```

--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -61,4 +61,17 @@ Before we can launch the editor, we need to first make it an **executable file**
 
 ![Allow execution of file.](assets/linux-installation.gif)
 
-You can now double click the file to launch the Arduino IDE 2 on your Linux machine.
+You can now double click the file to launch the Arduino IDE 2 on your Linux machine. In case you cannot run the AppImage file, make sure that FUSE is installed on your system.
+
+In Ubuntu (>= 22.04):
+```bash
+sudo add-apt-repository universe
+sudo apt install libfuse2
+```
+
+In Fedora
+```bash
+dnf install fuse
+```
+
+See instructions for installing FUSE on your distribution [here](https://github.com/AppImage/AppImageKit/wiki/FUSE).


### PR DESCRIPTION
## What This PR Changes
I was unable to install Arduino IDE on Ubuntu 22.04 with the current instructions. 

- State FUSE (https://github.com/AppImage/AppImageKit/wiki/FUSE) as pre requisite for running AppImage in Linux
- Provide installation instruction for Ubuntu and Fedora
- Point users to FUSE documentation for instructions on other distributions.
- Create `/etc/udev/rules.d/99-arduino.rules` to prevent `exit error 74`cc @cmaglie 
    -  ```SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", GROUP="plugdev", MODE="0666"```

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
