### PR TITLE
[MicroPython] Add reference to pin map.

### DIFF
--- a/content/micropython-course/course/04.digital/03.digital.md
+++ b/content/micropython-course/course/04.digital/03.digital.md
@@ -53,6 +53,8 @@ while True:
         print("BUTTON PRESSED!")
 ```
 
+***Please note that the pin number reflects the GPIO on the ESP32-S3, not the Nano board. In the circuit, we are connecting the button to pin `D6`, but in the code, we use pin `9`. You can read more about this and see the full pin map [here](/micropython-course/course/introduction-python#nano-esp32--micropython-pinout).***
+
 Then, click on the **Run"** button to run the script. Now, if we click the button, we should see a message in the terminal: **"BUTTON PRESSED!"**.
 
 ![Button pressed.](assets/button.gif).


### PR DESCRIPTION
User did not find the pin map for ESP32 <> Nano ESP32 (GPIO vs PIN numbering). This PR adds a note that refers back to the pin map, in the first practical example (5. digital)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
