### PR TITLE
updated name of uno r4 boards

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/datasheet/datasheet.md
@@ -88,7 +88,7 @@ The board features the standard 14 digital I/O ports, 6 analog channels, dedicat
 
 ## Block Diagram
 
-![Arduino R4 Minima Block Diagram](assets/UNO_R4_Minima_Block_Diagram.png)
+![Arduino UNO R4 Minima Block Diagram](assets/UNO_R4_Minima_Block_Diagram.png)
 
 ## Board Topology
 
@@ -111,7 +111,7 @@ The board features the standard 14 digital I/O ports, 6 analog channels, dedicat
 
 ### Back View
 
-![Back View of Arduino R4 Minima](assets/backViewMinima.svg)
+![Back View of Arduino UNO R4 Minima](assets/backViewMinima.svg)
 
 ## Microcontroller (R7FA4M1AB3CFM#AA0)
 

--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/adc-resolution/adc-resolution.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/adc-resolution/adc-resolution.md
@@ -18,7 +18,7 @@ The goals of this tutorials are:
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- [Arduino R4 Minima](https://store.arduino.cc/uno-r4-minima)
+- [Arduino UNO R4 Minima](https://store.arduino.cc/uno-r4-minima)
 - [UNO R4 Board Package](/tutorials/uno-r4-minima/minima-getting-started)
 
 ## Analog-to-Digital Converter (ADC) 

--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/can/can.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/can/can.md
@@ -20,7 +20,7 @@ The goals of this tutorial are:
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- [Arduino R4 Minima](https://store.arduino.cc/uno-r4-minima)
+- [Arduino UNO R4 Minima](https://store.arduino.cc/uno-r4-minima)
 - [UNO R4 Board Package](/tutorials/uno-r4-minima/minima-getting-started)
 - CAN transceiver module * 
 - Jumper wires

--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/debugger/debugger.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/debugger/debugger.md
@@ -31,7 +31,7 @@ The goals of this tutorial are:
 ## Hardware & Software Needed
 
 - [Arduino IDE](https://www.arduino.cc/en/main/software)
-- [Arduino R4 Minima](https://store.arduino.cc/uno-r4-minima)
+- [Arduino UNO R4 Minima](https://store.arduino.cc/uno-r4-minima)
 - [UNO R4 Board Package](/tutorials/uno-r4-minima/minima-getting-started)
 - [Segger J-Link](https://www.segger.com/products/debug-probes/j-link/)
 - [Ozone](https://www.segger.com/products/development-tools/ozone-j-link-debugger/)

--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/eeprom/eeprom.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/eeprom/eeprom.md
@@ -19,7 +19,7 @@ The goals of this tutorials are:
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software)) 
 - USB-C cable 
-- [Arduino R4 Minima](/hardware/uno-r4-minima)
+- [Arduino UNO R4 Minima](/hardware/uno-r4-minima)
 - [UNO R4 Board Package](/tutorials/uno-r4-minima/minima-getting-started)
 
 ## EEPROM

--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/rtc/rtc.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/rtc/rtc.md
@@ -20,7 +20,7 @@ The goals of this project are:
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- [Arduino R4 Minima](https://store.arduino.cc/uno-r4-minima)
+- [Arduino UNO R4 Minima](https://store.arduino.cc/uno-r4-minima)
 - [UNO R4 Board Package](/tutorials/uno-r4-minima/minima-getting-started)
 
 ## Real-Time Clock (RTC)

--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/usb-hid/usb-hid.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/usb-hid/usb-hid.md
@@ -23,7 +23,7 @@ The goals of this tutorial are to:
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- [Arduino R4 Minima](https://store.arduino.cc/uno-r4-minima)
+- [Arduino UNO R4 Minima](https://store.arduino.cc/uno-r4-minima)
 - [UNO R4 Board Package](/tutorials/uno-r4-minima/minima-getting-started)
 
 ## Human Interface Device (HID) 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/datasheet/datasheet.md
@@ -104,7 +104,7 @@ In addition, it features an ESP32-S3 module for Wi-Fi® & Bluetooth® connectivi
 
 ## Block Diagram
 
-![Arduino R4 WiFi Block Diagram](assets/UNO_R4_WiFi_Block_Diagram.png)
+![Arduino UNO R4 WiFi Block Diagram](assets/UNO_R4_WiFi_Block_Diagram.png)
 
 ## Board Topology
 
@@ -597,7 +597,7 @@ UNO R4 WiFi是第一代32位开发板的一部分, 之前基于8位AVR微控制�
 
 ## 方框图
 
-![Arduino R4 WiFi 框图](assets/UNO_R4_WiFi_Block_Diagram.png)
+![Arduino UNO R4 WiFi 框图](assets/UNO_R4_WiFi_Block_Diagram.png)
 
 ## 板卡拓扑
 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/adc-resolution/adc-resolution.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/adc-resolution/adc-resolution.md
@@ -20,7 +20,7 @@ The goals of this tutorials are:
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- [Arduino R4 WiFi](https://store.arduino.cc/uno-r4-wifi)
+- [Arduino UNO R4 WiFi](https://store.arduino.cc/uno-r4-wifi)
 - [UNO R4 Board Package](/tutorials/uno-r4-wifi/r4-wifi-getting-started)
 
 ## Analog-to-Digital Converter (ADC) 

--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/eeprom/eeprom.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/eeprom/eeprom.md
@@ -21,7 +21,7 @@ The goals of this tutorials are:
 ## Hardware & Software Needed
 
 - Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software))
-- [Arduino R4 WiFi](https://store.arduino.cc/uno-r4-wifi)
+- [Arduino UNO R4 WiFi](https://store.arduino.cc/uno-r4-wifi)
 - [UNO R4 Board Package](/tutorials/uno-r4-wifi/r4-wifi-getting-started)
 
 ## EEPROM


### PR DESCRIPTION
## What This PR Changes
Some tutorials for the UNO R4's had the incorrect name in the tutorials and datasheets. This PR updates the names.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
