### PR TITLE
Jhansson ard/retired products

### DIFF
--- a/content/retired/01.boards/arduino-101-619/content.md
+++ b/content/retired/01.boards/arduino-101-619/content.md
@@ -7,6 +7,8 @@ sku: "ABX00005"
 source: "https://store.arduino.cc/arduino-101-619"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino 101 board](./assets/ABX00005_featured_2.jpg)
 
 A learning and development board that delivers the performance and low-power consumption of the [Intel® Curie™](/resources/datasheets/intel-curie-module-datasheet.pdf) Module with the simplicity of Arduino at an entry-level price. It keeps the same robust form factor and peripheral list of the UNO with the addition of onboard Bluetooth® Low Energy capabilities and a 6-axis accelerometer/gyro to help you easily expand your creativity into the connected world. 

--- a/content/retired/01.boards/arduino-BT-v1/content.md
+++ b/content/retired/01.boards/arduino-BT-v1/content.md
@@ -3,6 +3,8 @@ title: "Arduino BT v1"
 source: "https://arduino.cc/en/Main/ArduinoBoardBluetoothNew"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Arduino BT (Bluetooth®)
 
 ![](assets/ArduinoBT400.jpg)

--- a/content/retired/01.boards/arduino-BT/content.md
+++ b/content/retired/01.boards/arduino-BT/content.md
@@ -3,6 +3,8 @@ title: "Arduino BT (Bluetooth)"
 source: "https://arduino.cc/en/Main/ArduinoBoardBT"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Arduino BT (Bluetooth)
 
 ![Arduino BT Front](assets/ArduinoBT_Front_400px.jpg)

--- a/content/retired/01.boards/arduino-diecimila/content.md
+++ b/content/retired/01.boards/arduino-diecimila/content.md
@@ -3,6 +3,8 @@ title: "Arduino Diecimila"
 source: "https://arduino.cc/en/Main/ArduinoBoardDiecimila"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Arduino Diecimila
 
 ![](assets/ArduinoDiecimila400.jpg)

--- a/content/retired/01.boards/arduino-duemilanove/content.md
+++ b/content/retired/01.boards/arduino-duemilanove/content.md
@@ -3,6 +3,8 @@ title: "Arduino Duemilanove"
 source: "https://arduino.cc/en/Main/ArduinoBoardDuemilanove"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Arduino Duemilanove
 
 ![](assets/ArduinoDuemilanove.jpg)

--- a/content/retired/01.boards/arduino-esplora/content.md
+++ b/content/retired/01.boards/arduino-esplora/content.md
@@ -7,6 +7,8 @@ sku: "A000095"
 source: "https://store.arduino.cc/arduino-esplora"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Esplora board](./assets/A000095_top_2.jpg)
 
 The **Arduino Esplora** is a microcontroller board derived from the [Arduino Leonardo](https://www.arduino.cc/en/Guide/ArduinoLeonardo). The Esplora differs from all preceding Arduino boards in that it provides a number of built-in, ready-to-use set of onboard sensors for interaction. It's designed for people who want to get up and running with Arduino without having to learn about the electronics first. For a step-by-step introduction to the Esplora, check out the [Getting Started with Esplora](https://www.arduino.cc/en/Guide/ArduinoEsplora) guide.

--- a/content/retired/01.boards/arduino-ethernet-rev3-with-poe/content.md
+++ b/content/retired/01.boards/arduino-ethernet-rev3-with-poe/content.md
@@ -6,6 +6,8 @@ sku: "A000074"
 source: "https://store.arduino.cc/arduino-ethernet-rev3-with-poe"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Ethernet Rev3 with PoE](./assets/a000074_front.jpg)
 
 The **Arduino Ethernet** is a microcontroller board based on the ATmega328P. It has 14 digital input/output pins, 6 analog inputs, a 16 MHz crystal oscillator, a RJ45 connection, a power jack, an ICSP header, and a reset button.

--- a/content/retired/01.boards/arduino-ethernet-rev3-without-poe/content.md
+++ b/content/retired/01.boards/arduino-ethernet-rev3-without-poe/content.md
@@ -6,6 +6,8 @@ sku: "A000068"
 source: "https://store.arduino.cc/arduino-ethernet-rev3-without-poe"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Ethernet Rev3 without PoE](assets/a000068_front.jpg)
 
 The **Arduino Ethernet** is a microcontroller board based on the ATmega328\. It has 14 digital input/output pins, 6 analog inputs, a 16 MHz crystal oscillator, a RJ45 connection, a power jack, an ICSP header, and a reset button.

--- a/content/retired/01.boards/arduino-fio/content.md
+++ b/content/retired/01.boards/arduino-fio/content.md
@@ -3,6 +3,8 @@ title: Arduino Fio
 source: https://www.arduino.cc/en/Main/ArduinoBoardFio
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Fio board.](./assets/ArduinoFio.jpg)
 
 ## Overview

--- a/content/retired/01.boards/arduino-gemma/content.md
+++ b/content/retired/01.boards/arduino-gemma/content.md
@@ -7,6 +7,8 @@ sku: "ABX00001"
 source: "https://store.arduino.cc/arduino-gemma"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Gemma board](assets/abx00001_front.jpg)
 
 The **Arduino Gemma** is a microcontroller board made by [Adafruit](https://www.adafruit.com/) based on the [ATtiny85](http://www.atmel.com/assets/atmel-2586-avr-8-bit-microcontroller-attiny25-attiny45-attiny85_datasheet.pdf). It has 3 digital input/output pins (of which 2 can be used as PWM outputs and 1 as analog input), an 8 MHz resonator, a micro USB connection, a JST connector for a 3.7V battery, and a reset button. It contains everything needed to support the microcontroller; simply connect it to a computer with a USB cable or power it with a battery to get started.

--- a/content/retired/01.boards/arduino-industrial-101/content.md
+++ b/content/retired/01.boards/arduino-industrial-101/content.md
@@ -7,6 +7,8 @@ sku: "A000126"
 source: "https://store.arduino.cc/arduino-industrial-101"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Industrial 101 board](assets/A000126_ArduinoIndustrial101_featured_2.jpg)
 
 **Arduino Industrial 101** is an Evaluation board for Arduino 101 LGA module. The ATmega32u4 microcontroller is integrated in the baseboard. The module supports a Linux distribution based on OpenWRT named LininoOS. The board has built-in WiFi (IEEE 802.11b/g/n operations up to 150Mbps 1x1 2.4 GHz), 3 GPIOs (of which 2 can be used as PWM Outputs), 4 Analog Inputs, 1 USB, 1 Ethernet signal on pin headers and a built-in DC/DC converter. Check out the assembling guide and simply connect your board to a computer with a micro USB cable to get started.

