### PR TITLE
Correct pin numbers for Nano ESP32 LED

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
@@ -346,16 +346,16 @@ There are several examples provided bundled with the core that showcase how to m
 
 ## RGB
 
-The ESP32 features an RGB that can be controlled with the `0`, `45` and `46` GPIO. These are not connected to any physical pins. 
+The ESP32 features an RGB that can be controlled with the `LED_RED`, `LED_GREEN` and `LED_BLUE` pins. These are not connected to any physical pins. 
 
 ***Some boards from the first limited production batch were assembled with a different RGB LED which has the green and blue pins inverted. Read our full Help Center article [here](https://support.arduino.cc/hc/en-us/articles/9589073738012)***
 
 To control them, use:
 
 ```arduino
-digitalWrite(46, STATE); //red
-digitalWrite(45, STATE); //green
-digitalWrite(0, STATE); //blue
+digitalWrite(LED_RED, STATE); //red
+digitalWrite(LED_GREEN, STATE); //green
+digitalWrite(LED_BLUE, STATE); //blue
 ```
 
 


### PR DESCRIPTION
## What This PR Changes

Arduino pin numbers are an arbitrary numerical identifier for the I/O pins on the microcontroller. They are [mapped to the lower level identifier in the board's core variant](https://github.com/espressif/arduino-esp32/blob/2.0.11/variants/arduino_nano_nora/io_pin_remap.cpp#L5-L31). Generally, Arduino functions that take a pin number argument require that argument to be an Arduino pin number rather than some lower level identifier for the pin, and that is the case with the Arduino core functions for the Nano ESP32 board.

Previously, the documentation of the pins connected to the RGB LED on the Nano ESP32 board used the lower level ESP32 GPIO pin numbers in the digitalWrite calls in the code snippet. Since `digitalWrite` requires the use of an Arduino pin number, not a GPIO number, that code was wrong and did not control the RGB LED as claimed.

When correcting this error, I chose to use [the human friendly constants](https://github.com/espressif/arduino-esp32/blob/2.0.11/variants/arduino_nano_nora/pins_arduino.h#L38-L40) rather than the bare integer literals (14, 15, 16).

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.

## Additional Context

Originally reported at https://forum.arduino.cc/t/esp32u-code-problem-moisture-sensor-in-arduino-ide-ambient/1151663/3