### PR TITLE
Add delay() in plotter examples

### DIFF
--- a/content/software/ide-v2/tutorials/ide-v2-serial-plotter/ide-v2-serial-plotter.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-plotter/ide-v2-serial-plotter.md
@@ -59,6 +59,8 @@ void loop() {
   Serial.print(",");
   Serial.print("Variable_2:");
   Serial.println(static_variable);
+
+  delay(20);
 }
 ```
 
@@ -83,6 +85,8 @@ void loop() {
   Serial.print(",");
   Serial.print("Variable_2:");
   Serial.println(static_variable);
+
+  delay(20);
 }
 ```
 ***The Serial Plotter recognizes only CRLF`(\r\n)` & LF`(\n)` as linebreak characters. So ensure that the either there is a linebreak character after the last variable. You can use `Serial.print("\n")` or `Serial.print("\r\n")` to introduce a linebreak character at the end. Conversely, `Serial.println()` introduces a CRLF character automatically. Further, you can also use `\t`(tab) or ` `(space) as a delimiter instead of `,`(comma) in the above example.***


### PR DESCRIPTION
## What This PR Changes
This PR adds `delay()` in the examples of `software/ide-v2/tutorials/ide-v2-serial-plotter` 
The original examples doesn't have `delay()` in the `loop()`, which is fine for the boards with hardware serial ports. The baudrate (9600) limits the data speed.
![normal](https://docs.arduino.cc/14cb1a81430656c7ae945f10c0f4e32c/random_plotter.gif)
However, for boards with USB serial port, the baudrate doesn't take affect. The board will send data to the PC at the maximum speed.
![too_fast](https://github.com/arduino/docs-content/assets/62299611/7bb7d7f8-c60f-4933-8a1c-332ad884825b)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
