### PR TITLE
Renaming boards in tutorial for setup guide

### DIFF
--- a/content/software/ide-v1/tutorials/getting-started/cores/arduino-avr/arduino-avr.md
+++ b/content/software/ide-v1/tutorials/getting-started/cores/arduino-avr/arduino-avr.md
@@ -1,5 +1,5 @@
 ---
-title: 'Installing classic AVR boards.'
+title: 'Installing classic AVR boards'
 compatible-products: [uno-rev3, uno, micro, mega, leonardo, nano]
 difficulty: beginner
 description: 'A quick guide to installing classic Arduino boards, including the UNO, Mega, Leonardo and Micro.'
@@ -19,11 +19,11 @@ You can download the editor from [our software page](https://www.arduino.cc/en/s
 ### Boards using the AVR core
 
 - Arduino UNO R3
-- Arduino Mega2560
+- Arduino Mega 2560 Rev3
 - Arduino Nano (classic)
 - Arduino Micro
 - Arduino Leonardo
-- UNO Mini LE
+- Arduino UNO Mini Limited Edition
 
 ### Retired boards using the AVR core
 

--- a/content/software/ide-v1/tutorials/getting-started/cores/arduino-avr/arduino-avr.md
+++ b/content/software/ide-v1/tutorials/getting-started/cores/arduino-avr/arduino-avr.md
@@ -19,6 +19,7 @@ You can download the editor from [our software page](https://www.arduino.cc/en/s
 ### Boards using the AVR core
 
 - Arduino UNO R3
+- Arduino UNO R3 SMD
 - Arduino Mega 2560 Rev3
 - Arduino Nano (classic)
 - Arduino Micro


### PR DESCRIPTION
## What This PR Changes
- The Setup Guide is still used by many users, so it's important we keep the tutorials in it up to date with names. This PR updates some names in the product list.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
