### PR TITLE
Fail build if datasheets cannot be rendered

### DIFF
--- a/scripts/datasheet-rendering/render-datasheets.sh
+++ b/scripts/datasheet-rendering/render-datasheets.sh
@@ -24,7 +24,7 @@ if [ -n "$CI" ]; then
     echo "Running on Node version: `node -v`"
     npm install
     npx datasheet-renderer config.json
-    exit 0
+    exit $?
 fi
 
 if ! command -v node &> /dev/null


### PR DESCRIPTION
## What This PR Changes
- Exit the build process if the datasheet rendering is not successful, that is, if at least 1 datasheet couldn't be rendered.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
