### PR TITLE
Update board-examples.md

### DIFF
--- a/content/micropython/01.basics/06.board-examples/board-examples.md
+++ b/content/micropython/01.basics/06.board-examples/board-examples.md
@@ -63,8 +63,8 @@ from machine import Pin, I2C
 lsm = LSM6DSOX(I2C(0, scl=Pin(13), sda=Pin(12)))
 
 while (True):
-    print('Accelerometer: x:{:>8.3f} y:{:>8.3f} z:{:>8.3f}'.format(*lsm.read_accel()))
-    print('Gyroscope:     x:{:>8.3f} y:{:>8.3f} z:{:>8.3f}'.format(*lsm.read_gyro()))
+    print('Accelerometer: x:{:>8.3f} y:{:>8.3f} z:{:>8.3f}'.format(*lsm.accel()))
+    print('Gyroscope:     x:{:>8.3f} y:{:>8.3f} z:{:>8.3f}'.format(*lsm.gyro()))
     print("")
     time.sleep_ms(100)
 ```


### PR DESCRIPTION
renamed function calls to 'LSM6DSOX' library because library uses different function names.

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