--- a/content/retired/01.boards/arduino-isp/content.md
+++ b/content/retired/01.boards/arduino-isp/content.md
@@ -7,6 +7,8 @@ sku: "A000092"
 source: "https://store.arduino.cc/arduino-isp"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino ISP board](assets/A000092_last_featured_2.jpg)
 
 The **Arduino ISP** is a tiny AVR-ISP (in-system programmer) based on David Mellis' project FabISP([http://fab.cba.mit.edu/content/projects/fabisp/](http://fab.cba.mit.edu/content/archive/projects/fabisp/)). With this programmer you can upload sketches and burn the bootloader on any AVR based boards, including Arduinos. By uploading a sketch with an external programmer you can remove the bootloader and use the extra space for your sketch. The Arduino ISP can also be used to burn the Arduino bootloader, so you can recover your chip if you accidentally corrupt the bootloader. Burning the bootloader is also necessary when you use a new ATmega microcontroller in your Arduino, and you wish to use the bootloader to upload a sketch via the USB-Serial connection.

--- a/content/retired/01.boards/arduino-leonardo-eth-2-with-poe/content.md
+++ b/content/retired/01.boards/arduino-leonardo-eth-2-with-poe/content.md
@@ -6,6 +6,8 @@ sku: "A000023"
 source: "https://store.arduino.cc/arduino-leonardo-eth-2-with-poe"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Leonardo ETH with PoE](assets/a000023_iso.jpg)
 
 The Arduino Leonardo ETH is the Leonardo with a built-in ethernet controller (Wiznet 5500 controller with RJ45 connector). Optional PoE (Power over Ethernet)

--- a/content/retired/01.boards/arduino-leonardo-eth/content.md
+++ b/content/retired/01.boards/arduino-leonardo-eth/content.md
@@ -7,6 +7,8 @@ sku: "A000022"
 source: "https://store.arduino.cc/arduino-leonardo-eth"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Leonardo ETH board](./assets/a000022_front.jpg)
 
 The **Leonardo ETH** is a microcontroller board based on the ATmega32U4 (datasheet) and the new W5500 TCP/IP Embedded Ethernet Controller (datasheet). It has 20 digital input/output pins (of which 7 can be used as PWM outputs and 12 as analog inputs), a 16 MHz crystal oscillator, a RJ45 connection, a micro USB connector, a power jack, an ICSP header, and a reset button. It contains everything needed to support the microcontroller; simply connect it to a computer with a USB cable or power it with a AC-to-DC adapter or battery to get started.

--- a/content/retired/01.boards/arduino-m0-pro/content.md
+++ b/content/retired/01.boards/arduino-m0-pro/content.md
@@ -7,6 +7,8 @@ sku: "A000111"
 source: "https://store.arduino.cc/m0-pro"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino M0 Pro board](./assets/a000111_front_1.jpg)
 
 With the new **Arduino M0 Pro** board, the more creative individual will have the potential to create one’s most imaginative and new ideas for IoT devices, wearable technologies, high tech automation, wild robotics and other not yet thinkable adventures in the world of makers. The Arduino M0 pro represents a simple, yet powerful, 32-bit extension of the Arduino UNO platform. The board is powered by Atmel’s SAMD21 MCU, featuring a 32-bit ARM Cortex® M0 core.

--- a/content/retired/01.boards/arduino-m0/content.md
+++ b/content/retired/01.boards/arduino-m0/content.md
@@ -7,6 +7,8 @@ sku: "A000103"
 source: "https://store.arduino.cc/arduino-m0"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino M0 board](./assets/a000103_front.jpg)
 
 With the new **Arduino M0** board, the more creative individual will have the potential to create one’s most imaginative and new ideas for IoT devices, wearable technologies, high tech automation, wild robotics and other not yet thinkable adventures in the world of makers. The Arduino M0 represents a simple, yet powerful, 32-bit extension of the Arduino UNO platform. The board is powered by Atmel’s SAMD21 MCU, featuring a 32-bit ARM Cortex® M0 core. With the addition of the M0 board, the Arduino family becomes larger with a new member providing increased performance.

--- a/content/retired/01.boards/arduino-mega-adk-rev3/content.md
+++ b/content/retired/01.boards/arduino-mega-adk-rev3/content.md
@@ -7,6 +7,8 @@ sku: "A000069"
 source: "https://store.arduino.cc/arduino-mega-adk-rev3"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Mega ADK Rev3 board](./assets/A000069_front_2.jpg)
 
 The **Arduino MEGA ADK** is a microcontroller board based on the ATmega2560\. It has a USB host interface to connect with Android based phones, based on the MAX3421e IC. It has 54 digital input/output pins (of which 15 can be used as PWM outputs), 16 analog inputs, 4 UARTs(hardware serial ports), a 16 MHz crystal oscillator, a USB connection, a power jack, an ICSP header, and a reset button.

