### PR TITLE
[MKC-1066]Add Interrupts to UNO-R4 datasheets

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
@@ -365,6 +365,7 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 
 ## Change Log
 
-| **Date**   | **Changes** |
-| ---------- | ----------- |
-| 06/19/2023 | Release     |
+| **Date**   | **Changes**      |
+| ---------- | ---------------- |
+| 06/19/2023 | Release          |
+| 25/07/2023 | Update Pin Table |

--- a/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
@@ -365,7 +365,7 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 
 ## Change Log
 
-| **Date**   | **Changes**      |
-| ---------- | ---------------- |
-| 06/19/2023 | Release          |
-| 25/07/2023 | Update Pin Table |
+| Date       | **Revision** | **Changes**        |
+| ---------- | ------------ | ------------------ |
+| 25/07/2023 | 2            | Update Pin Table   |
+| 06/19/2023 | 1            | First Release      |

--- a/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
@@ -207,8 +207,8 @@ In case you need to power external devices that require more power, e.g. servo m
 | 12  | D6        | Digital | GPIO 6 (PWM~)                                    |
 | 13  | D5/CANRX0 | Digital | GPIO 5 (PWM~) / CAN Transmitter (TX)             |
 | 14  | D4/CANTX0 | Digital | GPIO 4 / CAN Receiver (RX)                       |
-| 15  | D3        | Digital | GPIO 3 (PWM~)                                    |
-| 16  | D2        | Digital | GPIO 2                                           |
+| 15  | D3        | Digital | GPIO 3 (PWM~) / Interrupt                        |
+| 16  | D2        | Digital | GPIO 2 / Interrupt                               |
 | 17  | D1/TX0    | Digital | GPIO 1 / Serial 0 Transmitter (TX)               |
 | 18  | D0/TX0    | Digital | GPIO 0 / Serial 0 Receiver    (RX)               |
 

--- a/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
@@ -207,8 +207,8 @@ In case you need to power external devices that require more power, e.g. servo m
 | 12  | D6        | Digital | GPIO 6 (PWM~)                                    |
 | 13  | D5/CANRX0 | Digital | GPIO 5 (PWM~) / CAN Transmitter (TX)             |
 | 14  | D4/CANTX0 | Digital | GPIO 4 / CAN Receiver (RX)                       |
-| 15  | D3        | Digital | GPIO 3 (PWM~) / Interrupt                        |
-| 16  | D2        | Digital | GPIO 2 / Interrupt                               |
+| 15  | D3        | Digital | GPIO 3 (PWM~) / Interrupt Pin                  |
+| 16  | D2        | Digital | GPIO 2 / Interrupt Pin                         |
 | 17  | D1/TX0    | Digital | GPIO 1 / Serial 0 Transmitter (TX)               |
 | 18  | D0/TX0    | Digital | GPIO 0 / Serial 0 Receiver    (RX)               |
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
@@ -322,8 +322,8 @@ For powering e.g. servo motors, always use an external power supply.
 | 12  | D6             | Digital | GPIO 6 (PWM~)                                          |
 | 13  | D5             | Digital | GPIO 5 (PWM~)                                          |
 | 14  | D4             | Digital | GPIO 4                                                 |
-| 15  | D3             | Digital | GPIO 3 (PWM~) / Interrupt                              |
-| 16  | D2             | Digital | GPIO 2 / Interrupt                                     |
+| 15  | D3             | Digital | GPIO 3 (PWM~) / Interrupt Pin                          |
+| 16  | D2             | Digital | GPIO 2 / Interrupt Pin                                 |
 | 17  | D1/TX0         | Digital | GPIO 1 / Serial 0 Transmitter (TX)                     |
 | 18  | D0/TX0         | Digital | GPIO 0 / Serial 0 Receiver    (RX)                     |
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
@@ -322,8 +322,8 @@ For powering e.g. servo motors, always use an external power supply.
 | 12  | D6             | Digital | GPIO 6 (PWM~)                                          |
 | 13  | D5             | Digital | GPIO 5 (PWM~)                                          |
 | 14  | D4             | Digital | GPIO 4                                                 |
-| 15  | D3             | Digital | GPIO 3 (PWM~)                                          |
-| 16  | D2             | Digital | GPIO 2                                                 |
+| 15  | D3             | Digital | GPIO 3 (PWM~) / Interrupt                              |
+| 16  | D2             | Digital | GPIO 2 / Interrupt                                     |
 | 17  | D1/TX0         | Digital | GPIO 1 / Serial 0 Transmitter (TX)                     |
 | 18  | D0/TX0         | Digital | GPIO 0 / Serial 0 Receiver    (RX)                     |
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
@@ -474,3 +474,4 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 | ---------- | ------------ | ------------------ |
 | 08/06/2023 | 1            | First Release      |
 | 30/06/2023 | 2            | Update Pinout File |
+| 25/07/2023 | 3            | Update Pin Table   |

--- a/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
@@ -472,6 +472,6 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 
 | Date       | **Revision** | **Changes**        |
 | ---------- | ------------ | ------------------ |
-| 08/06/2023 | 1            | First Release      |
-| 30/06/2023 | 2            | Update Pinout File |
 | 25/07/2023 | 3            | Update Pin Table   |
+| 30/06/2023 | 2            | Update Pinout File |
+| 08/06/2023 | 1            | First Release      |


### PR DESCRIPTION
## What This PR Changes
- Adds interrupt pins to UNO R4 Datasheets

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
