### PR TITLE
Fix: weight of Arduino Nano is specified at 7 gr both on product page and the starts of the corresponding docs page.

### DIFF
--- a/content/hardware/03.nano/boards/nano/tech-specs.yml
+++ b/content/hardware/03.nano/boards/nano/tech-specs.yml
@@ -21,6 +21,6 @@ Clock speed:
 Memory:
   ATmega328P: 2KB SRAM, 32KB flash 1KB EEPROM
 Dimensions:
-  Weight: 5gr
+  Weight: 7 gr
   Width: 18 mm
   Length: 45 mm

--- a/content/hardware/03.nano/boards/nano/tech-specs.yml
+++ b/content/hardware/03.nano/boards/nano/tech-specs.yml
@@ -21,6 +21,6 @@ Clock speed:
 Memory:
   ATmega328P: 2KB SRAM, 32KB flash 1KB EEPROM
 Dimensions:
-  Weight: 7 gr
+  Weight: 7 g
   Width: 18 mm
   Length: 45 mm


### PR DESCRIPTION
## What This PR Changes
Fix: Board weight of Arduino Nano is specified at 7 gr both on product page and the starts of the corresponding docs page. Only the tech specs are listing a value of 5 gr. This PR is rectifying this.

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
