### PR TITLE
[PC-1527] Portenta Hat Carrier: Added Compatibility Tags

### DIFF
--- a/content/hardware/04.pro/boards/portenta-c33/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-c33/compatibility.yml
@@ -15,3 +15,4 @@ hardware:
   carriers:
     - portenta-breakout
     - portenta-max-carrier
+    - portenta-hat-carrier

--- a/content/hardware/04.pro/boards/portenta-c33/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-c33/datasheets/datasheet.md
@@ -303,6 +303,7 @@ The Portenta C33 is a powerful microcontroller board designed for low-cost IoT a
 - Arduino® Nicla Vision (SKU: ABX00051)
 - Arduino® Nicla Voice (SKU: ABX00061)
 - Arduino® Portenta Max Carrier (SKU: ABX00043)
+- Arduino® Portenta Hat Carrier (SKU: ASX00049)
 - Arduino® Portenta CAT.M1/NB IoT GNSS Shield (SKU: ABX00043)
 - Arduino® Portenta Vision Shield - Ethernet (SKU: ABX00021)
 - Arduino® Portenta Vision Shield - LoRa® (SKU: ABX00026)
@@ -651,7 +652,8 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 ## Document Revision History
 
 |  **Date**  | **Revision** |                      **Changes**                       |
-| :--------: | :----------: | :----------------------------------------------------: |
+|:----------:|:------------:|:------------------------------------------------------:|
+| 14/12/2023 |      6       |            Updated Related Product section             |
 | 14/11/2023 |      5       |             FCC and Block Diagram Updates              |
 | 30/10/2023 |      4       |          I2C ports information section added           |
 | 20/06/2023 |      3       | Power tree added, related products information updated |

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/compatibility.yml
@@ -24,3 +24,4 @@ hardware:
   carriers:
     - portenta-breakout
     - portenta-max-carrier
+    - portenta-hat-carrier

--- a/content/hardware/04.pro/boards/portenta-h7-lite/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/compatibility.yml
@@ -23,3 +23,4 @@ hardware:
   carriers:
     - portenta-breakout
     - portenta-max-carrier
+    - portenta-hat-carrier

--- a/content/hardware/04.pro/boards/portenta-h7/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-h7/compatibility.yml
@@ -24,3 +24,4 @@ hardware:
   carriers:
     - portenta-breakout
     - portenta-max-carrier
+    - portenta-hat-carrier

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -638,9 +638,12 @@ Laboratory equipment, Computer vision
 Due to the dual core processing, the Portenta supports a wide array of applications.  
 
 ### Accessories (Not Included)
-* Portenta Vision shield
+
 * USB 2.0 Cable Type A/B
+* Portenta Vision shield
 * Portenta Breakout Board
+* Portenta Max Carrier
+* Portenta Hat Carrier
 
 ## Functional Overview
 

--- a/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-x8/compatibility.yml
@@ -5,4 +5,5 @@ hardware:
   carriers:
     - portenta-breakout
     - portenta-max-carrier
+    - portenta-hat-carrier
     

--- a/content/hardware/04.pro/boards/portenta-x8/datasheet/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-x8/datasheet/datasheet.md
@@ -289,6 +289,7 @@ The Arduino® Portenta X8 has been designed for high-performance embedded comput
 
 - Arduino® Portenta Breakout Board (ASX00031)
 - Arduino® Portenta Max Carrier (ABX00043)
+- Arduino® Portenta Hat Carrier (ASX00049)
 
 ## Rating
 
@@ -435,7 +436,7 @@ Now that you have gone through the basics of what you can do with the board you 
 
 All Arduino boards have a built-in bootloader which allows flashing the board via USB. In case a sketch locks up the processor and the board is not reachable anymore via USB it is possible to enter bootloader mode by configuring DIP switches.
 
-**Note: A compatible carrier board with DIP switches (e.g. Portenta Max Carrier or Portenta Breakout) is required to enable bootloader mode. It cannot be enabled with the Portenta X8 alone.**
+**Note: A compatible carrier board with DIP switches (e.g. Portenta Max Carrier, Portenta Hat Carrier, or Portenta Breakout) is required to enable bootloader mode. It cannot be enabled with the Portenta X8 alone.**
 
 ## Mechanical Information
 
@@ -563,6 +564,7 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 
 | **Date**   | **Revision** | **Changes**                            |
 |------------|--------------|----------------------------------------|
+| 11/12/2023 | 5            | Add Portenta Hat Carrier compatibility |
 | 07/11/2023 | 4            | Add missing board dimensions           |
 | 26/01/2023 | 3            | Clarify open-source nature of M7 core  |
 | 12/09/2022 | 2            | Make cores clear, minor fixes          |


### PR DESCRIPTION
## What This PR Changes
Adds and updates the product page of the Portenta family documentation with the Portenta Hat Carrier compatibility tags.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
