### PR TITLE
[MKC-1036] Giga R1 WiFi add codeBlock and frontmatter board information

### DIFF
--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/cheat-sheet/cheat-sheet.md
@@ -15,7 +15,7 @@ tags:
   - Audio Jack
 author: 'Jacob Hylén'
 hardware:
-  - hardware/08.mega/boards/giga-r1-wifi
+  - hardware/10.mega/boards/giga-r1-wifi
 software:
   - ide-v1
   - ide-v2

--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-audio/content.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-audio/content.md
@@ -2,6 +2,8 @@
 title: Guide to GIGA R1 Advanced ADC/DAC and Audio Features
 description: 'Learn how to use the ADC/DAC features, along with useful examples on how to generate waveforms and play audio from a file.'
 author: José Bagur, Taddy Chung & Karl Söderby
+hardware:
+  - hardware/10.mega/boards/giga-r1-wifi
 tags: [ADC, DAC, Audio, USB]
 ---
 

--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-camera/giga-camera.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-camera/giga-camera.md
@@ -3,6 +3,8 @@ title: GIGA R1 Camera Guide
 description: Learn about the GIGA R1 WiFi's camera connector, and how to use existing examples.
 tags: [ArduCAM, Camera, Processing]
 author: Karl Söderby
+hardware:
+  - hardware/10.mega/boards/giga-r1-wifi
 ---
 
 The GIGA R1 has a dedicated camera connector that allows certain camera modules to mount directly on the board. This makes it possible to add machine vision to your GIGA R1 board without much effort at all.

--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-dual-core/giga-dual-core.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-dual-core/giga-dual-core.md
@@ -2,6 +2,8 @@
 title: Guide to GIGA R1 Dual Cores
 description: Learn how to access and control the M4 and M7 cores on the GIGA R1, and how to communicate between them using RPC.
 author: Karl Söderby
+hardware:
+  - hardware/10.mega/boards/giga-r1-wifi
 tags: [Dual Core, M4, M7]
 ---
 

--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-getting-started/giga-getting-started.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-getting-started/giga-getting-started.md
@@ -2,6 +2,8 @@
 title: Getting Started with GIGA R1 WiFi
 description: A step-by-step guide to install the board package needed for the GIGA R1 WiFi board.
 author: Karl Söderby
+hardware:
+  - hardware/10.mega/boards/giga-r1-wifi
 tags: [GIGA R1 WiFi, Installation, IDE]
 ---
 

--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-micropython/giga-micropython.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-micropython/giga-micropython.md
@@ -2,6 +2,8 @@
 title: MicroPython on the GIGA R1
 description: Get started with MicroPython on the GIGA R1.
 author: Karl Söderby
+hardware:
+  - hardware/10.mega/boards/giga-r1-wifi
 tags: [MicroPython, dfu-util]
 ---
 

--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-wifi/giga-wifi.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-wifi/giga-wifi.md
@@ -2,6 +2,8 @@
 title: GIGA R1 WiFi Network Examples
 description: Discover examples compatible with the WiFi library included in the GIGA core.
 author: Karl Söderby
+hardware:
+  - hardware/10.mega/boards/giga-r1-wifi
 tags: [Wi-Fi, Web Server, AP Mode, SSL, UDP]
 ---
 


### PR DESCRIPTION
## What This PR Changes
This PR changes the core example code snippets to use the new codeBlock component fetching the code straight from GitHub and also adds missing board information to the front matter for certain tutorials (see below).

 CodeBlocks added:
- USB Features

Front Matter added:
- Cheat Sheet
- Advanced ADC / DAC
- Camera Guide
- Dual Cores
- Getting Started
- MicroPython
- USB Features
- Network Examples

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.