### PR TITLE
Fix Cloud note in Nano ESP32 cheat sheet

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
@@ -67,9 +67,12 @@ In this course, you will fundamental knowledge to get started, as well as a larg
 ## Arduino IoT Cloud
 
 Nano ESP32 is supported in the [Arduino IoT Cloud](https://create.arduino.cc/iot/) platform. You can connect to the cloud either through "classic" Arduino, using the C++ library, or via MicroPython:
+
+***IoT Cloud support is coming August 2023***
+
 - [Getting Started with Arduino IoT Cloud (classic)](https://docs.arduino.cc/arduino-cloud/getting-started/iot-cloud-getting-started)
 - [MicroPython with Arduino IoT Cloud](https://docs.arduino.cc/arduino-cloud/getting-started/iot-cloud-micropython)
-***IoT Cloud support is coming August 2023***
+
 
 ## API
 


### PR DESCRIPTION
## What This PR Changes
- The IoT Cloud note in the Nano ESP32 cheat sheet looks weird. 
- This PR changes it 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
