### PR TITLE
Dimensions numbers fix.

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/enclosure-kit/tech-specs.yml
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/enclosure-kit/tech-specs.yml
@@ -9,9 +9,9 @@ Operating Temperatures:
   Max: 85º C (185º F)
 Weight: 165 g
 Dimensions:
-  Width: 11 mm
-  Length: 9 mm
-  Height: 6 mm
+  Width: 110 mm
+  Length: 90 mm
+  Height: 60 mm
 Included components:
   Breakout:
     LCD:


### PR DESCRIPTION


## What This PR Changes
- 11x9x6 millimeters can't be, I took the real dimensions from here https://www.mouser.do/datasheet/2/34/Arduino_9_8_2022_Product_Brif___Arduino_Edge_Contr-3011342.pdf

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