--- a/content/retired/01.boards/arduino-mini-05-without-header/content.md
+++ b/content/retired/01.boards/arduino-mini-05-without-header/content.md
@@ -6,6 +6,8 @@ sku: "A000088"
 source: "https://store.arduino.cc/arduino-mini-05-without-header"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Mini 05 board, without headers](./assets/a000088_featured.jpg)
 
 The **Arduino Mini 05** is a small microcontroller board originally based on the ATmega168, but now supplied with the 328.([datasheet](http://www.atmel.com/assets/Atmel-8271-8-bit-AVR-Microcontroller-ATmega48A-48PA-88A-88PA-168A-168PA-328-328P_datasheet_Complete.pdf)), intended for use on breadboards and when space is at a premium. It has 14 digital input/output pins (of which 6 can be used as PWM outputs), 8 analog inputs, and a 16 MHz crystal oscillator. It can be programmed with the [USB Serial adapter](https://www.arduino.cc/en/Main/USBSerial) or other USB or RS232 to TTL serial adapter.

--- a/content/retired/01.boards/arduino-mini-05/content.md
+++ b/content/retired/01.boards/arduino-mini-05/content.md
@@ -7,6 +7,8 @@ sku: "A000087"
 source: "https://store.arduino.cc/arduino-mini-05"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Mini 05 board, with headers](./assets/A000087_iso_2.jpg)
 
 The **Arduino Mini 05** is a small microcontroller board originally based on the ATmega168, but now supplied with the 328.([datasheet](/resources/datasheets/Atmel-8271-8-bit-AVR-Microcontroller-ATmega48A-48PA-88A-88PA-168A-168PA-328-328P_datasheet_Complete.pdf)), intended for use on breadboards and when space is at a premium. It has 14 digital input/output pins (of which 6 can be used as PWM outputs), 8 analog inputs, and a 16 MHz crystal oscillator. It can be programmed with the [USB Serial adapter](https://www.arduino.cc/en/Main/USBSerial) or other USB or RS232 to TTL serial adapter.

--- a/content/retired/01.boards/arduino-ng/content.md
+++ b/content/retired/01.boards/arduino-ng/content.md
@@ -3,6 +3,8 @@ title: Arduino NG
 source:
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Upgrading an Arduino NG to Auto-Reset
 
 If you have an Arduino NG and you're envious of all the seconds saved by those Diecimila owners who don't have to press the reset button anymore, this page is for you. You can upgrade an Arduino NG to take advantage of the auto-reset functionality in Arduino 0009 and beyond with just a 0.1uF capacitor and a soldering iron.

--- a/content/retired/01.boards/arduino-primo-core/content.md
+++ b/content/retired/01.boards/arduino-primo-core/content.md
@@ -6,6 +6,8 @@ sku: "A000138"
 source: "https://store.arduino.cc/arduino-primo-core"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Primo Core board](./assets/a000138_featured.jpg)
 
 Arduino Primo Core is the compact Arduino board developed in cooperation with [Nordic Semiconductor](http://www.nordicsemi.com/).  

--- a/content/retired/01.boards/arduino-primo/content.md
+++ b/content/retired/01.boards/arduino-primo/content.md
@@ -6,6 +6,8 @@ sku: "A000135"
 source: "https://store.arduino.cc/arduino-primo"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Primo board](./assets/a000135_featured.jpg)
 
 The Arduino Primo is the first board developed in cooperation with [Nordic Semiconductor](http://www.nordicsemi.com/). It brings new benefits for the IoT world all on one platform: advanced 32-bit microcontroller architecture, Bluetooth® low energy, Wi-Fi, near-field communications (NFC), and infrared (IR) transmit and receive capability.  

--- a/content/retired/01.boards/arduino-pro-mini/content.md
+++ b/content/retired/01.boards/arduino-pro-mini/content.md
@@ -7,6 +7,8 @@ sku: "E000025"
 source: "https://store.arduino.cc/arduino-pro-mini"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Pro Mini board](./assets/e000025_featured.jpg)
 
 The **Arduino Pro Mini** is a microcontroller board based on the [ATmega328P](http://www.atmel.com/Images/Atmel-8271-8-bit-AVR-Microcontroller-ATmega48A-48PA-88A-88PA-168A-168PA-328-328P_datasheet.pdf).  

--- a/content/retired/01.boards/arduino-pro/content.md
+++ b/content/retired/01.boards/arduino-pro/content.md
@@ -7,6 +7,8 @@ sku: "E000023"
 source: "https://store.arduino.cc/arduino-pro"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Pro board](./assets/e000023_featured.jpg)
 
 The **Arduino Pro** is a microcontroller board based on the ATmega328\. The Pro comes in both 3.3V/8MHz and 5V/16MHz versions. It has 14 digital input/output pins (of which 6 can be used as PWM outputs), 6 analog inputs, a battery power jack, a power switch, a reset button, and holes for mounting a power jack, an ICSP header, and pin headers. A six pin header can be connected to an FTDI cable or Sparkfun breakout board to provide USB power and communication to the board. The Arduino Pro is intended for semi-permanent installation in objects or exhibitions. The board comes without pre-mounted headers, allowing the use of various types of connectors or direct soldering of wires. The pin layout is compatible with Arduino shields. The 3.3V versions of the Pro can be powered with a battery. The Arduino Pro was designed and manufactured by SparkFun Electronics.

--- a/content/retired/01.boards/arduino-serial-single-sided-3/content.md
+++ b/content/retired/01.boards/arduino-serial-single-sided-3/content.md
@@ -3,6 +3,8 @@ title: "Arduino Board Serial Single Sided v3"
 source: "https://arduino.cc/en/Main/ArduinoBoardSerialSingleSided3"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Arduino Single-Sided Serial Board (version 3)
 
 If you don't have an easy way to order an Arduino board or kit, you can etch this PCB design by hand and solder it together. It is pin-compatible with the Arduino Diecimila, and should work with any Arduino shield.

--- a/content/retired/01.boards/arduino-serial-single-sided/content.md
+++ b/content/retired/01.boards/arduino-serial-single-sided/content.md
@@ -3,9 +3,9 @@ title: "Arduino Board Serial Single Sided"
 source: "https://arduino.cc/en/Main/ArduinoBoardSerialSingleSided"
 ---
 
-## Single Sided Board
+***Note: This page refers to a product that is retired. The files mentioned on this page might no longer be available.***
 
-***Note that the files mentioned on this page might no longer be available.***
+## Single Sided Board
 
 For those that are in a hurry to produce a board or that don't have an easy access to the postal system (the way how we distribute the boards), it is possible to etch the circuit yourself using the following design.
 

--- a/content/retired/01.boards/arduino-serial/content.md
+++ b/content/retired/01.boards/arduino-serial/content.md
@@ -3,6 +3,8 @@ title: "Arduino Board Serial"
 source: "https://arduino.cc/en/Main/ArduinoBoardSerial"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Arduino Board - Serial Interface 
 
 **This page has been updated for historical purposes and we cannot guarantee that the files will be available forever.**   

--- a/content/retired/01.boards/arduino-tian/content.md
+++ b/content/retired/01.boards/arduino-tian/content.md
@@ -7,6 +7,8 @@ sku: "A000116"
 source: "https://store.arduino.cc/arduino-tian"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Tian board](./assets/A000116_Tian_featured_2.jpg)
 
 The new **Arduino Tian** board is powered by Atmel’s SAMD21 MCU, featuring a 32-bit ARM Cortex® M0+ core and a Qualcomm Atheros AR9342, which is an highly integrated MIPS processor operating at up to 533MHz and feature-rich IEEE802.11n 2x2 2.4/5 GHz dual-band WiFi module. Qualcomm Atheros MIPS supports a Linux distribution, based on OpenWRT named Linino. The Arduino Tian has also a build in 4GB eMMC memory that will can be helpful to build your projects. It is possible to Switch ON/OFF the Linux port from the MCU to reduce the power consumption.

