### PR TITLE
[UNO R4 WiFi] Add NTP RTC example

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
@@ -262,6 +262,13 @@ To retrieve and store the current time, we can make a request to an NTP server, 
  
 <CodeBlock url="https://github.com/arduino/ArduinoCore-renesas/blob/main/libraries/RTC/examples/RTC_NTPSync/RTC_NTPSync.ino" className="arduino"/>
 
+Please also note that you will need to create a new tab called `arduino_secrets.h`. This is used to store your credentials. In this file, you will need to add:
+
+```arduino
+#define SECRET_SSID "" //network name
+#define SECRET_PASS "" //network password
+```
+
 ## Summary
 
 This tutorial shows how to use the RTC on the UNO R4 WiFi, such as setting a start time, setting an alarm, or obtaining time in calendar or unix format.

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
@@ -256,6 +256,12 @@ void alarm_cbk() {
 }
 ```
 
+## Network Time Protocol (NTP)
+
+To retrieve and store the current time, we can make a request to an NTP server, `pool.ntp.org`. This will retrieve the UNIX time stamp and store it in an `RTC` object. 
+ 
+<CodeBlock url="https://github.com/arduino/ArduinoCore-renesas/blob/main/libraries/RTC/examples/RTC_NTPSync/RTC_NTPSync.ino" className="arduino"/>
+
 ## Summary
 
 This tutorial shows how to use the RTC on the UNO R4 WiFi, such as setting a start time, setting an alarm, or obtaining time in calendar or unix format.


### PR DESCRIPTION
The NTP RTC example is in the core but was not available in the RTC guide on docs. This PR adds it.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
