### PR TITLE
Update WiFiRTC.md regarding the timezone

### DIFF
--- a/content/library-examples/wifi-library/WiFiRTC/WiFiRTC.md
+++ b/content/library-examples/wifi-library/WiFiRTC/WiFiRTC.md
@@ -155,7 +155,7 @@ void setup() {
 
     Serial.println(epoch);
 
-    rtc.setEpoch(epoch);
+    rtc.setEpoch(epoch+ GMT*3600); //Add the time zone to the epoch
 
     Serial.println();
 
@@ -176,7 +176,7 @@ void loop() {
 void printTime()
 {
 
-  print2digits(rtc.getHours() + GMT);
+  print2digits(rtc.getHours());
 
   Serial.print(":");
 


### PR DESCRIPTION
## What This PR Changes
Correction on the code to handle the GMT info.

The orginial code adds the GMT variable at the moment of printing the hour:
 _print2digits(rtc.getHours() + GMT);_

But the concept is wrong because only operates hours but doesn't contemplate if that operation affects the change of date (adding or subtracting). The correct way is to add/substract 3600 seconds per hour of GMT to the value got from epoch:
_rtc.setEpoch(epoch+ GMT*3600); //Add the time zone to the epoch_

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
