### PR TITLE
[PC-1210] Opta - Tech Specs Product Page Update

### DIFF
--- a/content/hardware/07.opta/opta-family/opta/tech-specs.yml
+++ b/content/hardware/07.opta/opta-family/opta/tech-specs.yml
@@ -8,7 +8,11 @@ Microcontroller:
   Cortex-M7 core: Up to 480 MHz
   Cortex-M4 core: Up to 240 MHz
 Input:
-  Configurable digital / analog (0-10V) input: 8
+  Configurable digital / analog inputs: 8
+  Digital Operational Range: 0-24 VDC
+  Digital VIL Max: 4.46 VDC
+  Digital VIH Min: 6.6 VDC
+  Analog Operational Range: 0-10 VAC
 Relays:
   Nº of relays: 4
   Type: Normally Open (NO)

--- a/content/hardware/07.opta/opta-family/opta/tech-specs.yml
+++ b/content/hardware/07.opta/opta-family/opta/tech-specs.yml
@@ -8,11 +8,11 @@ Microcontroller:
   Cortex-M7 core: Up to 480 MHz
   Cortex-M4 core: Up to 240 MHz
 Input:
-  Configurable digital / analog inputs: 8
-  Digital Operational Range: 0-24 VDC
-  Digital VIL Max: 4.46 VDC
-  Digital VIH Min: 6.6 VDC
-  Analog Operational Range: 0-10 VAC
+  Configurable digital / analog input: 8
+  Digital Operational Range: 0-24 V
+  Digital VIL Max: 4.46 V
+  Digital VIH Min: 6.6 V
+  Analog Operational Range: 0-10 V
 Relays:
   Nº of relays: 4
   Type: Normally Open (NO)


### PR DESCRIPTION
## What This PR Changes
- Adding some information to the Tech Specs table on Opta's product page regarding the information about input voltage levels.
-[Jira Task](https://arduino.atlassian.net/browse/PC-1210)

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
