### PR TITLE
Fix to show the `Alarm-clock.png` image in MicroPython tutorial

### DIFF
--- a/content/micropython-course/projects/alarm-clock/alarm-clock-project.md
+++ b/content/micropython-course/projects/alarm-clock/alarm-clock-project.md
@@ -23,7 +23,7 @@ You will need the following to build this project:
 
 Assemble the components according to the circuit diagram below:
 
-![Circuit for the alarm clock](assets/alarm-clock.png)
+![Circuit for the alarm clock](assets/Alarm-clock.png)
 
 ## Code
 


### PR DESCRIPTION
The image for `Alarm-clock.png` is not displayed in the [Alarm Clock tutorial for MicroPython](https://docs.arduino.cc/micropython-course/projects/alarm-clock). This PR fixes this problem
![bild](https://github.com/arduino/docs-content/assets/75624145/05f41d23-f067-41bc-b503-ed9723b215f5)

## What This PR Changes
- Change `alarm-clock.png` to `Alarm-clock.png` in the markdown file so that it is displayed correctly https://github.com/arduino/docs-content/blob/7a0fa59fae2f4a2181988d224f0875d9e063cdca/content/micropython-course/projects/alarm-clock/alarm-clock-project.md?plain=1#L26

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
