### PR TITLE
Update content.md

### DIFF
--- a/content/hardware/06.nicla/boards/nicla-vision/tutorials/image-classification/content.md
+++ b/content/hardware/06.nicla/boards/nicla-vision/tutorials/image-classification/content.md
@@ -143,7 +143,7 @@ The ML model is trained and already optimized to be used with microcontrollers. 
 
 ### Deploy
 
-Deploying the ML model to your board requires a few steps. The Edge Impulse® Studio provides an export feature for OpenMV. Switch to the deployment section in the menu, select OpenMV under "Build firmware" and click "build". This will create an OpenMV compatible library and download it as a zip file. Unzip it.
+Deploying the ML model to your board requires a few steps. The Edge Impulse® Studio provides an export feature for OpenMV. Switch to the deployment section in the menu, select OpenMV under "Create Library" and click "build". This will create an OpenMV compatible library and download it as a zip file. Unzip it.
 
 ![The Edge Impulse® Studio has a built-in export function for OpenMV](assets/deployment.png)
 


### PR DESCRIPTION
Under the Deploy heading, the trained model is being created as a library option, not firmware. Because later in the following steps, it is the library that is created by EdgeImpulse that is being implemented into the forked firmware at OpenMV github. Thank you.

## What This PR Changes
Under the Using the ML Model > Deploy heading on this page, the third sentence reads, '...OpenMV under "Build firmware" and click "build"', which I think needs to state '...OpenMV under "Create Library" and click "build"'. Because in the following steps on this page, it is the exported library from Edge Impulse that is being integrated to a new firmware build on OpenMV github. Now, EdgeImpulse does provide the option to create a firmware as well, but that is not the method that is followed here if I am understanding right. Thank you.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
