### PR TITLE
Correct `arduino-iot-cloud` package name in installation command

### DIFF
--- a/content/arduino-cloud/01.getting-started/10.manual-device/manual-devices.md
+++ b/content/arduino-cloud/01.getting-started/10.manual-device/manual-devices.md
@@ -148,7 +148,7 @@ The pre-requisities for connecting with Python is:
 Connection to the cloud via Python uses the same API as the MicroPython example listed in this article. To install the [arduino-iot-cloud-py](https://github.com/arduino/arduino-iot-cloud-py) module, we can use `pip`.
 
 ```py
-pip install arduino-iot-cloud-py
+pip install arduino-iot-cloud
 ```
 
 You will also need to have configured a manual device in the cloud. The **Device ID** and **Secret Key** are required in your script to authenticate. To connect, we use the following command:


### PR DESCRIPTION
Arduino provides [an Arduino IoT Cloud client Python package](https://github.com/arduino/arduino-iot-cloud-py) to allow interfacing with Arduino IoT Cloud objects from a Python script.

The documentation for the package includes a command that can be used to install the package on the host PC. Previously, the command used an incorrect name for the package, which caused the command to fail:

```
$ pip install arduino-iot-cloud-py
ERROR: Could not find a version that satisfies the requirement arduino-iot-cloud-py (from versions: none)
ERROR: No matching distribution found for arduino-iot-cloud-py
```


## What This PR Changes

Correct the package name in the installation command:

https://pypi.org/project/arduino-iot-cloud/

```toml
pip install arduino-iot-cloud
```

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.

## Additional Context

Originally reported at:

- https://forum.arduino.cc/t/connect-python-javascript-and-micropython-based-devices-to-arduino-cloud/1137831
- https://forum.arduino.cc/t/problems-loading-arduino-iot-cloud-py-package-for-manual-device-configuration/1148306