### PR TITLE
Document special upload procedure in UNO R4 WiFi HID tutorial

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/usb-hid/usb-hid.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/usb-hid/usb-hid.md
@@ -36,8 +36,6 @@ To turn your board into an HID, you can use the **keyboard/mouse** API that is b
 - [Keyboard](https://www.arduino.cc/reference/en/language/functions/usb/keyboard/)
 - [Mouse](https://www.arduino.cc/reference/en/language/functions/usb/mouse/)
 
-In the section below, you will a couple of useful examples to get you started!
-
 ## Keyboard
 
 To use keyboard functionalities, we need to include the library at the top of our sketch. The Keyboard class contains several methods that are useful to emulate a keyboard.

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/usb-hid/usb-hid.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/usb-hid/usb-hid.md
@@ -36,6 +36,18 @@ To turn your board into an HID, you can use the **keyboard/mouse** API that is b
 - [Keyboard](https://www.arduino.cc/reference/en/language/functions/usb/keyboard/)
 - [Mouse](https://www.arduino.cc/reference/en/language/functions/usb/mouse/)
 
+## Sketch Upload Interference
+
+As a consequence of the multi-processor design of the UNO R4 WiFi board, uploads may fail with a "`No device found on ...`" error when the board is running a sketch that uses the HID capabilities.
+
+For this reason, you should use the following procedure to upload under these conditions:
+
+**1.** Press and release the button marked "**RESET**" on the board quickly twice. The LED marked "**L**" on the board should now be pulsing.
+
+**2.** Select the port of the board from the menu in Arduino IDE. The port might have changed after the previous step, so make sure to verify that it is selected.
+
+**3.** Upload your sketch as usual.
+
 ## Keyboard
 
 To use keyboard functionalities, we need to include the library at the top of our sketch. The Keyboard class contains several methods that are useful to emulate a keyboard.


### PR DESCRIPTION
## What This PR Changes

When an [**UNO R4 WiFi**](https://docs.arduino.cc/hardware/uno-r4-wifi) board is running a sketch that uses the [HID capabilities](https://docs.arduino.cc/tutorials/uno-r4-wifi/usb-hid), the port address changes during the upload. Since this change does not occur under other conditions, the platform is not configured to handle such a change. This causes uploads via the standard procedure to fail under these conditions (https://github.com/arduino/ArduinoCore-renesas/issues/73). Since adjusting the configuration to allow reliable uploads under any conditions would have harmful side effects, the decision was made to leave the configuration as it is now:

https://github.com/arduino/ArduinoCore-renesas/pull/74#issuecomment-1665193136

> I'd prefer to force using the "manual" procedure (double tap on reset + select the "new" port manually before uploading)

The upload can be accomplished reliably if the user performs the "manual" procedure mentioned above, but this fact is not documented in the tutorial about the board's HID capabilities.

This pull request proposes to add the documentation of this important procedure to the to the tutorial.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
