### PR TITLE
Get Started button link updated

### DIFF
--- a/content/hardware/06.nicla/boards/nicla-voice/product.md
+++ b/content/hardware/06.nicla/boards/nicla-voice/product.md
@@ -1,7 +1,7 @@
 ---
 title: Nicla Voice
 url_shop: https://store.arduino.cc/nicla-voice
-url_guide: /software/ide-v1/tutorials/getting-started/cores/arduino-mbed_nicla
+url_guide: /tutorials/nicla-voice/user-manual
 core: arduino:mbed_voice
 productCode: 'ABX00061'
 certifications: [CE]


### PR DESCRIPTION
## What This PR Changes
- In the [Nicla Voice product section](https://docs.arduino.cc/hardware/nicla-voice), I updated the "Get Started" button redirection address to the [Nicla Voice User Manual](https://docs.arduino.cc/tutorials/nicla-voice/user-manual)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
