### PR TITLE
[GIGA] USB Keyboard Example fix

### DIFF
--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-usb/giga-usb.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-usb/giga-usb.md
@@ -432,33 +432,42 @@ After logging data, remove the USB stick from your board, and insert it in your 
 
 It is possible to connect generic USB keyboards to the GIGA R1's USB-A connector without any additional circuitry. 
 
-The library used for this can be downloaded through Github.
+The library used for this can be downloaded through Github. 
 - [USBHostGiga](https://github.com/arduino-libraries/USBHostGiga)
+
+Please note that this library is in **Alpha** development stage. This means support is experimental and examples may not function as expected. Future versions of this library may break the example provided below. 
 
 ***The USBHostGiga library is not available in the Arduino IDE and needs to be installed manually. You can do so my navigating to `Sketch` > `Include Library` > `Add .ZIP Library`.***
 
 ```arduino
-#include "HIDHost.h"
+#include "USBHostGiga.h"
 
-Keyboard keyb; //create object
+//REDIRECT_STDOUT_TO(Serial)
+Keyboard keyb;
+HostSerial ser;
 
 void setup() {
   // put your setup code here, to run once:
   Serial.begin(115200);
   while (!Serial);
-  pinMode(PA_15, OUTPUT); //enable the USB-A port //enable the USB-A connector
-  keyb.begin(); //init the library
+  pinMode(PA_15, OUTPUT);
+  keyb.begin();
+  ser.begin();
 }
 
 
 void loop() {
   if (keyb.available()) {
-    Serial.println(keyb.read()); //print any incoming character
+    auto _key = keyb.read();
+    Serial.println(keyb.getAscii(_key));
   }
+  while (ser.available()) {
+    auto _char = ser.read();
+    Serial.write(_char);
+  }
+  //delay(1);
 }
 ```
-
-***Please note that he `PA15` pin must be configured as an `OUTPUT`.***
 
 ## USB HID
 


### PR DESCRIPTION
Updated keyboard host example that was broken in the GIGA USB guide.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
