### PR TITLE
Fix computation of half wavelength in I2s-library-examples.md

### DIFF
--- a/content/tutorials/generic/I2s-library-examples/I2s-library-examples.md
+++ b/content/tutorials/generic/I2s-library-examples/I2s-library-examples.md
@@ -150,7 +150,7 @@ const int amplitude = 500; // amplitude of square wave
 
 const int sampleRate = 8000; // sample rate in Hz
 
-const int halfWavelength = (sampleRate / frequency); // half wavelength of square wave
+const int halfWavelength = (sampleRate / frequency) / 2; // half wavelength of square wave
 
 short sample = amplitude; // current sample value
 int count = 0;


### PR DESCRIPTION
Dividing the sampleRate by the frequency results in the number of samples per complete wave. For example: with a sampling rate of 24 and a 4Hz frequency we have 24/4 -> 6 samples, which represent a wave peak to peak; we still need to divide by 2 to have its half.

## What This PR Changes
The PR modifies an example code, fixing what I believe is a small mistake. I am not sure if the same mistake is also anywhere else.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
