### PR TITLE
[MKC-1081] Nano ESP32 return to IDE

### DIFF
--- a/content/micropython-course/course/02.installation/installation-tools.md
+++ b/content/micropython-course/course/02.installation/installation-tools.md
@@ -82,6 +82,8 @@ After loading the script, we should be seeing a green light blink on the board.
 
 So what just happened? We just loaded a script to our board, instructing it to blink a green LED every second. This is to confirm things are working, and if you see blinking green light, you successfully installed and uploaded a script to your board!
 
+If you ever want to return your board to program it with the Arduino IDE, you need to put it in bootloader mode. You can read about what this means and how to do it in the [Nano ESP32 Cheat sheet](https://docs.arduino.cc/tutorials/nano-esp32/cheat-sheet#arduino-bootloader-mode)
+
 ## Summary
 
 Congratulations! You’ve completed the installation chapter of MicroPython 101.

--- a/content/micropython-course/course/02.installation/installation-tools.md
+++ b/content/micropython-course/course/02.installation/installation-tools.md
@@ -82,7 +82,7 @@ After loading the script, we should be seeing a green light blink on the board.
 
 So what just happened? We just loaded a script to our board, instructing it to blink a green LED every second. This is to confirm things are working, and if you see blinking green light, you successfully installed and uploaded a script to your board!
 
-If you ever want to return your board to program it with the Arduino IDE, you need to put it in bootloader mode. You can read about what this means and how to do it in the [Nano ESP32 Cheat sheet](https://docs.arduino.cc/tutorials/nano-esp32/cheat-sheet#arduino-bootloader-mode)
+If you ever want to return your board to program it with the Arduino IDE, you need to put it in bootloader mode. You can read about what this means and how to do it in the [Nano ESP32 Cheat sheet](https://docs.arduino.cc/tutorials/nano-esp32/cheat-sheet#arduino-bootloader-mode).
 
 ## Summary
 


### PR DESCRIPTION
## What This PR Changes
- Adds a short note in MicroPython 101 about how to return your board to be programmed in the Arduino IDE in C++ after installing a MicroPython firmware
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
