### PR TITLE
Correct CVD links

### DIFF
--- a/content/arduino-cloud/09.business/00.security-considerations/security-considerations.md
+++ b/content/arduino-cloud/09.business/00.security-considerations/security-considerations.md
@@ -109,7 +109,7 @@ Results are shared with Software Engineers and reviewed together with the Securi
 
 Should Arduino become aware of any unauthorized release of user data, in violation of applicable privacy laws and/or binding contractual obligations relating to data privacy and security, we will notify the  designated privacy Authority in the most expedient way possible and without unreasonable delay.
 
-Should an Arduino user or customer suspect a vulnerability or security issue, they are invited to report it as described in our Coordinated Vulnerability Disclosure policy available at https://www.arduino.cc/en/security 
+Should an Arduino user or customer suspect a vulnerability or security issue, they are invited to report it as described in our Coordinated Vulnerability Disclosure policy available at https://www.arduino.cc/en/security_cvd
 
 If there is valid reason to suspect a breach (e.g., clients report fraudulent activity on their accounts, or we see signs that someone has gained unauthorized remote or physical access to the data center), Arduino incident response team will check for common indicators of compromise to determine whether or not a breach has actually occurred.
 * Notify the Chief Information Security Officer, security team, and application owners of findings.

--- a/content/software/ide-v1/tutorials/ide-v1-security/ide-v1-security.md
+++ b/content/software/ide-v1/tutorials/ide-v1-security/ide-v1-security.md
@@ -38,7 +38,7 @@ As part of the security testing activities, Arduino periodically performs the fo
 - **Secure Component Analysis (SCA)**: security engineers evaluate components related to Theia npm packages and Electron.
 - **Secrets scanning analysis**: activities performed to ensure that secrets are not inadvertently leaked within the repository.
 
-Finally, should an Arduino user or customer suspect a vulnerability or security issue, they are invited to report it as described in our Coordinated Vulnerability Disclosure policy available at: [https://www.arduino.cc/en/security](https://www.arduino.cc/en/security).
+Finally, should an Arduino user or customer suspect a vulnerability or security issue, they are invited to report it as described in our Coordinated Vulnerability Disclosure policy available at: [https://www.arduino.cc/en/security_cvd](https://www.arduino.cc/en/security_cvd).
 
 ## Third Party Components
 

--- a/content/software/ide-v2/tutorials/ide-v2-security/ide-v2-security.md
+++ b/content/software/ide-v2/tutorials/ide-v2-security/ide-v2-security.md
@@ -38,7 +38,7 @@ As part of the security testing activities, Arduino periodically performs the fo
 - **Secure Component Analysis (SCA)**: security engineers evaluate components related to Theia npm packages and Electron.
 - **Secrets scanning analysis**: activities performed to ensure that secrets are not inadvertently leaked within the repository.
 
-Finally, should an Arduino user or customer suspect a vulnerability or security issue, they are invited to report it as described in our Coordinated Vulnerability Disclosure policy available at: [https://www.arduino.cc/en/security](https://www.arduino.cc/en/security).
+Finally, should an Arduino user or customer suspect a vulnerability or security issue, they are invited to report it as described in our Coordinated Vulnerability Disclosure policy available at: [https://www.arduino.cc/en/security_cvd](https://www.arduino.cc/en/security_cvd).
 
 ## Third Party Components
 


### PR DESCRIPTION
Several documentation pages provide links to Arduino's Coordinated Vulnerability Disclosure Policy. This important document ensures 3rd parties report discovered security vulnerabilities in a responsible manner.

Previously these links targeted a page that was simply a vague overview of the Arduino company's approach to security in our own work, which is completely irrelevant to a 3rd party wanting to report a vulnerability. The 3rd party would have had to sift through all that irrelevant information in order to find the tangential link to the actual CVD document. That unfriendly approach to providing the essential information risks causing some 3rd parties to conclude that Arduino doesn't have a formal procedure for reporting and resorting to using an insecure or inefficient reporting procedure instead.

For this reason, it is better to point the links directly to the information they claim to target.

## What This PR Changes
- Point the links directly to the information they claim to target.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
