### PR TITLE
[GIGA R1] Fix SSL example

### DIFF
--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-wifi/giga-wifi.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-wifi/giga-wifi.md
@@ -729,6 +729,7 @@ by Karl Söderby
 
 #include <SPI.h>
 #include <WiFi.h>
+#include <WiFiSSLClient.h>
 
 #include "arduino_secrets.h" 
 ///////please enter your sensitive data in the Secret tab/arduino_secrets.h


### PR DESCRIPTION
## What This PR Changes
- SSL example in the **Wi-Fi** guide missed an include. This PR fixes it.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
