### PR TITLE
Broken quickstart link nano esp32

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/essentials.md
+++ b/content/hardware/03.nano/boards/nano-esp32/essentials.md
@@ -1,5 +1,5 @@
 <EssentialsColumn title="First Steps">
-  <EssentialElement title="Quickstart Guide" type="getting-started" link="/software/ide-v1/tutorials/getting-started-nano-esp32">
+  <EssentialElement title="Quickstart Guide" type="getting-started" link="/tutorials/nano-esp32/getting-started-nano-esp32">
     All you need to know to get started with your new Arduino board.
   </EssentialElement>
 


### PR DESCRIPTION
## What This PR Changes
- Fixes a broken quickstart link on the product page 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
