### PR TITLE
Correct Zero tech specs table 

### DIFF
--- a/content/hardware/02.hero/boards/zero/tech-specs.yml
+++ b/content/hardware/02.hero/boards/zero/tech-specs.yml
@@ -8,7 +8,7 @@ Pins:
   Digital I/O Pins: 20
   Analog Input Pins: 6
   Analog Output Pins: 1 (DAC 10 bit)
-  PMW Pins: 13 (0 - 8, 10, 12, A3, A4)
+  PMW Pins: 3, 4, 5, 6, 8, 9, 10, 11, 12, 13
   External interrupts: All pins except pin 4
 Communication:
   UART: 2 (Native and Programming)


### PR DESCRIPTION
## What This PR Changes
- This PR aligns the PWM information on the Arduino Zero in the tech specs table with the information in pinout, store and core.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
