### PR TITLE
Added ATmega328 to the chips

### DIFF
--- a/content/hacking/01.software/PortManipulation/content.md
+++ b/content/hacking/01.software/PortManipulation/content.md
@@ -1,12 +1,12 @@
 ---
 title: "Arduino - PortManipulation"
 source: "https://arduino.cc/en/Reference/PortManipulation"
-description: Learn how to control pins on an Arduino through three different registers (DDR, PORT, PIN). 
+description: Learn how to control pins on an Arduino Uno R3 through three different registers (DDR, PORT, PIN). 
 ---
 
 ## Port Registers
 
-Port registers allow for lower-level and faster manipulation of the i/o pins of the microcontroller on an Arduino board. The chips used on the Arduino board (the ATmega8 and ATmega168) have three ports:
+Port registers allow for lower-level and faster manipulation of the i/o pins of the microcontroller on an Arduino Uno R3 board(Or similar ). The chips used on the Arduino board (the ATmega8, ATmega168, and ATmega328) have three ports:
 
 * B (digital pin 8 to 13)
 * C (analog input pins)


### PR DESCRIPTION
I added Atmega328 to the list.
Perhaps this should be updated for Uno R4?
Would be nice to reference the Arduino board as the Uno r3?

The list was missing the ATmega328 so I added it

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
