### PR TITLE
[MKC-1074] Remove Nano ESP32 cloud support note

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/features.md
+++ b/content/hardware/03.nano/boards/nano-esp32/features.md
@@ -11,8 +11,6 @@ Learn the basics of MicroPython with the Nano ESP32 and our free MicroPython 101
 
 <Feature title="Arduino IoT Cloud" image="wifi">
 The Nano ESP32 is compatible with the Arduino IoT Cloud platform. Build IoT projects in just minutes!
-
-available from August 2023 
 <FeatureLink title="Go to Platform" url="https://create.arduino.cc/iot/"/>
 </Feature>
 

--- a/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
@@ -68,8 +68,6 @@ In this course, you will fundamental knowledge to get started, as well as a larg
 
 Nano ESP32 is supported in the [Arduino IoT Cloud](https://create.arduino.cc/iot/) platform. You can connect to the cloud either through "classic" Arduino, using the C++ library, or via MicroPython:
 
-***IoT Cloud support is coming August 2023***
-
 - [Getting Started with Arduino IoT Cloud (classic)](https://docs.arduino.cc/arduino-cloud/getting-started/iot-cloud-getting-started)
 - [MicroPython with Arduino IoT Cloud](https://docs.arduino.cc/arduino-cloud/getting-started/iot-cloud-micropython)
 


### PR DESCRIPTION
## What This PR Changes
- The board is now supported buy the IoT Cloud, and the notes stating a release in August need to be removed.
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
