### PR TITLE
[PC-1448] - Portenta C33/H7 Tech Specs Table Update

### DIFF
--- a/content/hardware/04.pro/boards/portenta-c33/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-c33/tech-specs.yml
@@ -36,7 +36,7 @@ Digital-to-analog converter (DAC):
   Resolution: 12 bits 
 Secure element: NXP® SE050C2
 Communication:
-  I2C: 3
+  I2C: 3 (I2C0, I2C1, I2C2; any I2C port can be used as it is free to use without restrictions.)
   UART: 4
   CAN FD: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-c33/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-c33/tech-specs.yml
@@ -36,7 +36,7 @@ Digital-to-analog converter (DAC):
   Resolution: 12 bits 
 Secure element: NXP® SE050C2
 Communication:
-  I2C: 3 ports (I2C0, I2C1, and I2C2; any port can be used used without restrictions)
+  I2C: 3 ports (I2C0, I2C1, and I2C2)
   UART: 4
   CAN FD: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-c33/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-c33/tech-specs.yml
@@ -36,7 +36,7 @@ Digital-to-analog converter (DAC):
   Resolution: 12 bits 
 Secure element: NXP® SE050C2
 Communication:
-  I2C: 3 (I2C0, I2C1, I2C2; any I2C port can be used as it is free to use without restrictions.)
+  I2C: 3 ports (I2C0, I2C1, and I2C2; any port can be used used without restrictions)
   UART: 4
   CAN FD: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -35,7 +35,7 @@ Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication Interfaces:
-  I2C: 3
+  I2C: 3 ports (I2C0, I2C1, and I2C2; is adviced to use I2C0 as it is free to use without restrictions)
   UART: 4
   CAN: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/tech-specs.yml
@@ -35,7 +35,7 @@ Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication Interfaces:
-  I2C: 3 ports (I2C0, I2C1, and I2C2; is adviced to use I2C0 as it is free to use without restrictions)
+  I2C: 3 ports (I2C0, I2C1, and I2C2; is advised to use I2C0 as it is free to use without restrictions)
   UART: 4
   CAN: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -31,7 +31,7 @@ Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication Interfaces:
-  I2C: 3
+  I2C: 3 ports (I2C0, I2C1, and I2C2; is adviced to use I2C0 as it is free to use without restrictions)
   UART: 4
   CAN: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/tech-specs.yml
@@ -31,7 +31,7 @@ Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication Interfaces:
-  I2C: 3 ports (I2C0, I2C1, and I2C2; is adviced to use I2C0 as it is free to use without restrictions)
+  I2C: 3 ports (I2C0, I2C1, and I2C2; is advised to use I2C0 as it is free to use without restrictions)
   UART: 4
   CAN: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -36,7 +36,7 @@ Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication Interfaces:
-  I2C: 3
+  I2C: 3 ports (I2C0, I2C1, and I2C2; is adviced to use I2C0 as it is free to use without restrictions)
   UART: 4
   CAN: 2
   I2S: 1

--- a/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/tech-specs.yml
@@ -36,7 +36,7 @@ Digital-to-analog converter (DAC):
   Channels: 2 (only one accessible through pin A6)
   Resolution: 12 bits 
 Communication Interfaces:
-  I2C: 3 ports (I2C0, I2C1, and I2C2; is adviced to use I2C0 as it is free to use without restrictions)
+  I2C: 3 ports (I2C0, I2C1, and I2C2; is advised to use I2C0 as it is free to use without restrictions)
   UART: 4
   CAN: 2
   I2S: 1


### PR DESCRIPTION
## What This PR Changes
- This PR updates the I2C information in the tech specs table of the Portenta C33 and Portenta H7.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
