### PR TITLE
[MKC-1356][MKC-1357]Add more info about the Analog Reference on UNO R4

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/cheat-sheet/cheat-sheet.md
@@ -129,9 +129,12 @@ The UNO R4 Minima has six analog input pins (A0-A5) that can be read by using th
 value = analogRead(pin);
 ```
 
-The reference voltage of these pins is 5 V.
+The default reference voltage of these pins is 5 V, but this can be changed as follows:
 
-The default resolution is set to 10-bit but can be updated to 12 and 14-bit resolutions. To do so, use the following method in the `setup()` of your sketch.
+- `analogReference(AR_DEFAULT)` (Default reference of 5 V)
+- `analogReference(AR_INTERNAL)` (Built in reference of 1.5 V.)
+
+The default resolution is set to 10-bit, but can be updated to 12 and 14-bit resolutions. To do so, use the following method in the `setup()` of your sketch.
 - `analogReadResolution(10)` (default)
 - `analogReadResolution(12)`
 - `analogReadResolution(14)`

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/cheat-sheet/cheat-sheet.md
@@ -135,7 +135,10 @@ The UNO R4 WiFi has six analog input pins (A0-A5) that can be read by using the 
 value = analogRead(pin);
 ```
 
-The reference voltage of these pins is 5 V.
+The default reference voltage of these pins is 5 V, but this can be changed as follows:
+
+- `analogReference(AR_DEFAULT)` (Default reference of 5 V)
+- `analogReference(AR_INTERNAL)` (Built in reference of 1.5 V.)
 
 The default resolution is set to 10-bit, but can be updated to 12 and 14-bit resolutions. To do so, use the following method in the `setup()` of your sketch.
 - `analogReadResolution(10)` (default)


### PR DESCRIPTION
## What This PR Changes
- Expands on the documentation of the UNO R4's analog Reference in the respective cheat sheets, by adding the available options.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
