### PR TITLE
Fix to show the `Temperature-light.png` image in MicroPython tutorial

### DIFF
--- a/content/micropython-course/projects/temperature-display/temperature-display-project.md
+++ b/content/micropython-course/projects/temperature-display/temperature-display-project.md
@@ -22,7 +22,7 @@ You will need the following to build this project:
 
 Assemble the components according to the circuit diagram below:
 
-![Circuit for the temperature display](assets/temperature-light.png)
+![Circuit for the temperature display](assets/Temperature-light.png)
 
 ## Code
 


### PR DESCRIPTION
The image for `Temperature-light.png`  is not displayed in the [Temperature Display tutorial for MicroPython](https://docs.arduino.cc/micropython-course/projects/temperature-display). This PR fixes this problem

![bild](https://github.com/arduino/docs-content/assets/75624145/53c27641-9ae9-4cb0-966b-8896dde14849)


## What This PR Changes
- Change `temperature-light.png` to `Temperature-light.png` in the markdown file so that it is displayed correctly https://github.com/arduino/docs-content/blob/cfa61b1558cd00598f4966b73feb977ab01c58bb/content/micropython-course/projects/temperature-display/temperature-display-project.md?plain=1#L25
- 
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.