--- a/content/retired/01.boards/arduino-tre/content.md
+++ b/content/retired/01.boards/arduino-tre/content.md
@@ -3,6 +3,7 @@ title: "Arduino Tre"
 source: "https://arduino.cc/en/Main/ArduinoBoardTre"
 ---
 
+***Note: This page refers to a product that is retired.***
 
 ## Arduino TRE (discontinued)
 

--- a/content/retired/01.boards/arduino-uno-rev3-with-long-pins/content.md
+++ b/content/retired/01.boards/arduino-uno-rev3-with-long-pins/content.md
@@ -7,6 +7,8 @@ tags: [8 bit, AVR, 20 mA, Usb, 5V, Standard (~20), No battery]
 source: "https://store.arduino.cc/arduino-uno-rev3-with-long-pins"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino UNO board](./assets/a000099_featured_1.jpg)
 
 **Arduino UNO** is a microcontroller board based on the ATmega328P ([datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42735-8-bit-AVR-Microcontroller-ATmega328-328P_Summary.pdf)). It has 14 digital input/output pins (of which 6 can be used as PWM outputs), 6 analog inputs, a 16 MHz ceramic resonator (CSTCE16M0V53-R0), a USB connection, a power jack, an ICSP header and a reset button. It contains everything needed to support the microcontroller; simply connect it to a computer with a USB cable or power it with a AC-to-DC adapter or battery to get started.. You can tinker with your UNO without worring too much about doing something wrong, worst case scenario you can replace the chip for a few dollars and start over again.

--- a/content/retired/01.boards/arduino-uno-wifi/content.md
+++ b/content/retired/01.boards/arduino-uno-wifi/content.md
@@ -6,9 +6,9 @@ sku: "A000133"
 source: "https://store.arduino.cc/arduino-uno-wifi"
 ---
 
-![The Arduino UNO WiFi](./assets/a000133_featured.jpg)
+***Note: This page refers to a product that is retired. Check out the [Arduino UNO WiFi Rev2](https://docs.arduino.cc/hardware/uno-wifi-rev2)***
 
-**This product is retired, check out the [Arduino UNO WiFi Rev2](https://docs.arduino.cc/hardware/uno-wifi-rev2)**
+![The Arduino UNO WiFi](./assets/a000133_featured.jpg)
 
 The Arduino UNO WiFi is the same as a Arduino UNO Rev3 but with an integrated Wi-Fi module! The board is based on the ATmega328P with an ESP8266 Wi-Fi Module integrated (datasheet). It has 14 digital input/output pins (of which 6 can be used as PWM outputs), 6 analog inputs, a 16 MHz ceramic resonator, a USB connection, a power jack, an ICSP header, and a reset button. It contains everything needed to support the microcontroller; simply connect it to a computer with a USB cable or power it with an AC-to-DC adapter or battery to get started.  
   

--- a/content/retired/01.boards/arduino-usb-2-serial-micro/content.md
+++ b/content/retired/01.boards/arduino-usb-2-serial-micro/content.md
@@ -6,6 +6,8 @@ sku: "A000107"
 source: "https://store.arduino.cc/arduino-usb-2-serial-micro"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino USB 2 Serial Micro board](./assets/A000107_featured_2.jpg)
 
 This board converts a USB connection into a 5 volt Serial TX and RX that you can connect straight to the Arduino Mini, Arduino Ethernet or other microcontrollers, allowing them to talk to the computer. It features an Atmega16U2 programmed as a USB-to-serial converter, the same chip found on the [Arduino Uno](https://www.arduino.cc/en/Main/ArduinoBoardUno). The *16U2 firmware* uses the standard USB COM drivers, and no external driver is needed. However, on Windows, a .inf file is required.

--- a/content/retired/01.boards/arduino-usb/content.md
+++ b/content/retired/01.boards/arduino-usb/content.md
@@ -2,6 +2,8 @@
 title: Arduino USB
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Assembling the Arduino USB Board v2.0
 
 *by Tom Igoe* 

--- a/content/retired/01.boards/arduino-yun-mini/content.md
+++ b/content/retired/01.boards/arduino-yun-mini/content.md
@@ -7,6 +7,8 @@ sku: "A000108"
 source: "https://store.arduino.cc/arduino-yun-mini"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Yún Mini board](./assets/A000108_ArduinoYunMini1_featured_2.jpg)
 
 **Arduino Yún Mini** is a breadboard PCB developed with ATmega 32u4 MCU and QCA MIPS 24K SoC CPU operating up to 400 MHz. Qualcomm Atheros CPU supports a Linux distribution based on OpenWRT named Linino. The board has built- in WiFi ( IEEE 802.11b/g/n operations up to 150Mbps 1x1 2.4 GHz ) supports 20 digital input/output pins (of which 7 can be used as PWM outputs and 12 as analog inputs), a 16 MHz crystal oscillator, a micro USB connector, an ICSP header, two reset buttons and one user button. The Arduino Yún Mini is similar to the Leonardo in that the ATmega32u4 has built-in USB communication, eliminating the need for a secondary processor. This allows the Arduino Yún Mini to appear to a connected computer as a mouse and keyboard, in addition to a virtual (CDC) serial / COM port.

--- a/content/retired/01.boards/arduino-yun-with-poe/content.md
+++ b/content/retired/01.boards/arduino-yun-with-poe/content.md
@@ -7,6 +7,8 @@ sku: "A000003"
 source: "https://store.arduino.cc/arduino-yun-with-poe"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Yún board with PoE](./assets/a000003_featured.jpg)
 
 The **Arduino Yún** is a microcontroller board based on the ATmega32u4 and the Atheros AR9331\. The Atheros processor supports a Linux distribution based on OpenWrt named Linino OS. The board has built-in Ethernet and WiFi support, a USB-A port, micro-SD card slot, 20 digital input/output pins (7 of them can be used as PWM outputs and 12 as analog inputs), a 16 MHz crystal oscillator, a micro USB connection, an ICSP header, and 3 reset buttons.

