### PR TITLE
[GIGA-R1-WiFi] Update guide link

### DIFF
--- a/content/hardware/10.mega/boards/giga-r1-wifi/product.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/product.md
@@ -2,7 +2,6 @@
 title: GIGA R1 WiFi
 url_shop: https://store.arduino.cc/giga-r1-wifi
 url_guide: /tutorials/giga-r1-wifi/giga-getting-started
-core: arduino:mbed_giga
 ---
 
 The **GIGA R1 WiFi** is a powerful, feature-packed board with a large amount of GPIOs and dedicated connectors. Based on the [STM32H747XI](/resources/datasheets/stm32h747xi.pdf) micro based on the [Mbed OS](https://os.mbed.com/), the GIGA R1 WiFi features 76 GPIOs, a [dual core processor](/tutorials/giga-r1-wifi/giga-dual-core), [advanced ADC/DAC](/tutorials/giga-r1-wifi/giga-audio) features as well as camera & display connectors. It also has a rich [USB interface](/tutorials/giga-r1-wifi/giga-usb) with support for HID via USB-C and USBHost (keyboard, mass storage) via a dedicated USB-A connector.


### PR DESCRIPTION
the product template always choose the "core" over "url_guide" as default. Since no mbed_giga tutorial exist (this is an IDE 1 specific implementation), it is empty and redirects back to the top of the product page.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
