### PR TITLE
Update cheat-sheet.md - fix: Table of IO pins

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
@@ -101,10 +101,10 @@ If you just need a quick overview of the pins functionality, this is a full tabl
 | D11 | Digital   | SPI (COPI), GPIO pin, PWM         |
 | D12 | Digital   | SPI (CIPO), GPIO pin              |
 | D13 | Digital   | SPI (SCK), GPIO pin, Built-in LED |
-| A0  | Digital   | Analog In, DAC                    |
+| A0  | Analog    | Analog In, DAC OUT                |
 | A1  | Analog in | Analog In, OPAMP +                |
 | A2  | Analog in | Analog In, OPAMP -                |
-| A3  | Analog in | Analog In, OPAMP OUT              |
+| A3  | Analog    | Analog In, OPAMP OUT              |
 | A4  | Analog in | Analog In, SDA\*                  |
 | A5  | Analog in | Analog In, SCL\*                  |
 


### PR DESCRIPTION
fix: Table of IO pins

## What This PR Changes
Change type of pin A0 from "Digital" to "Analog". Change type of pin A3 from "Analog In" to "Analog" to account for the fact that it is also the OpAmp output.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
