### PR TITLE
Update string title and array source to fix type definition in docs

### DIFF
--- a/content/hardware/_unlisted/boards/101/product.md
+++ b/content/hardware/_unlisted/boards/101/product.md
@@ -1,4 +1,4 @@
 ---
-title: 101
+title: "101"
 certifications: [CE]
 ---

--- a/content/learn/03.programming/10.audio/audio.md
+++ b/content/learn/03.programming/10.audio/audio.md
@@ -1,14 +1,6 @@
 ---
 title: "Audio Basics with Arduino"
 description: "Learn how to create tones and even entire songs using an Arduino."
-source:
-  [
-    "https://playground.arduino.cc/Main/Freqout/",
-    "https://playground.arduino.cc/Code/MusicalAlgoFun/",
-    "https://playground.arduino.cc/Code/PCMAudio/",
-    "https://playground.arduino.cc/Main/RickRoll/",
-    "https://playground.arduino.cc/Main/Smoothstep/",
-  ]
 author: "Paul Badger, Alexandre Quessy, Michael Smith, Samantha Lagestee, Dan Thompson"
 ---
 


### PR DESCRIPTION
## What This PR Changes
Developing docs 2.0.0 we found some inconsistency with type definition for **title** and **source** frontmatter:
- Title should be a string, in one case we have a number;
- Source it's unused in docs (i guess), but anyway we managed it as a string. We have one case where we have an array.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
