### PR TITLE
Portenta Hat Carrier: Secondary Button for Product Page for Pinout

### DIFF
--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/product.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/product.md
@@ -4,6 +4,8 @@ url_shop: https://store.arduino.cc/products/portenta-hat-carrier
 url_guide: /tutorials/portenta-hat-carrier/user-manual
 primary_button_url: /tutorials/portenta-hat-carrier/user-manual
 primary_button_title: User Manual
+secondary_button_url: /interactive/ASX00049-pinout.png
+secondary_button_title: Simple Pinout
 certifications: [CE, UKCA, RoHS, FCC, IC, RCM]
 ---
 


### PR DESCRIPTION
## What This PR Changes
Adds a secondary button in the Portenta Hat Carrier product page linked to a pinout file. Either the complete or simple pinout.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
