### PR TITLE
Fix wrong pin name

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/cheat-sheet/cheat-sheet.md
@@ -275,12 +275,12 @@ If you want to read more about the EEPROM check out [this article about Arduino 
 
 The UNO R4 Minima features a Serial Peripheral Interface (SPI) bus. The bus (connector), ‘SPI’ uses the following pins:
 
-| Pin  | Type | 
-| ---- | ---- | 
-| D13  | SCK  |
-| D12  | CIP  |
-| D11  | COP  |
-| D10  | CS   |
+| Pin  | Type  | 
+| ---- | ----- | 
+| D13  | SCK   |
+| D12  | CIPO  |
+| D11  | COPI  |
+| D10  | CS    |
 
 The following example shows how to use SPI:
 


### PR DESCRIPTION
## What This PR Changes
This PR fixes a typo in the SPI pin section in the Arduino UNO R4 Minima Cheat Sheet.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.