### PR TITLE
[Arduino Cloud] Add UNO R4 to OTA list 

### DIFF
--- a/content/arduino-cloud/01.guides/01.cloud-editor/getting-started-cloud-editor.md
+++ b/content/arduino-cloud/01.guides/01.cloud-editor/getting-started-cloud-editor.md
@@ -4,6 +4,7 @@ description: 'A step-by-step guide to set up your online development environment
 author: 'Karl Söderby'
 ---
 
+***Please note that this documentation refers to the old Web Editor version that soon will be replaced. See the documentation for the [Cloud Editor (New)](https://docs.arduino.cc/arduino-cloud/guides/editor/).***
 
 The Cloud Editor is a great choice for working with your Arduino board. It stores all of your sketches online, doesn't require you to install board packages and includes most of the popular libraries, while letting you upload your own if you need to.
 

--- a/content/arduino-cloud/06.features/04.ota-getting-started/ota-getting-started.md
+++ b/content/arduino-cloud/06.features/04.ota-getting-started/ota-getting-started.md
@@ -23,6 +23,7 @@ OTA is supported on several Arduino devices, as well as many ESP32 devices.
 
 ### Supported Arduino Boards
 
+- [Arduino UNO R4 WiFi](https://store.arduino.cc/products/uno-r4-wifi)
 - [Arduino MKR WiFi 1010](https://store.arduino.cc/mkr-wifi-1010)
 - [Arduino Nano 33 IoT](https://store.arduino.cc/arduino-nano-33-iot)
 - [Arduino Nano RP2040 Connect](https://store.arduino.cc/nano-rp2040-connect-with-headers)


### PR DESCRIPTION
## What This PR Changes
- UNO R4 is now OTA supported and is added to the list of supported boards in the OTA article.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
