### PR TITLE
Capitalise mention of MKR THERM library

### DIFF
--- a/content/hardware/01.mkr/02.shields/mkr-therm-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-therm-shield/product.md
@@ -7,4 +7,4 @@ certifications: [CE]
 
 The MKR Therm Shield is a great addon for MKR family boards, and allows you to connect high quality thermocouplers, and can calculate temperatures from -200 °C to +700 °C. An ideal solution to use for ovens, freezers, smokers and similar environments.
 
-To use this shield, you can refer to the documentation of the [MKR therm library](https://www.arduino.cc/reference/en/libraries/arduino_mkrtherm/).
+To use this shield, you can refer to the documentation of the [Arduino MKR THERM library](https://www.arduino.cc/reference/en/libraries/arduino_mkrtherm/).


### PR DESCRIPTION
## What This PR Changes
- When mentioning the library, change Therm to THERM in line with the correct usage of the board name

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
