### PR TITLE
[MKC-1331] MicroPython 101 Tweaks

### DIFF
--- a/content/micropython-course/course/00.introduction-arduino/intro-to-arduino.md
+++ b/content/micropython-course/course/00.introduction-arduino/intro-to-arduino.md
@@ -73,4 +73,4 @@ Programming an Arduino using MicroPython is a slightly different experience. In 
 
 Over the years Arduino has released over a hundred different development boards, each different from the other. You choose the board depending on what you want to achieve, e.g. some boards have a Wi-Fi® module allowing you to connect to the Internet, and some have onboard sensors that allow you to record sensor data.
 
-- [Next chapter: Introduction to MicroPython](/micropython-course/course/introduction-python)
+- [Next chapter: Introduction to MicroPython](/micropython-course/course/installation)

--- a/content/micropython-course/course/01.installation/installation-tools.md
+++ b/content/micropython-course/course/01.installation/installation-tools.md
@@ -16,8 +16,8 @@ In this chapter we will go over how to install the prerequisite software: the **
 
 The software you will have installed are:
 
-- [Arduino Lab for MicroPython](https://labs.arduino.cc/en/labs/micropython)
-- The [Arduino MicroPython Installer](https://labs.arduino.cc/en/labs/micropython-installer)
+- Arduino Lab for MicroPython
+- The Arduino MicroPython Installer
 
 ![The Installed Software](./assets/apps-open.png)
 
@@ -39,7 +39,7 @@ The **Firmware Installer** program will help install MicroPython on your board.
 
 It will automatically download the latest version of the MicroPython firmware and install it on your board, so that all you need to do is to connect the board and press a button.
 
-First [download the app here](), and extract the files to a folder on your computer.
+First [download the app here](https://labs.arduino.cc/en/labs/micropython-installer), and extract the files to a folder on your computer.
 
 If you're on macOS, move the application to your **Applications** folder.
 

--- a/content/micropython-course/course/01.installation/installation-tools.md
+++ b/content/micropython-course/course/01.installation/installation-tools.md
@@ -7,17 +7,17 @@ title: '2. MicroPython Installation Guide'
 description: 'Learn how to install a code editor needed to program your board with MicroPython.'
 ---
 
-## Goals
+## Software Required
 
 In this chapter we will go over how to install the prerequisite software: the **code editor** and the **MicroPython firmware installer**, that will enable you to dive into the learning activities of this course.
 
-
 ![Arduino Labs for MicroPython and the Installer tool](./assets/logo.png)
 
-The software you will have installed are:
+Later in this chapter, we'll walk you through the installation process step by step. You can download the required softwares below, but if do - you please return to this page afterwards for instructions on what to do with them.
+To run MicroPython code on your Arduino board, you will need:
 
-- Arduino Lab for MicroPython
-- The Arduino MicroPython Installer
+- [Arduino Lab for MicroPython](https://labs.arduino.cc/en/labs/micropython)
+- [MicroPython Firmware Installer](https://labs.arduino.cc/en/labs/micropython-installer)
 
 ![The Installed Software](./assets/apps-open.png)
 

--- a/content/micropython-course/course/01.installation/installation-tools.md
+++ b/content/micropython-course/course/01.installation/installation-tools.md
@@ -113,4 +113,4 @@ To do this, **tap the reset button twice**, but not too fast (about 1 second bet
 
 Congratulations! You’ve completed the installation chapter of MicroPython 101.
 
-Having trouble? Continue to the troubleshooting section. Otherwise, move on to the [Next chapter](/micropython-course/course/digital).
+Having trouble? Continue to the troubleshooting section. Otherwise, move on to the [Next chapter](/micropython-course/course/introduction-python).

--- a/content/micropython-course/course/01.installation/installation-tools.md
+++ b/content/micropython-course/course/01.installation/installation-tools.md
@@ -13,7 +13,7 @@ In this chapter we will go over how to install the prerequisite software: the **
 
 ![Arduino Labs for MicroPython and the Installer tool](./assets/logo.png)
 
-Later in this chapter, we'll walk you through the installation process step by step. You can download the required softwares below, but if do - you please return to this page afterwards for instructions on what to do with them.
+Later in this chapter, we'll walk you through the installation process step by step. You can download the required software below, but if you do - please return to this page afterwards for instructions on what to do with them.
 To run MicroPython code on your Arduino board, you will need:
 
 - [Arduino Lab for MicroPython](https://labs.arduino.cc/en/labs/micropython)


### PR DESCRIPTION
## What This PR Changes
This PR fixes a couple oversights in the MicroPython 101 Course:
- When we've reordered tutorials within the course, we didn't change the "next chapter" links, so if you follow them the order is jumbled and incorrect.
- In the installation guide, we were listing the tools to be installed, with links. The links may seem initially like they would be a good idea, but they inherently prompt readers to click, and download. Instead, we should prefer them to wait with downloading until they get to the step by step guide later on the page, for a more intuitive flow. 
- One empty link.  

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
