### PR TITLE
Fix voltage calculation - Update mkr-battery-app-note.md

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-battery-app-note/mkr-battery-app-note.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-battery-app-note/mkr-battery-app-note.md
@@ -124,7 +124,7 @@ We will go through the lines needed to create a Sketch to read the battery value
 **4.** We will now create a variable to store the maximum source voltage `max_Source_voltage` as well as the upper (`batteryFullVoltage`) and lower (`batteryEmptyVoltage`) values for the battery. We will also define the battery capacity as `batteryCapacity` so as to determine the charging current. Since we are using a 750 mAh battery in this example, we will set the value to `0.750`.
 
 ```arduino
-  int max_Source_voltage;
+  float max_Source_voltage;
 
   float batteryFullVoltage = 4.2;
   float batteryEmptyVoltage = 3.3;
@@ -303,8 +303,8 @@ void loop()
 {
   
   rawADC = analogRead(ADC_BATTERY);                     //the value obtained directly at the PB09 input pin
-  voltADC = rawADC * (3.3/4095.0);                      //convert ADC value to the voltage read at the pin
-  voltBat = voltADC * (max_Source_voltage/3.3);         //we cannot use map since it requires int inputs/outputs
+  voltADC = rawADC * 3.3 / 4096.0;                      //convert ADC value to the voltage read at the pin
+  voltBat = max_Source_voltage * rawADC / 4096.0;       //we cannot use map since it requires int inputs/outputs
   
   int new_batt = (voltBat - batteryEmptyVoltage) * (100) / (batteryFullVoltage - batteryEmptyVoltage);    //custom float friendly map function
 


### PR DESCRIPTION
I was wondering why the calculated voltages in the example have not been correct. So I analysed it and found a wrong data type (max_Source_voltage).

## What This PR Changes
- Fix data type of variable max_Source_voltage. Float is correct here to get correct values.
-  Made calculation of the two voltages (voltADC and voltBat) better. No real change, but more accurate results this way. The order of the operations matter when you want to get accurate results.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
