### PR TITLE
[MKC-1261] Update RTC examples 

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/rtc/rtc.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/rtc/rtc.md
@@ -243,26 +243,62 @@ The period can be specified using the following enumerations:
 - `RTC.setAlarmCallback(alarm_cbk, alarmtime, am)`
 
 ```arduino
+unsigned long previousMillis = 0;
+const long interval = 1000;
+bool ledState = false;
+
+// Include the RTC library
 #include "RTC.h"
 
 void setup() {
+  //initialize Serial Communication
   Serial.begin(9600);
 
+  //define LED as output
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  // Initialize the RTC
   RTC.begin();
 
-  RTCTime alarmtime;
-  alarmtime.setSecond(35);
+  // RTC.setTime() must be called for RTC.setAlarmCallback to work, but it doesn't matter
+  // what date and time it's set to in this example
+  RTCTime initialTime(7, Month::JUNE, 2023, 13, 03, 00, DayOfWeek::WEDNESDAY, SaveLight::SAVING_TIME_ACTIVE);
+  RTC.setTime(initialTime);
 
-  AlarmMatch am;
-  am.addMatchSecond();
+  // Trigger the alarm every time the seconds are zero
+  RTCTime alarmTime;
+  alarmTime.setSecond(0);
 
-  if (!RTC.setAlarmCallback(alarm_cbk, alarmtime, am)) {
-    Serial.println("ERROR: alarm callback not set");
+  // Make sure to only match on the seconds in this example - not on any other parts of the date/time
+  AlarmMatch matchTime;
+  matchTime.addMatchSecond();
+
+  //sets the alarm callback
+  RTC.setAlarmCallback(alarmCallback, alarmTime, matchTime);
+}
+
+void loop() {
+
+  // in the loop, we continuously print the alarm's current state
+  // this is for debugging only and has no effect on the alarm whatsoever
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval) {
+    // save the last time you blinked the LED
+    previousMillis = currentMillis;
+    Serial.print("Alarm state: ");
+    Serial.println(ledState);
   }
 }
 
-void alarm_cbk() {
-  Serial.println("ALARM INTERRUPT");
+// this function activates every minute
+// and changes the ledState boolean
+void alarmCallback() {
+  if (!ledState) {
+    digitalWrite(LED_BUILTIN, HIGH);
+  } else {
+    digitalWrite(LED_BUILTIN, LOW);
+  }
+  ledState = !ledState;
 }
 ```
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/rtc/rtc.md
@@ -247,26 +247,62 @@ The period can be specified using the following enumerations:
 - `RTC.setAlarmCallback(alarm_cbk, alarmtime, am)`
 
 ```arduino
+unsigned long previousMillis = 0;
+const long interval = 1000;
+bool ledState = false;
+
+// Include the RTC library
 #include "RTC.h"
 
 void setup() {
+  //initialize Serial Communication
   Serial.begin(9600);
 
+  //define LED as output
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  // Initialize the RTC
   RTC.begin();
 
-  RTCTime alarmtime;
-  alarmtime.setSecond(35);
+  // RTC.setTime() must be called for RTC.setAlarmCallback to work, but it doesn't matter
+  // what date and time it's set to in this example
+  RTCTime initialTime(7, Month::JUNE, 2023, 13, 03, 00, DayOfWeek::WEDNESDAY, SaveLight::SAVING_TIME_ACTIVE);
+  RTC.setTime(initialTime);
 
-  AlarmMatch am;
-  am.addMatchSecond();
+  // Trigger the alarm every time the seconds are zero
+  RTCTime alarmTime;
+  alarmTime.setSecond(0);
 
-  if (!RTC.setAlarmCallback(alarm_cbk, alarmtime, am)) {
-    Serial.println("ERROR: alarm callback not set");
+  // Make sure to only match on the seconds in this example - not on any other parts of the date/time
+  AlarmMatch matchTime;
+  matchTime.addMatchSecond();
+
+  //sets the alarm callback
+  RTC.setAlarmCallback(alarmCallback, alarmTime, matchTime);
+}
+
+void loop() {
+
+  // in the loop, we continuously print the alarm's current state
+  // this is for debugging only and has no effect on the alarm whatsoever
+  unsigned long currentMillis = millis();
+  if (currentMillis - previousMillis >= interval) {
+    // save the last time you blinked the LED
+    previousMillis = currentMillis;
+    Serial.print("Alarm state: ");
+    Serial.println(ledState);
   }
 }
 
-void alarm_cbk() {
-  Serial.println("ALARM INTERRUPT");
+// this function activates every minute
+// and changes the ledState boolean
+void alarmCallback() {
+  if (!ledState) {
+    digitalWrite(LED_BUILTIN, HIGH);
+  } else {
+    digitalWrite(LED_BUILTIN, LOW);
+  }
+  ledState = !ledState;
 }
 ```
 


### PR DESCRIPTION
## What This PR Changes
- Updates the alarm RTC examples for UNO R4 so that they:
 a) don't `Serial.print()` in the callback function
 b) Match the examples that are bundled in the core
 
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
