### PR TITLE
Add UNO R4 to list of compatible boards

### DIFF
--- a/content/arduino-cloud/01.getting-started/01.iot-cloud-getting-started/iot-cloud-getting-started.md
+++ b/content/arduino-cloud/01.getting-started/01.iot-cloud-getting-started/iot-cloud-getting-started.md
@@ -63,6 +63,7 @@ The following boards connect to the Arduino IoT Cloud via Wi-Fi.
 - [Portenta Machine Control](https://store.arduino.cc/products/arduino-portenta-machine-control)
 - [Nicla Vision](https://store.arduino.cc/products/nicla-vision)
 - [Opta](https://docs.arduino.cc/hardware/opta).
+- [UNO R4 WiFi](https://store.arduino.cc/products/uno-r4-wifi)
 
 Connection via Wi-Fi is an easy alternative, and your credentials can safely be entered during the configuration of a project. This type of connection is most suitable for low-range projects, where you connect your board to the cloud via your home/work/school router.
 

--- a/content/arduino-cloud/01.getting-started/02.technical-reference/iot-cloud-tech-ref.md
+++ b/content/arduino-cloud/01.getting-started/02.technical-reference/iot-cloud-tech-ref.md
@@ -29,6 +29,7 @@ The following boards connect to the Arduino IoT Cloud via Wi-Fi.
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Portenta H7 Lite Connected](https://store.arduino.cc/products/portenta-h7-lite-connected)
 - [Nicla Vision](https://store.arduino.cc/products/nicla-vision)
+- [UNO R4 WiFi](https://store.arduino.cc/products/uno-r4-wifi)
 
 Connection via Wi-Fi is an easy alternative, and your credentials can safely be entered during the configuration of a project. This type of connection is most suitable for low-range projects, where you connect your board to the cloud via your home/work/school router.
 


### PR DESCRIPTION
UNO R4 WiFi is now supported by Arduino IoT Cloud. 

## What This PR Changes

- Added to list of compatible boards in getting started + technical reference article.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
