### PR TITLE
[GIGA R1 WiFi] Update M4 compatibility

### DIFF
--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-dual-core/giga-dual-core.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/giga-dual-core/giga-dual-core.md
@@ -41,7 +41,6 @@ In this guide you will discover:
 The M4 processor can access most of the peripherals that the M7 can access, with some exceptions.
 
 The M4 supports:
-- Wi-Fi®
 - I2C
 - SPI
 - UART
@@ -51,6 +50,7 @@ The M4 supports:
 - Bluetooth® Low Energy (via [ArduinoBLE Library](https://www.arduino.cc/reference/en/libraries/arduinoble/))
 
 The M4 does **not** support:
+- Wi-Fi®
 - Serial communication\*
 - [Arduino Cloud](https://app.arduino.cc) sketches.
 


### PR DESCRIPTION
## What This PR Changes
- Wi-Fi is currently not working on the M4. This PR removes it until the issue has been resolved.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
