### PR TITLE
[Nano ESP32] Clarify low power consumption ratings

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/datasheet/datasheet.md
+++ b/content/hardware/03.nano/boards/nano-esp32/datasheet/datasheet.md
@@ -14,6 +14,7 @@ The Nano ESP32 is compatible with the Arduino IoT Cloud, and has support for Mic
 Maker, IoT, MicroPython
 
 # Features
+
 * **Xtensa® Dual-core 32-bit LX7 Microprocessor**
   * Up to 240 MHz
   * 384 kB ROM
@@ -41,12 +42,14 @@ Maker, IoT, MicroPython
   * UART
   * CAN (TWAI®)
 * **Low Power**
-  * 7 μA consumption in deep sleep mode
-  * 240 μA consumption in light sleep mode
+  * 7 μA consumption in deep sleep mode\*
+  * 240 μA consumption in light sleep mode\*
   * RTC Memory
   * Ultra Low Power (ULP) Coprocessor
   * Power Management Unit (PMU)
   * ADC in RTC mode
+
+\*The power consumption in low power modes is only for the ESP32-S3 SoC. Other components on the board (such as LEDs), consumes power as well, which increases the overall power consumption of the board. 
 
 # Contents
 

--- a/content/hardware/03.nano/boards/nano-esp32/datasheet/datasheet.md
+++ b/content/hardware/03.nano/boards/nano-esp32/datasheet/datasheet.md
@@ -49,7 +49,7 @@ Maker, IoT, MicroPython
   * Power Management Unit (PMU)
   * ADC in RTC mode
 
-\*The power consumption in low power modes is only for the ESP32-S3 SoC. Other components on the board (such as LEDs), consumes power as well, which increases the overall power consumption of the board. 
+\*The power consumption ratings listed in low power modes are only for the ESP32-S3 SoC. Other components on the board (such as LEDs), consumes power as well, which increases the overall power consumption of the board.
 
 # Contents
 
@@ -481,6 +481,8 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 | 11/06/2023 | Correct company name, correct VBUS/VUSB                |
 | 11/09/2023 | Block Diagram Update, Antenna Specifications           |
 | 11/15/2023 | Ambient temperature update                             |
+| 11/23/2023 | Added label to LP modes                                |
+
 
 
 


### PR DESCRIPTION
## What This PR Changes

The datasheet for Nano ESP32 listed power consumption ratings in deep sleep / light sleep modes. These ratings apply on to the ESP32-S3 SoC, not to the development board (Nano ESP32). A comment was added to clarify this.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
