### PR TITLE
[AE-139] Correct I2C & SPI labelling in MKR Shield `tech-specs.yml` files

### DIFF
--- a/content/hardware/01.mkr/02.shields/mkr-485-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-485-shield/tech-specs.yml
@@ -3,7 +3,7 @@ Shield:
   SKU: ASX00004
   Compatibility: MKR
 Protocol: RS485
-Interface: Serial
+Interface: Serial (TXP on D7, RXP on D6)
 Operating mode: Isolated half / full duplex (switchable)
 Integrated circuits:
   Transceiver: MAXIM MAX3157

--- a/content/hardware/01.mkr/02.shields/mkr-can-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-can-shield/tech-specs.yml
@@ -4,6 +4,7 @@ Shield:
   Compatibility: MKR
 Protocol: CAN bus
 Communication: SPI
+Chip Select Pin (SPI): D3
 Integrated circuits:
   Controller: Microchip MCP2515
   Transceiver: NXP® TJA1049

--- a/content/hardware/01.mkr/02.shields/mkr-env-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-env-shield/tech-specs.yml
@@ -2,7 +2,9 @@ Shield:
   Name: MKR ENV Shield
   SKU: ASX00011
   Compatibility: MKR
-Communication: I2C and analog
+Communication: SPI and I2C
+Chip Select Pin (SPI): D4
+Device Ready Pin (I2C): LPS22HB on D7, HTS221 on D6
 Storage: Micro SD card slot
 Sensors:
   Temperature (HTS221):

--- a/content/hardware/01.mkr/02.shields/mkr-eth-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-eth-shield/tech-specs.yml
@@ -7,6 +7,7 @@ Ethernet:
   Controller: W5500
   Speed: 10/100 Mbps
   Communication: SPI
+  Chip Select Pin (SPI): MicroSD on D4, Ethernet on D5
   Internal memory: 32KB
   Maximum sockets: 8 individual
   Supported protocols: IPv4, ICMP, TCP, UDP, ARP, IGMP, PPPoE, MQTT

--- a/content/hardware/01.mkr/02.shields/mkr-gps-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-gps-shield/tech-specs.yml
@@ -2,7 +2,7 @@ Shield:
   Name: Arduino® MKR GPS Shield
   SKU: ASX00017
   Compatibility: MKR
-Communication: Serial / I2C / DCC
+Communication: Serial / I2C (over ESLOV only) / DCC
 GPS Module: u-blox SAM-M8Q
 Connector: Eslov
 Power:

--- a/content/hardware/01.mkr/02.shields/mkr-mem-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-mem-shield/tech-specs.yml
@@ -3,6 +3,7 @@ Shield:
   SKU: ASX00008
   Compatibility: MKR
 Communication: SPI
+Chip Select Pin (SPI): MicroSD on D4, Flash on D% 
 Features:
   Storage: Micro SD card slot
   Flash memory: 2MB (W25Q16)

--- a/content/hardware/01.mkr/02.shields/mkr-rgb-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-rgb-shield/tech-specs.yml
@@ -2,7 +2,7 @@ Shield:
   Name: Arduino® MKR RGB Shield
   SKU: ASX00010
   Compatibility: MKR
-Communication: SPI
+Communication: SDI (Serial Data Input)
 LEDs:
   Type: APA102
   Count: 84

--- a/content/hardware/01.mkr/02.shields/mkr-sd-proto-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-sd-proto-shield/tech-specs.yml
@@ -3,6 +3,7 @@ Shield:
   SKU: TSX00004
   Compatibility: MKR
 Communication: SPI
+Chip Select Pin (SPI): Flash on D3, MicroSD on D4
 Storage: Micro SD card slot
 Prototyping Area: Yes
 Operating Voltage: 3.3V

--- a/content/hardware/01.mkr/02.shields/mkr-therm-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-therm-shield/tech-specs.yml
@@ -2,7 +2,9 @@ Shield:
   Name: Arduino® MKR Therm Shield
   SKU: ASX00012
   Compatibility: MKR
-Communication: SPI
+Communication: SPI and 1-Wire®
+Chip Select Pin (SPI): A3
+1-Wire® Pin: D0
 Digital converter: MAX31855
 Connectors:
   K-type: Yes


### PR DESCRIPTION
## What This PR Changes
- The Docs page ,specifically `tech-specs.yml`, is revised to ensure that
     - The protocol (SPI/I2C/other) is correct
     - The pins used for said protocol are documented (they are not all common)
     - CS pin (if applicable) is defined. (RGB Shield may not need a CS pin?)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
