### PR TITLE
[UNO R4] Update Interrupt Pins for UNO R4 boards

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/tech-specs.yml
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tech-specs.yml
@@ -9,6 +9,7 @@ Pins:
   Analog input pins: 6
   DAC: 1
   PWM pins: 6
+  External interrupts: 2,3
 Communication:
   UART: Yes, 1x
   I2C: Yes, 1x

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tech-specs.yml
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tech-specs.yml
@@ -10,6 +10,7 @@ Pins:
   Analog input pins: 6
   DAC: 1
   PWM pins: 6
+  External interrupts: 2,3
 Communication:
   UART: Yes, 1x
   I2C: Yes, 1x


### PR DESCRIPTION
Added the external interrupt pins to UNO R4 WiFi/Minima boards tech specs.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