--- a/content/retired/01.boards/arduino-yun/content.md
+++ b/content/retired/01.boards/arduino-yun/content.md
@@ -7,6 +7,8 @@ sku: "A000008"
 source: "https://store.arduino.cc/arduino-yun"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Yún board](./assets/A000008_featured_2.jpg)
 
 The **Arduino Yún** is a microcontroller board based on the ATmega32u4 and the Atheros AR9331\. The Atheros processor supports a Linux distribution based on OpenWrt named Linino OS. The board has built-in Ethernet and WiFi support, a USB-A port, micro-SD card slot, 20 digital input/output pins (7 of them can be used as PWM outputs and 12 as analog inputs), a 16 MHz crystal oscillator, a micro USB connection, an ICSP header, and 3 reset buttons.

--- a/content/retired/01.boards/lilypad-arduino-main-board/content.md
+++ b/content/retired/01.boards/lilypad-arduino-main-board/content.md
@@ -7,6 +7,8 @@ sku: "DEV-13342"
 source: "https://store.arduino.cc/lilypad-arduino-main-board"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The LilyPad Arduino Main Board](assets/lilypad_main.jpg)
 
 The **LilyPad Arduino Main Board** is based on the ATmega168V (the low-power version of the ATmega168) or the ATmega328V. The LilyPad Arduino was designed and developed by Leah Buechley and SparkFun Electronics.

--- a/content/retired/01.boards/lilypad-arduino-simple/content.md
+++ b/content/retired/01.boards/lilypad-arduino-simple/content.md
@@ -7,6 +7,8 @@ sku: "DEV-10274"
 source: "https://store.arduino.cc/lilypad-arduino-simple"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The LilyPad Arduino Simple board](./assets/lilypad.jpg)
 
 Unlike the [LilyPad Arduino Main Board](https://www.arduino.cc/en/Main/ArduinoBoardLilyPad), the **LilyPad Simple** has only 9 pins for input/output. Additionally, it has a JST connector and a built in charging circuit for Lithium Polymer batteries. The board is based on the [ATmega328](http://www.atmel.com/assets/Atmel-8271-8-bit-AVR-Microcontroller-ATmega48A-48PA-88A-88PA-168A-168PA-328-328P_datasheet_Complete.pdf).  

--- a/content/retired/01.boards/lilypad-arduino-simplesnap/content.md
+++ b/content/retired/01.boards/lilypad-arduino-simplesnap/content.md
@@ -7,6 +7,8 @@ sku: "E000059"
 source: "https://store.arduino.cc/lilypad-arduino-simplesnap"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The LilyPad Arduino SimpleSnap board](./assets/store_e000059-featured_1.jpg)
 
 The **LilyPad Arduino SimpleSnap** is a microcontroller board designed for wearables and e-textiles. It is similar to the [LilyPad Arduino Simple](https://www.arduino.cc/en/Main/ArduinoBoardLilyPadSimple), except that it has a built in lithium polymer battery, and instead of through-holes, it has conductive snaps. By using matching snaps in your project, you can affix the LilyPad securely but remove it to wash your project or move it to another project. The LilyPad SimpleSnap has 9 pins for input/output. Additionally, it has a built in charging circuit for the battery. The board is based on the [ATmega328](http://www.atmel.com/assets/Atmel-8271-8-bit-AVR-Microcontroller-ATmega48A-48PA-88A-88PA-168A-168PA-328-328P_datasheet_Complete.pdf).  

--- a/content/retired/01.boards/lilypad-arduino-usb/content.md
+++ b/content/retired/01.boards/lilypad-arduino-usb/content.md
@@ -7,6 +7,8 @@ sku: "E000017"
 source: "https://store.arduino.cc/lilypad-arduino-usb"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The LilyPad Arduino USB board](./assets/store_e000017_featured_1.jpg)
 
 The **LilyPad Arduino USB** is a microcontroller board based on the [ATmega32u4](http://www.atmel.com/Images/Atmel-7766-8-bit-AVR-ATmega16U4-32U4_Datasheet.pdf). It has 9 digital input/output pins (of which 4 can be used as PWM outputs and 4 as analog inputs), an 8 MHz resonator, a micro USB connection, a JST connector for a 3.7V LiPo battery, and a reset button. It contains everything needed to support the microcontroller; simply connect it to a computer with a USB cable or power it with a battery to get started.

--- a/content/retired/02.shields/arduino-ethernet-shield-2-with-poe/content.md
+++ b/content/retired/02.shields/arduino-ethernet-shield-2-with-poe/content.md
@@ -6,6 +6,8 @@ sku: "A000025"
 source: "https://store.arduino.cc/arduino-ethernet-shield-2-with-poe"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Ethernet Shield 2 with PoE](./assets/a000025_featured.jpg)
 
 The **Arduino Ethernet Shield 2 with PoE** connects your Arduino to the internet in mere minutes. Just plug this shield into your Arduino Board, connect it to your network with an RJ45 cable (not included) and follow a few simple steps to start controlling your world through the internet. As always with Arduino, every element of the platform – hardware, software and documentation – is freely available and open-source. This means you can learn exactly how it's made and use its design as the starting point for your own circuits. Hundreds of thousands of Arduino Boards are already fueling people’s creativity all over the world, everyday. Join us now, Arduino is you!   

