### PR TITLE
[MKC-1092] Update Nano Every tech specs

### DIFF
--- a/content/hardware/03.nano/boards/nano-every/tech-specs.yml
+++ b/content/hardware/03.nano/boards/nano-every/tech-specs.yml
@@ -14,7 +14,7 @@ Communication:
   SPI: D11 (COPI), D12 (CIPO), D13 (SCK). Use any GPIO for Chip Select (CS).
 Power:
   I/O Voltage: 5V
-  Input voltage (nominal): 7-18V
+  Input voltage (nominal): 7-21V
   DC Current per I/O Pin: 15 mA
 Clock speed:
   Processor: ATMega4809 16 MHz


### PR DESCRIPTION
## What This PR Changes
- corrects the Nano Every tech specs table Voltage range to match Pinout and store entry.
- checked against datasheet of component 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
