### PR TITLE
Update Github-provided actions

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -15,8 +15,8 @@ jobs:
       APP_ENV: prod
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
           cache: "npm"
@@ -34,7 +34,7 @@ jobs:
           find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
 
       - name: Gatsby main cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: gatsby-cache-folder
         with:
           path: .cache
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-cache-gatsby-
 
       - name: Gatsby Public Folder
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: gatsby-public-folder
         with:
           path: public/

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -14,8 +14,8 @@ jobs:
       APP_ENV: staging
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 14
           cache: "npm"
@@ -33,7 +33,7 @@ jobs:
           find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
 
       - name: Gatsby main cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: gatsby-cache-folder
         with:
           path: .cache
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-cache-gatsby-
 
       - name: Gatsby Public Folder
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: gatsby-public-folder
         with:
           path: public/


### PR DESCRIPTION
## What This PR Changes
Update the Github-provided actions to the latest version

actions/cache@v3 is especially important since it fixes an issue with restoring caches bigger than 2GB (which this repo hits)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
