### PR TITLE
Fix: Arduino Nano has only 20 digital pins max.

### DIFF
--- a/content/hardware/03.nano/boards/nano/datasheet/datasheet.md
+++ b/content/hardware/03.nano/boards/nano/datasheet/datasheet.md
@@ -8,7 +8,7 @@ type: maker
 
 # Description
 
-**Arduino® Nano** is an intelligent development board designed for building faster prototypes with the smallest dimension. Arduino Nano being the oldest member of the Nano family, provides enough interfaces for your breadboard-friendly applications. At the heart of the board is **ATmega328 microcontroller** clocked at a frequency of 16 MHz featuring more or less the same functionalities as the Arduino Duemilanove. The board offers 22 digital input/output pins, 8 analog pins, and a mini-USB port.
+**Arduino® Nano** is an intelligent development board designed for building faster prototypes with the smallest dimension. Arduino Nano being the oldest member of the Nano family, provides enough interfaces for your breadboard-friendly applications. At the heart of the board is **ATmega328 microcontroller** clocked at a frequency of 16 MHz featuring more or less the same functionalities as the Arduino Duemilanove. The board offers 20 digital input/output pins, 8 analog pins, and a mini-USB port.
 
 # Target Areas 
 Maker, Security, Environmental, Robotics and Control Systems
@@ -37,7 +37,7 @@ Maker, Security, Environmental, Robotics and Control Systems
   - Standby
   - Extended Standby
 - **I/O**
-  - 22 Digital
+  - 20 Digital
   - 8 Analog
   - 6 PWM Output
 


### PR DESCRIPTION
## What This PR Changes
Fix: Arduino Nano has only 20 digital pins max: D0 - D19 (which contains A0 to A5). A6/A7 can only be analog intputs.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
