### PR TITLE
Update Cloud API key creation instructions for new site design

### DIFF
--- a/content/arduino-cloud/01.guides/07.node-red/nodered-intro.md
+++ b/content/arduino-cloud/01.guides/07.node-red/nodered-intro.md
@@ -181,7 +181,7 @@ The final step is connecting the **DHT11 humidity sensor** to our Arduino MKR Wi
 
 Use the steps below to use Node-RED with the Arduino Cloud:
 
-**1.** Go to the [API keys section](https://app.arduino.cc/home/api-keys), and create a new API key.
+**1.** Go to the [API keys section](https://app.arduino.cc/api-keys), and create a new API key.
 
 **2.** Save the Client ID and Client Secret in a safe document
 

--- a/content/arduino-cloud/07.api/01.api-overview/api-overview.md
+++ b/content/arduino-cloud/07.api/01.api-overview/api-overview.md
@@ -13,7 +13,7 @@ The main goal of the Application API is to allow you to create and manage IoT re
 
 The core of those APIs is organized around  [REST](http://en.wikipedia.org/wiki/Representational_State_Transfer). Our API has predictable resource-oriented URLs, accepts  [form-encoded](https://en.wikipedia.org/wiki/POST_(HTTP)#Use_for_submitting_web_forms)  request bodies, returns  [JSON-encoded](http://www.json.org/) responses, and uses standard HTTP response codes, authentication, and verbs. 
 
-You can use those APIs, both directly calling our HTTP endpoints or using our clients that wrap those calls into easy-to-use abstractions like objects and functions. We have Applications API clients available in `javascript`, `golang`, and `python`. To use the Application API, you need to create an **API Key** in the [API Keys](https://cloud.arduino.cc/home/api-keys) section.
+You can use those APIs, both directly calling our HTTP endpoints or using our clients that wrap those calls into easy-to-use abstractions like objects and functions. We have Applications API clients available in `javascript`, `golang`, and `python`. To use the Application API, you need to create an **API Key** in the [API Keys](https://cloud.arduino.cc/api-keys) section.
 
 With this API, you can:
 - Build an automated script to create your things, in bulk

--- a/content/arduino-cloud/07.api/02.arduino-iot-api/arduino-iot-api.md
+++ b/content/arduino-cloud/07.api/02.arduino-iot-api/arduino-iot-api.md
@@ -47,9 +47,9 @@ To authenticate, you will need to generate a `clientId` and `clientSecret`. This
 
 **1.** Log in to your [Arduino account](https://cloud.arduino.cc/home/).
 
-**2.** Navigate to the [Arduino Cloud home page](https://cloud.arduino.cc/home/).
+**2.** Navigate to the [API Keys page](https://app.arduino.cc/api-keys).
 
-**3.** Click **"API keys"** at the bottom left corner, and then click **"CREATE API KEY"**. Name it, and save it as a PDF. You will **not** be able to see `clientSecret` again.
+**3.** Click **"CREATE API KEY"**. Name it, and save it as a PDF. You will **not** be able to see `clientSecret` again.
 
 ![API Keys in the Arduino Cloud](assets/api-keys.png)
 

--- a/content/arduino-cloud/08.arduino-cloud-cli/07.getting-started/arduino-cloud-cli.md
+++ b/content/arduino-cloud/08.arduino-cloud-cli/07.getting-started/arduino-cloud-cli.md
@@ -73,7 +73,7 @@ Each command has a set of **subcommands** which we will be exploring in this gui
 
 - `arduino-cloud-cli credentials`
 
-***Get your API key from the [Arduino Cloud home page](https://cloud.arduino.cc/home/) (bottom left corner of the page)***
+***Get your API key from the [Arduino Cloud API Keys page](https://app.arduino.cc/api-keys)***
 
 To authenticate with the Arduino Cloud, we will need to first set our credentials, using our `clientId` and `clientSecret` which is obtained from the Arduino Cloud API keys section.
 


### PR DESCRIPTION
The Arduino Cloud website was [recently redesigned](https://blog.arduino.cc/2023/11/15/announcing-a-better-arduino-cloud-together/). Before the redesign, API keys were managed by selecting "API keys" from the navigation panel on the Arduino Cloud home page.

That item was removed from the navigation panel and there is now a dedicated page for managing API keys. This means the instructions based on the old design are no longer correct.

## What This PR Changes

The outdated instructions for getting to the Arduino Cloud API key management interface are updated for the new Arduino Cloud site design.

The new design allows us to point the user directly to the relevant page rather than sending them to the home page and then instructing them in how to navigate to the key management interface. That navigation process is slightly more complex with the new design so continuing with the previous approach of starting from the home page would require adding an additional step to the instructions.

---

Some of the existing links to the "API Keys" page were broken, redirecting to the Arduino Cloud home page instead of the intended target. Those are updated to point to the current URL of the page.

## Additional Context

This approach of directing the user to the "API Keys" page was already in use in some of the content:

https://github.com/arduino/docs-content/blob/aa7c281ca5a298c7489f462dbef02a2d880c1bd7/content/arduino-cloud/01.guides/07.node-red/nodered-intro.md?plain=1#L184

https://github.com/arduino/docs-content/blob/aa7c281ca5a298c7489f462dbef02a2d880c1bd7/content/arduino-cloud/07.api/01.api-overview/api-overview.md?plain=1#L16

https://github.com/arduino/docs-content/blob/aa7c281ca5a298c7489f462dbef02a2d880c1bd7/content/arduino-cloud/07.api/01.api-overview/api-overview.md?plain=1#L16

---

An update of a graphic is also required but I'm not set up for that so I was not able to include that in this PR. I submitted an issue to track the task: https://github.com/arduino/docs-content/issues/1615

---

Originally reported at https://forum.arduino.cc/t/api-key-generation-page-not-available-on-home-screen/1200517

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
