### PR TITLE
Update Wikipedia link for RC servos

### DIFF
--- a/content/learn/04.electronics/05.servo-motors/servo-motors.md
+++ b/content/learn/04.electronics/05.servo-motors/servo-motors.md
@@ -7,7 +7,7 @@ author: Arduino
 
 The [Servo Library](https://www.arduino.cc/reference/en/libraries/servo/) is a great library for controlling servo motors. In this article, you will find two easy examples that can be used by any Arduino board.
 
-The first example controls the position of a RC (hobby) [servo motor](http://en.wikipedia.org/wiki/Servo_motor#RC_servos) with your Arduino and a potentiometer. The second example sweeps the shaft of a RC [servo motor](http://en.wikipedia.org/wiki/Servo_motor#RC_servos) back and forth across 180 degrees.
+The first example controls the position of a RC (hobby) [servo motor](https://en.wikipedia.org/wiki/Servo_(radio_control)) with your Arduino and a potentiometer. The second example sweeps the shaft of a RC [servo motor](https://en.wikipedia.org/wiki/Servo_(radio_control)) back and forth across 180 degrees.
 
 You can also visit the [Servo GitHub repository](https://github.com/arduino-libraries/Servo) to learn more about this library.
 


### PR DESCRIPTION
## What This PR Changes
- The content about RC servos was moved to [a different Wikipedia article](https://en.wikipedia.org/wiki/Servo_(radio_control)), so I've updated the link accordingly.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
