### PR TITLE
[AE-121] Correct MKR Therm Shield SKU

### DIFF
--- a/content/hardware/01.mkr/02.shields/mkr-therm-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-therm-shield/tech-specs.yml
@@ -1,6 +1,6 @@
 Shield:
   Name: Arduino® MKR Therm Shield
-  SKU: ASX00005
+  SKU: ASX00012
   Compatibility: MKR
 Communication: SPI
 Digital converter: MAX31855


### PR DESCRIPTION
## What This PR Changes
- The MKR Therm Shield has an SKU of ASX00012 not ASX00005. Changed this in the `tech-specs.yml` file.
![image](https://github.com/arduino/docs-content/assets/75624145/ebfb8db2-2fe7-48b0-82bb-31ea0a6a48ea)

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
