### PR TITLE
Fix: safe external supply voltage range via VIN is 7 to 15 V

### DIFF
--- a/content/hardware/03.nano/boards/nano/datasheet/datasheet.md
+++ b/content/hardware/03.nano/boards/nano/datasheet/datasheet.md
@@ -27,7 +27,7 @@ Maker, Security, Environmental, Robotics and Control Systems
   - Master/Slave SPI Serial Interface
 - **Power**
   - Mini-B USB connection
-  - 6-20V unregulated external power supply (pin 30)
+  - 7-15V unregulated external power supply (pin 30)
   - 5V regulated external power supply (pin 27)
 - **Sleep Modes**
   - Idle


### PR DESCRIPTION
## What This PR Changes
Fix: safe external supply voltage range via VIN is 7 to 15 V.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
