### PR TITLE
[MKC-1109] Add missing network example from core

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/wifi-examples/wifi-examples.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/wifi-examples/wifi-examples.md
@@ -63,5 +63,8 @@ You will need to create this file, or remove the `#include "arduino_secrets.h"` 
 ### Wi-Fi® Web Client Repeating
 <CodeBlock url="https://github.com/arduino/ArduinoCore-renesas/blob/main/libraries/WiFiS3/examples/WiFiWebClientRepeating/WiFiWebClientRepeating.ino" className="arduino"/>
 
+### Wi-Fi® Web Client SSL
+<CodeBlock url="https://github.com/arduino/ArduinoCore-renesas/blob/main/libraries/WiFiS3/examples/WiFiWebClientSSL/WiFiWebClientSSL.ino" className="arduino"/>
+
 ### Wi-Fi® Web Server
 <CodeBlock url="https://github.com/arduino/ArduinoCore-renesas/blob/main/libraries/WiFiS3/examples/WiFiWebServer/WiFiWebServer.ino" className="arduino"/>


### PR DESCRIPTION
## What This PR Changes
This PR adds the missing Wi-Fi® Web Client SSL example from UNO R4 Core to the [R4 WiFi Guide](https://docs.arduino.cc/tutorials/uno-r4-wifi/wifi-examples).
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
