### PR TITLE
Arduino Pro Tutorial removed

### DIFF
--- a/content/hardware/04.pro/boards/portenta-c33/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-c33/essentials.md
@@ -14,10 +14,6 @@
 
 </EssentialElement>
 
-<EssentialElement link="https://github.com/arduino-libraries/Arduino_Pro_Tutorials" title="Arduino Pro Tutorials" type="library">
-        The complete Arduino sketches from the Pro tutorials.
-</EssentialElement>
-
 </EssentialsColumn>
 
 <EssentialsColumn title="Arduino Basics">


### PR DESCRIPTION
## What This PR Changes
- Arduino Pro Tutorial removed

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
