### PR TITLE
Add missing temperature variable

### DIFF
--- a/content/arduino-cloud/11.application-notes/cloud-environmental-data/cloud-environmental-data.md
+++ b/content/arduino-cloud/11.application-notes/cloud-environmental-data/cloud-environmental-data.md
@@ -45,6 +45,7 @@ The goals of this project are:
 
 | Name            | Data type | Permission |
 | --------------- | --------- | ---------- |
+| temperature     | float     | Read Only  |
 | humidity        | float     | Read Only  |
 | illuminance     | float     | Read Only  |
 | pressure        | float     | Read Only  |


### PR DESCRIPTION
The temperature variable is missing from most screenshots of this tutorial as well as the initial list, but is present in the code example thus if the user doesn't create it in the cloud the sketch won't compile. This PR adds the variable to the list of variables to create - the screenshot will still lack it, but this fix is better than nothing. :)