### PR TITLE
Adds a voltage specification for the RTC pin 

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
@@ -263,7 +263,10 @@ To learn more about the DAC capabilities of the UNO R4 WiFi, check out the [DAC 
 
 ## RTC
 
+
 A real-time clock (RTC) is used to measure the time, and is useful in any time-tracking applications.
+
+The UNO R4 WiFi features a VRTC pin, that is used to keep the onboard RTC running, even when the board is turned off. In order to use this, apply a voltage in the range of 1.6 - 3.6 V to the VRTC pin.
 
 Below is a minimal example that shows how to obtain the date and time from the RTC:
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
@@ -266,7 +266,7 @@ To learn more about the DAC capabilities of the UNO R4 WiFi, check out the [DAC 
 
 A real-time clock (RTC) is used to measure the time, and is useful in any time-tracking applications.
 
-The UNO R4 WiFi features a VRTC pin, that is used to keep the onboard RTC running, even when the board is turned off. In order to use this, apply a voltage in the range of 1.6 - 3.6 V to the VRTC pin.
+***The UNO R4 WiFi features a VRTC pin, that is used to keep the onboard RTC running, even when the boards power supply is is cut off. In order to use this, apply a voltage in the range of 1.6 - 3.6 V to the VRTC pin.***
 
 Below is a minimal example that shows how to obtain the date and time from the RTC:
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
@@ -27,7 +27,7 @@ The goals of this project are:
 
 The RTC on the UNO R4 WiFi can be accessed using the [RTC](https://github.com/arduino/ArduinoCore-renesas/tree/main/libraries/RTC) library that is included in the [Renesas](https://github.com/arduino/ArduinoCore-renesas) core. This library allows you to set/get the time as well as using alarms to trigger interrupts. 
 
-The UNO R4 WiFi features a VRTC pin, that is used to keep the onboard RTC running, even when the board is turned off. In order to use this, apply a voltage in the range of 1.6 - 3.6 V to the VRTC pin.
+***The UNO R4 WiFi features a VRTC pin, that is used to keep the onboard RTC running, even when the boards power supply is is cut off. In order to use this, apply a voltage in the range of 1.6 - 3.6 V to the VRTC pin.***
 
 There are many practical examples using an RTC, and the examples provided in this page will help you get started with it.
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
@@ -27,6 +27,8 @@ The goals of this project are:
 
 The RTC on the UNO R4 WiFi can be accessed using the [RTC](https://github.com/arduino/ArduinoCore-renesas/tree/main/libraries/RTC) library that is included in the [Renesas](https://github.com/arduino/ArduinoCore-renesas) core. This library allows you to set/get the time as well as using alarms to trigger interrupts. 
 
+The UNO R4 WiFi features a VRTC pin, that is used to keep the onboard RTC running, even when the board is turned off. In order to use this, apply a voltage in the range of 1.6 - 3.6 V to the VRTC pin.
+
 There are many practical examples using an RTC, and the examples provided in this page will help you get started with it.
 
 ### Set Time


### PR DESCRIPTION

## What This PR Changes
Adds a paragraph in the RTC Guide and in the cheat sheet about how to use the UNO R4 WiFi's VRTC pin.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
