### PR TITLE
Fix typo StringReplace.md

### DIFF
--- a/content/built-in-examples/08.strings/StringReplace/StringReplace.md
+++ b/content/built-in-examples/08.strings/StringReplace/StringReplace.md
@@ -30,7 +30,7 @@ If you try to replace a substring that's more than the whole String itself, noth
 
 ```arduino
 String stringOne = "<html><head><body>";
-String stringTwo = stringOne.replace("<html><head></head><body></body></html>", "Blah");
+stringOne.replace("<html><head></head><body></body></html>", "Blah");
 ```
 
 In this case, the code will compile, but `stringOne` will remain unchanged, since the replacement substring is more than the String itself.


### PR DESCRIPTION
## What This PR Changes
- This PR removes the start of a line of an example code which implies that the String replace() function returns another String, whilst it returns void. When attempting to compile the code, an error is produced: `Compilation error: conversion from 'void' to non-scalar type 'String' requested`
- Now, it correctly indicates that replace() returns nothing

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