--- a/content/retired/02.shields/arduino-ethernet-shield-without-poe-module/content.md
+++ b/content/retired/02.shields/arduino-ethernet-shield-without-poe-module/content.md
@@ -6,6 +6,8 @@ sku: "A000072"
 source: "https://store.arduino.cc/arduino-ethernet-shield-without-poe-module"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Ethernet Shield without PoE](./assets/a000072_featured.jpg)
 
 The Arduino Ethernet Shield V1 connects your Arduino to the internet in mere minutes. Just plug this module onto your Arduino board, connect it to your network with an RJ45 cable (not included) and follow a few simple instructions to start controlling your world through the internet.

--- a/content/retired/02.shields/arduino-gsm-shield-2-antenna-connector/content.md
+++ b/content/retired/02.shields/arduino-gsm-shield-2-antenna-connector/content.md
@@ -6,6 +6,8 @@ sku: "A000106"
 source: "https://store.arduino.cc/arduino-gsm-shield-2-antenna-connector"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino GSM Shield 2 with antenna connector](./assets/a000106_featured.jpg)
 
 The **Arduino GSM Shield 2** allows an Arduino board to connect to the internet, make/receive voice calls and send/receive SMS messages. The shield uses a radio modem [M10 by Quectel](https://www.arduino.cc/en/uploads/Main/Quectel_M10_datasheet.pdf). It is possible to communicate with the board using [AT commands](https://www.arduino.cc/en/Main/en/uploads/Main/Quectel_M10_AT_commands.pdf). The [GSM library](https://www.arduino.cc/en/Reference/GSM) has a large number of methods for communication with the shield.

--- a/content/retired/02.shields/arduino-gsm-shield-2-integrated-antenna/content.md
+++ b/content/retired/02.shields/arduino-gsm-shield-2-integrated-antenna/content.md
@@ -7,6 +7,8 @@ sku: "A000105"
 source: "https://store.arduino.cc/arduino-gsm-shield-2-integrated-antenna"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino GSM Shield 2 with integrated antenna](./assets/A000105_featured_2.jpg)
 
 The **Arduino GSM Shield 2** allows an Arduino board to connect to the internet, make/receive voice calls and send/receive SMS messages. The shield uses a radio modem [M10 by Quectel](https://www.arduino.cc/en/uploads/Main/Quectel_M10_datasheet.pdf). It is possible to communicate with the board using [AT commands](https://www.arduino.cc/en/uploads/Main/Quectel_M10_AT_commands.pdf"). The [GSM library](https://www.arduino.cc/en/Reference/GSM) has a large number of methods for communication with the shield.

--- a/content/retired/02.shields/arduino-gsm-shield/content.md
+++ b/content/retired/02.shields/arduino-gsm-shield/content.md
@@ -6,6 +6,8 @@ sku: "A000043"
 source: "https://store.arduino.cc/arduino-gsm-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino GSM Shield](./assets/a000043_featured.jpg)
 
 The Arduino GSM Shield V1 connects your Arduino to the internet using the GPRS wireless network. Just plug this module onto your Arduino board, plug in a SIM card from an operator offering GPRS coverage and follow a few simple instructions to start controlling your world through the internet. You can also make/receive voice calls (you will need an external speaker and microphone circuit) and send/receive SMS messages.

--- a/content/retired/02.shields/arduino-lucky-shield/content.md
+++ b/content/retired/02.shields/arduino-lucky-shield/content.md
@@ -6,6 +6,8 @@ sku: "A000125"
 source: "https://store.arduino.cc/arduino-lucky-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Lucky Shield](./assets/A000125_featured_2.jpg)
 
 Arduino Lucky Shield is an easy way to use your Arduino boards, that grants you access to barometric pressure, relative altitude, luminosity, temperature, motion and presence. You can also turn it into a simple controller and OLED (organic light-emitting diode) display system. It is the perfect shield for IoT.

--- a/content/retired/02.shields/arduino-usb-host-shield/content.md
+++ b/content/retired/02.shields/arduino-usb-host-shield/content.md
@@ -6,6 +6,8 @@ sku: "A000004"
 source: "https://store.arduino.cc/arduino-usb-host-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino USB Host Shield](./assets/a000004_featured.jpg)
 
 The **Arduino USB Host Shield** allows you to connect a USB device to your Arduino board. The Arduino USB Host Shield is based on the MAX3421E ([datasheet](http://www.maximintegrated.com/datasheet/index.mvp/id/3639)), which is a USB peripheral/host controller containing the digital logic and analog circuitry necessary to implement a full-speed USB peripheral or a full-/low-speed host compliant to USB specification rev 2.0\. The shield is TinkerKit compatible, which means you can quickly create projects by plugging TinkerKit modules onto the board.

--- a/content/retired/02.shields/arduino-wifi-shield-101/content.md
+++ b/content/retired/02.shields/arduino-wifi-shield-101/content.md
@@ -7,6 +7,8 @@ sku: "ASX00001"
 source: "https://store.arduino.cc/arduino-wifi-101-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino WiFi Shield 101](./assets/store_asx00001_featured.jpg)
 
 **Arduino WiFi Shield 101** is a powerful IoT shield with crypto-authentication, developed with[ ATMEL](http://www.atmel.com/), that connects your Arduino or Genuino board to the internet wirelessly. Connecting it to a WiFi network is simple, no further configuration in addition to the SSID and the password are required. The WiFi 101 Shield comes with an [easy-to-use library](https://www.arduino.cc/en/Reference/WiFi101) that allows to connect your Arduino or Genuino board to the internet with few instructions. As always, every element of the platform – hardware, software and documentation – are freely available and open-source. This means that you can learn exactly how it's made and use its design as the starting point for your own projects.

--- a/content/retired/02.shields/arduino-wifi-shield/content.md
+++ b/content/retired/02.shields/arduino-wifi-shield/content.md
@@ -6,6 +6,8 @@ sku: "A000058"
 source: "https://store.arduino.cc/arduino-wifi-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino WiFi Shield](./assets/store_a000058_featured.jpg)
 
 The **Arduino WiFi Shield** connects your Arduino to the internet wirelessly. Connect it to your wireless network by following a few simple instructions to start controlling your world through the internet. As always with Arduino, every element of the platform – hardware, software and documentation – is freely available and open-source. This means you can learn exactly how it's made and use its design as the starting point for your own circuits.

--- a/content/retired/02.shields/arduino-wireless-proto-shield/content.md
+++ b/content/retired/02.shields/arduino-wireless-proto-shield/content.md
@@ -6,6 +6,8 @@ sku: "A000064"
 source: "https://store.arduino.cc/arduino-wireless-proto-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Wireless Proto Shield](./assets/A000064_featured_2.jpg)
 
 The **Arduino Wireless Proto Shield** allows an Arduino board to communicate wirelessly using a wireless module. It is based on the [Xbee modules from Digi](http://www.digi.com/products/wireless-wired-embedded-solutions/zigbee-rf-modules/zigbee-mesh-module/xbee-zb-module), but can use any module with the same footprint. The module can communicate up to 100 feet indoors or 300 feet outdoors (with line-of-sight). It can be used as a serial/usb replacement or you can put it into a command mode and configure it for a variety of broadcast and mesh networking options. The shields breaks out each of the Xbee's pins to a through-hole solder pad.

--- a/content/retired/02.shields/arduino-wireless-sd-shield/content.md
+++ b/content/retired/02.shields/arduino-wireless-sd-shield/content.md
@@ -7,6 +7,8 @@ sku: "A000065"
 source: "https://store.arduino.cc/arduino-wireless-sd-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Wireless SD Shield](./assets/A000065_featured_2.jpg)
 
 The **Arduino Wireless SD Shield** allows an Arduino board to communicate wirelessly using a wireless module. It is based on the [Xbee modules from Digi](http://www.digi.com/products/wireless-wired-embedded-solutions/zigbee-rf-modules/zigbee-mesh-module/xbee-zb-module), but can use any module with the same footprint. The module can communicate up to 100 feet indoors or 300 feet outdoors (with line-of-sight). It can be used as a serial/usb replacement or you can put it into a command mode and configure it for a variety of broadcast and mesh networking options. The shields breaks out each of the Xbee's pins to a through-hole solder pad.

--- a/content/retired/02.shields/arduino-xbee-shield/content.md
+++ b/content/retired/02.shields/arduino-xbee-shield/content.md
@@ -3,6 +3,8 @@ title: "Arduino Xbee Shield"
 source: "https://arduino.cc/en/Main/ArduinoXbeeShield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ## Arduino Xbee Shield
 
 ### Overview

--- a/content/retired/02.shields/genuino-yun-shield/content.md
+++ b/content/retired/02.shields/genuino-yun-shield/content.md
@@ -7,6 +7,8 @@ sku: "GSX00102"
 source: "https://store.arduino.cc/genuino-yun-shield"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Yún Shield](./assets/GSX00102_featured_2.jpg)
 
 The **Arduino Yún Shield** extends your Arduino & Genuino board with the power of a Linux based system that enables advanced network connections and applications.  

--- a/content/retired/03.kits/arduino-basic-kit/content.md
+++ b/content/retired/03.kits/arduino-basic-kit/content.md
@@ -6,9 +6,11 @@ sku: "AKX00001"
 source: "https://store.arduino.cc/arduino-basic-kit"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Basic Kit](./assets/store_akx00001_featured.jpg)
 
-This kit includes all the components you need to build simple projects and learn how to turn an idea into reality using Arduino. Arduino Basic Kit has been developed in collaboration with Autodesk. When you purchase the kit you will receive [online access to 15 step-by-step tutorials](http://projectignite.autodesk.com/arduino) to make simple projects using components that let you control the physical world through different kinds of sensors and actuators.
+This kit includes all the components you need to build simple projects and learn how to turn an idea into reality using Arduino. Arduino Basic Kit has been developed in collaboration with Autodesk. When you purchase the kit you will receive [online access to 15 step-by-step tutorials](http://projectignite.autodesk.com/arduino) to make simple projects using components that let you control the physical world through different kinds of sensors and actuators.
 
 Once you have mastered this knowledge, you will have a palette of code and circuits to create something beautiful and useful. So build, hack and share!
 

--- a/content/retired/03.kits/arduino-engineering-kit/content.md
+++ b/content/retired/03.kits/arduino-engineering-kit/content.md
@@ -6,9 +6,11 @@ sku: "AKX00004"
 source: "https://store.arduino.cc/arduino-engineering-kit"
 ---
 
+***Note: This page refers to a product that is retired. It has been replaced by the [**Arduino Engineering Kit Rev2**](https://store.arduino.cc/engineering-kit-r2).***
+
 ![The Arduino Engineering Kit](./assets/engineering_kit_featured_1.jpg)
 
-This product is retired and has been replaced by the [**Arduino Engineering Kit Rev2**](https://store.arduino.cc/engineering-kit-r2).
+This product is retired and 
 
 Challenge engineering students and help them develop engineering skills with the Arduino Engineering Kit. The kit is a practical, hands-on tool that demonstrates key engineering concepts, core aspects of mechatronics, and MATLAB and Simulink programming. Ideal for advanced high school and college students, it includes three projects to teach the basics of modeling, controls, image processing, robotics, signal processing, and more. 
 

--- a/content/retired/03.kits/arduino-on-android-kit/content.md
+++ b/content/retired/03.kits/arduino-on-android-kit/content.md
@@ -3,6 +3,8 @@ title: "Arduino On Android Kit"
 source: "https://arduino.cc/en/Main/ArduinoOnAndroidKit"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 Use your **Arduino MEGA ADK (usb cable included)** to connect an Android device. Mount all your experiments on the **breadboard** and join your components using your **wire kit**. Build visual indicators using some of the **40 LEDs** in the kit; you have them in **4 different colors**. 
 
 Build your own physical controller to your phone using some **potentiometers (you get a total of 10)**. Make a simple robot using **2 continuous rotation servo motors**. Measure the amount of light using some of the **5 light sensors** included. Display texts and small graphics on the **2 bicolor dot matrix LED display (32x16 LEDs)**. Control your physical world with a **relay module (wires included)**. 

--- a/content/retired/03.kits/arduino-proto-extension-kit/content.md
+++ b/content/retired/03.kits/arduino-proto-extension-kit/content.md
@@ -6,6 +6,8 @@ sku: "K000083"
 source: "https://store.arduino.cc/arduino-proto-extension-kit"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Proto Extension Kit](./assets/a000083_iso.jpg)
 
 ### Features & Benefits of the Proto Shield

--- a/content/retired/03.kits/shield-mega-proto-kit-rev3/content.md
+++ b/content/retired/03.kits/shield-mega-proto-kit-rev3/content.md
@@ -6,6 +6,8 @@ sku: "A000081"
 source: "https://store.arduino.cc/shield-mega-proto-kit-rev3"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Shield - MEGA Proto Kit Rev3 ](assets/a000081_top.jpg)
 
 Base kit to extend your Arduino MEGA with your own wired circuit. The kit is composed from: 

--- a/content/retired/04.other/arduino-lcd-screen/content.md
+++ b/content/retired/04.other/arduino-lcd-screen/content.md
@@ -6,6 +6,8 @@ sku: "A000096"
 source: "https://store.arduino.cc/arduino-lcd-screen"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino LCD Screen](./assets/A000096_featured_2.png)
 
 The Arduino LSD screen is a backlit LCD screen with headers. You can draw text, images, and shapes to the screen with the [TFT library](https://www.arduino.cc/en/Reference/TFTLibrary). There is an onboard micro-SD card slot on the back of the screen that can, among other things, store bitmap images for the screen to display.

--- a/content/retired/04.other/arduino-materia-101-assembled/content.md
+++ b/content/retired/04.other/arduino-materia-101-assembled/content.md
@@ -6,6 +6,8 @@ sku: "3DP0002"
 source: "https://store.arduino.cc/arduino-materia-101-assembled"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Materia 101 assembled](./assets/3dp0002_iso.jpg)
 
 **Arduino Materia 101** is the first official Arduino 3D printer. It uses an Arduino Mega2560 with a shield specifically made for controlling 3D printers. It's a small machine, with a sheet metal design housing the moving parts. The design is straightforward and easy to understand, which makes it a good machine for beginners, or up-and-coming hardware hackers who want to improve and experiment.  

--- a/content/retired/04.other/arduino-older-boards/content.md
+++ b/content/retired/04.other/arduino-older-boards/content.md
@@ -3,6 +3,8 @@ title: "Arduino Older Boards"
 source: "https://arduino.cc/en/Main/Boards"
 ---
 
+***Note: This page refers to products that are retired.***
+
 ## Arduino USB
 
 ### ARDUINO UNO

--- a/content/retired/04.other/arduino-robot/content.md
+++ b/content/retired/04.other/arduino-robot/content.md
@@ -7,6 +7,8 @@ sku: "A000078"
 source: "https://store.arduino.cc/arduino-robot"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino Robot](./assets/store_a000078_iso.jpg)
 
 The **Arduino Robot** is the first official Arduino on wheels. The robot has two processors, one on each of its two boards. The *Motor Board* controls the motors, and the *Control Board* reads sensors and decides how to operate. Each of the boards is a full Arduino board programmable using the Arduino IDE.

--- a/content/retired/04.other/getting-started-with-arduino/content.md
+++ b/content/retired/04.other/getting-started-with-arduino/content.md
@@ -7,13 +7,9 @@ sku: "B000001"
 source: "https://store.arduino.cc/product/B000001"
 ---
 
+***Note: This page refers to a product that is retired.This can no longer be bought from us.***
+
 ![](./assets/B000001_Featured.jpg)
-
-***Note: A fourth version of the book is planned for 2022!***
-
-
-
-**This version is a retired product and can no longer be bought from us.**
 
 This edition thorough introduction gives you lots of ideas for projects and helps you work with them right away!
 

--- a/content/retired/04.other/hardware-pictures/content.md
+++ b/content/retired/04.other/hardware-pictures/content.md
@@ -3,6 +3,8 @@ title: "Retired products - Hardware"
 source: "https://arduino.cc/en/Main/HardwarePictures"
 ---
 
+***Note: This page refers to products that are retired.***
+
 There are multiple versions of the Arduino board. The current basic board, the Duemilanove, uses the Atmel ATmega328 ([datasheet](http://www.atmel.com/dyn/resources/prod%5Fdocuments/doc8161.pdf)). The older Diecimila, and the first run of Duemilanoves used the Atmel ATmega168 ([datasheet](http://www.atmel.com/dyn/resources/prod%5Fdocuments/doc2545.pdf)), while older boards use the ATmega8 ([datasheet](http://www.atmel.com/dyn/resources/prod%5Fdocuments/doc2486.pdf)). The Arduino Mega is based on the ATmega1280 ([datasheet](http://www.atmel.com/dyn/resources/prod%5Fdocuments/doc2549.pdf)). 
 
 Note: The reference designs for arduino are distributed under a Creative Commons license [Attribution-ShareAlike 2.5](http://creativecommons.org/licenses/by-sa/2.5/). See [So you want to make an Arduino?](//www.arduino.cc/en/Main/Policy) for more information and guidelines on producing your own hardware.

--- a/content/retired/04.other/usb-serial-converter/content.md
+++ b/content/retired/04.other/usb-serial-converter/content.md
@@ -6,6 +6,8 @@ sku: "A000014"
 source: "https://store.arduino.cc/usb-serial-converter"
 ---
 
+***Note: This page refers to a product that is retired.***
+
 ![The Arduino USB/Serial Converter](assets/a000014_featured.jpg)
 
 This board converts a **USB connection** to the 5V TX and RX an Arduino requires for communication. You can connect straight to the Arduino Mini or other microcontrollers, allowing them to talk to the computer.  


### PR DESCRIPTION
## What This PR Changes
- Added a note to all the retired products in the Retired Documentation section. This way it is more clear that the product is retired and can no longer be bought from us.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
