### PR TITLE
Fix 14-bit ADC value range

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/adc-resolution/adc-resolution.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/adc-resolution/adc-resolution.md
@@ -7,7 +7,7 @@ tags:
 author: 'Karl Söderby'
 ---
 
-In this tutorial you will learn how to change the analog-to-digital converter (ADC) on an **Arduino UNO R4 WiFi** board. By default, the resolution is set to 10-bit, which can be updated to both 12-bit (0-4096) and 14-bit (0-65355) resolutions for improved accuracy on analog readings.
+In this tutorial you will learn how to change the analog-to-digital converter (ADC) on an **Arduino UNO R4 WiFi** board. By default, the resolution is set to 10-bit, which can be updated to both 12-bit (0-4096) and 14-bit (0-16383) resolutions for improved accuracy on analog readings.
 
 ## Goals
 
@@ -35,7 +35,7 @@ void setup(){
 }
 
 void loop(){
-  int reading = analogRead(A3); // returns a value between 0-65355
+  int reading = analogRead(A3); // returns a value between 0-16383
 }
 ```
 


### PR DESCRIPTION
14-bit ADC gives 16384 steps i.e. 0-16383.

## What This PR Changes
- Sets the correct value range for 14-bit ADC in ADC Resolution tutorials for UNO R4 WiFi and UNO R4 Minima.
- 14-bit ADC gives 16384 steps i.e. 0-16383.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
