### PR TITLE
[MKC-1071]Add bootloader mode-note to UNO R4 HID tutorial

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/usb-hid/usb-hid.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/usb-hid/usb-hid.md
@@ -38,6 +38,8 @@ To turn your board into an HID, you can use the **keyboard/mouse** API that is b
 
 In the section below, you will see a couple of useful examples to get you started!
 
+***Note: In certain cases, uploading a sketch that turns your board into an HID device will occupy the boards communication with the computer, making it temporarily unavailable for a new sketch. If you find that you cannot upload a new sketch, try quickly double tapping the reset button. This puts the board in bootloader-mode, a state where it is turned on and listening for a new sketch, without running the current one.***
+
 ## Keyboard
 
 To use keyboard functionalities, we need to include the library at the top of our sketch. The Keyboard class contains several methods that are useful to emulate a keyboard.

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/usb-hid/usb-hid.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/usb-hid/usb-hid.md
@@ -38,6 +38,8 @@ To turn your board into an HID, you can use the **keyboard/mouse** API that is b
 
 In the section below, you will a couple of useful examples to get you started!
 
+***Note: In certain cases, uploading a sketch that turns your board into an HID device will occupy the boards communication with the computer, making it temporarily unavailable for a new sketch. If you find that you cannot upload a new sketch, try quickly double tapping the reset button. This puts the board in bootloader-mode, a state where it is turned on and listening for a new sketch, without running the current one.***
+
 ## Keyboard
 
 To use keyboard functionalities, we need to include the library at the top of our sketch. The Keyboard class contains several methods that are useful to emulate a keyboard.


### PR DESCRIPTION
## What This PR Changes
- People in forum have been confused about the board becoming seemingly unresponsive to new sketches after uploading an HID sketch. 
- This PR adds a note to the UNO R4 HID tutorials explaining how to set the board into bootloader-mode, preparing it for a new sketch. 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
