### PR TITLE
Create functions above setup/loop

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/flash-optimized-key-value-store/content.md
@@ -242,7 +242,7 @@ Now that you have everything ready, let's retrieve the previous values from the 
 }
 ```
 
-To finish the sketch, create `getSketchStats` and `setSketchStats` functions at the bottom of the sketch (after the `setup()` and `loop()`). 
+To finish the sketch, create `getSketchStats` and `setSketchStats` functions above `setup()` and `loop()`. 
 
 The `getSketchStats` function tries to retrieve the stats values stored in the Flash using the key `key` and returns them via the `stats` pointer parameter. Our `SketchStats` data struct is very simple and has a fixed size. You can therefore deserialize the buffer with a simple `memcpy`.
 


### PR DESCRIPTION
setSketchStats and getSketchStats were not prototyped, so their definitions should go above setup/loop.

## What This PR Changes
This changes the explanation of where to place the `getSketchStats` and `setSketchStats` functions in the Portenta Key-Value pair flash storage example. These two functions were not prototyped earlier in the example firmware, so users would get a "not declared in this scope" error if the instructions were followed to the letter.

This could also be resolved by adding prototypes for the two functions in one of the earlier code snippets.

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
