### PR TITLE
Added forum slug to products missing them

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-nb-1500/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-nb-1500/product.md
@@ -3,7 +3,6 @@ title: MKR NB 1500
 url_shop: https://store.arduino.cc/arduino-mkr-nb-1500
 url_guide: /software/ide-v2/tutorials/ide-v2-board-manager#samd
 primary_button_url: /software/ide-v2/tutorials/ide-v2-board-manager#samd
-
 primary_button_title: Get Started
 core: arduino:samd
 forumCategorySlug: '/hardware/mkr-boards/mkrnb1500/156'

--- a/content/hardware/01.mkr/01.boards/mkr-wan-1300/product.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wan-1300/product.md
@@ -5,7 +5,7 @@ url_guide: /software/ide-v2/tutorials/ide-v2-board-manager#samd
 primary_button_url: /software/ide-v2/tutorials/ide-v2-board-manager#samd
 primary_button_title: Get Started
 core: arduino:samd
-forumCategorySlug: '/hardware/mkr-boards/mkrwan1310/161'
+forumCategorySlug: '/hardware/mkr-boards/mkrwan1300/145'
 certifications: [CE, UKCA]
 productCode: '129'
 ---

--- a/content/hardware/01.mkr/02.shields/mkr-485-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-485-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-485-shield
 url_guide: /tutorials/mkr-485-shield/mkr-485-communication
 primary_button_url: /tutorials/mkr-485-shield/mkr-485-communication
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-can-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-can-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-can-shield
 url_guide: /tutorials/mkr-can-shield/mkr-can-communication
 primary_button_url: /tutorials/mkr-can-shield/mkr-can-communication
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-env-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-env-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/mkr-env-shield-r2
 url_guide: /tutorials/mkr-env-shield/mkr-env-shield-basic
 primary_button_url: /tutorials/mkr-env-shield/mkr-env-shield-basic
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-eth-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-eth-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-eth-shield
 url_guide: /tutorials/mkr-eth-shield/mkr-eth-shield-webserver
 primary_button_url: /tutorials/mkr-eth-shield/mkr-eth-shield-webserver
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-gps-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-gps-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-gps-shield
 url_guide: /tutorials/mkr-gps-shield/mkr-gps-basic
 primary_button_url: /tutorials/mkr-gps-shield/mkr-gps-basic
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-imu-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-imu-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-imu-shield
 url_guide: /tutorials/mkr-imu-shield/mkr-imu-shield-basics
 primary_button_url: /tutorials/mkr-imu-shield/mkr-imu-shield-basics
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-mem-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-mem-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-mem-shield
 url_guide: /tutorials/mkr-mem-shield/mkr-mem-shield-data-logger
 primary_button_url: /tutorials/mkr-mem-shield/mkr-mem-shield-data-logger
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-relay-proto-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-relay-proto-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-relay-proto-shield
 url_guide: /tutorials/mkr-relay-proto-shield/mkr-relay-shield-basic
 primary_button_url: /tutorials/mkr-relay-proto-shield/mkr-relay-shield-basic
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-rgb-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-rgb-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-rgb-shield
 url_guide: /tutorials/mkr-rgb-shield/mkr-rgb-fade
 primary_button_url: /tutorials/mkr-rgb-shield/mkr-rgb-fade
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-sd-proto-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-sd-proto-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/mkr-sd-proto-shield
 url_guide: /tutorials/mkr-sd-proto-shield/mkr-sd-proto-shield-data-logger
 primary_button_url: /tutorials/mkr-sd-proto-shield/mkr-sd-proto-shield-data-logger
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/02.shields/mkr-therm-shield/product.md
+++ b/content/hardware/01.mkr/02.shields/mkr-therm-shield/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-therm-shield
 url_guide: /tutorials/mkr-therm-shield/mkr-therm-shield-basic
 primary_button_url: /tutorials/mkr-therm-shield/mkr-therm-shield-basic
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/03.carriers/mkr-connector-carrier/product.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-connector-carrier/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-connector-carrier
 url_guide: /tutorials/mkr-connector-carrier/connector-basics
 primary_button_url: /tutorials/mkr-connector-carrier/connector-basics
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier-rev2/product.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier-rev2/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/mkr-iot-carrier-rev2
 url_guide: https://docs.arduino.cc/tutorials/mkr-iot-carrier-rev2/cheat-sheet
 primary_button_url: /tutorials/mkr-iot-carrier-rev2/cheat-sheet
 primary_button_title: Cheat Sheet
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/product.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/product.md
@@ -5,6 +5,7 @@ url_guide: https://opla.arduino.cc/
 primary_button_url: https://opla.arduino.cc/
 primary_button_title: Get Started
 url_datasheet: ''
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [REACH, FCC, RoHS, CE, RCM, IC, UKCA, WEEE]
 ---
 

--- a/content/hardware/01.mkr/03.carriers/mkr-motor-carrier/product.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-motor-carrier/product.md
@@ -4,6 +4,7 @@ url_shop: https://store.arduino.cc/arduino-mkr-motor-carrier
 url_guide: /tutorials/mkr-motor-carrier/mkr-motor-carrier-battery
 primary_button_url: /tutorials/mkr-motor-carrier/mkr-motor-carrier-battery
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/mkr-boards/mkr-shields/162'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/02.hero/boards/leonardo/product.md
+++ b/content/hardware/02.hero/boards/leonardo/product.md
@@ -6,6 +6,7 @@ primary_button_url: /software/ide-v2/tutorials/ide-v2-board-manager#avr
 primary_button_title: Get Started
 core: arduino:avr
 productCode: '008'
+forumCategorySlug: '/hardware/12'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/02.hero/boards/micro/product.md
+++ b/content/hardware/02.hero/boards/micro/product.md
@@ -6,6 +6,7 @@ primary_button_url: /software/ide-v2/tutorials/ide-v2-board-manager#avr
 primary_button_title: Get Started
 core: arduino:avr
 productCode: '006'
+forumCategorySlug: '/hardware/12'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/02.hero/boards/uno-mini-le/product.md
+++ b/content/hardware/02.hero/boards/uno-mini-le/product.md
@@ -6,6 +6,7 @@ primary_button_url: /tutorials/uno-mini-le/uno-mini-le-guide
 primary_button_title: Get Started
 core: arduino:avr
 productCode: '117'
+forumCategorySlug: '/hardware/12'
 certifications: [CE, UKCA, FCC, RCM, RoHS]
 ---
 

--- a/content/hardware/02.hero/boards/uno-r4-minima/product.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/product.md
@@ -5,6 +5,7 @@ url_guide: /tutorials/uno-r4-minima/minima-getting-started
 primary_button_url: /tutorials/uno-r4-minima/minima-getting-started
 primary_button_title: Get Started
 certifications: [CE, UKCA, RoHS, FCC, RCM, IC]
+forumCategorySlug: '/hardware/uno-r4/uno-r4-minima/188'
 ---
 
 The Arduino UNO R4 Minima is the first UNO board featuring a 32-bit microcontroller, the RA4M1 from [Renesas](https://www.renesas.com/us/en). It is faster, has more memory and has a number of built-in features such as a [DAC](/tutorials/uno-r4-minima/dac), [RTC](/tutorials/uno-r4-minima/rtc) and [HID](/tutorials/uno-r4-minima/usb-hid). The UNO R4 Minima is a **5 V only** board.

--- a/content/hardware/02.hero/boards/uno-r4-wifi/product.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/product.md
@@ -5,6 +5,7 @@ url_guide: /tutorials/uno-r4-wifi/r4-wifi-getting-started
 certifications: [CE, UKCA, RCM, MIC, FCC, IC, KC]
 primary_button_url: /tutorials/uno-r4-wifi/r4-wifi-getting-started
 primary_button_title: Get Started
+forumCategorySlug: '/hardware/uno-r4/uno-r4-wifi/189'
 ---
 
 The Arduino UNO R4 WiFi is designed around the 32-bit microcontroller RA4M1 from [Renesas](https://www.renesas.com/us/en) while also featuring a ESP32 module for Wi-Fi® and Bluetooth® connectivity. Its distinctive 12x8 LED matrix makes it possible to prototype visuals directly on the board, and with a Qwiic connector, you can create projects plug-and-play style.

--- a/content/hardware/02.hero/boards/uno-rev3-smd/product.md
+++ b/content/hardware/02.hero/boards/uno-rev3-smd/product.md
@@ -5,6 +5,7 @@ url_guide: /software/ide-v2/tutorials/ide-v2-board-manager#avr
 primary_button_url: /software/ide-v2/tutorials/ide-v2-board-manager#avr
 primary_button_title: Get Started
 core: arduino:avr
+forumCategorySlug: '/hardware/12'
 certifications: [CE, UKCA]
 ---
 

--- a/content/hardware/02.hero/boards/uno-rev3/product.md
+++ b/content/hardware/02.hero/boards/uno-rev3/product.md
@@ -6,6 +6,7 @@ primary_button_url: /software/ide-v2/tutorials/ide-v2-board-manager#avr
 primary_button_title: Get Started
 core: arduino:avr
 certifications: [CE, FCC, GB4943, IC, RCM, REACH, RoHS, UKCA, WEEE]
+forumCategorySlug: '/hardware/12'
 productCode: '001'
 ---
 

--- a/content/hardware/02.hero/boards/uno-wifi-rev2/product.md
+++ b/content/hardware/02.hero/boards/uno-wifi-rev2/product.md
@@ -7,6 +7,7 @@ primary_button_title: Get Started
 core: arduino:megaavr
 certifications: [CE, UKCA]
 productCode: '023'
+forumCategorySlug: '/hardware/arduino-wifi-rev2/84'
 ---
 
 The Arduino UNO WiFi Rev2 is the easiest point of entry to basic IoT with the standard form factor of the UNO family. Whether you are looking at building a sensor network connected to your office or home router, or if you want to create a Bluetooth® Low Energy device sending data to a cellphone, the Arduino UNO WiFi Rev2 is your one-stop-solution for many of the basic IoT application scenarios.

--- a/content/hardware/02.hero/boards/yun-rev2/product.md
+++ b/content/hardware/02.hero/boards/yun-rev2/product.md
@@ -4,6 +4,7 @@ core: arduino:avr
 status: end-of-life
 certifications: [CE, UKCA]
 productCode: '127'
+forumCategorySlug: '/hardware/12'
 ---
 
 The Yún Rev2, Linux powered board with the Arduino simplicity, is the perfect board for your IoT projects!

--- a/content/hardware/02.hero/shields/4-relays-shield/product.md
+++ b/content/hardware/02.hero/shields/4-relays-shield/product.md
@@ -5,6 +5,7 @@ url_guide: /tutorials/4-relays-shield/4-relay-shield-basics
 primary_button_url: /tutorials/4-relays-shield/4-relay-shield-basics
 primary_button_title: Get Started
 certifications: [CE, UKCA]
+forumCategorySlug: '/hardware/12'
 ---
 
 The Arduino 4 Relays Shield allows your Arduino driving high power loads.

--- a/content/hardware/02.hero/shields/9-axis-motion-shield/product.md
+++ b/content/hardware/02.hero/shields/9-axis-motion-shield/product.md
@@ -2,6 +2,7 @@
 title: 9 Axis Motion Shield
 url_shop: https://store.arduino.cc/arduino-9-axis-motion-shield
 certifications: [CE, UKCA]
+forumCategorySlug: '/hardware/12'
 ---
 
 Allow your Arduino to measure movement: orientation, acceleration and magnetic field!

--- a/content/hardware/02.hero/shields/ethernet-shield-rev2/product.md
+++ b/content/hardware/02.hero/shields/ethernet-shield-rev2/product.md
@@ -5,6 +5,7 @@ url_guide: https://www.arduino.cc/en/Guide/ArduinoEthernetShield
 primary_button_url: retired/getting-started-guides/ArduinoEthernetShield
 primary_button_title: Get Started
 certifications: [CE, UKCA]
+forumCategorySlug: '/hardware/12'
 ---
 
 Have an idea for a network project? Connect your Arduino to an ethernet shield and you will quickly be able to start sending sensor data to your network to interact with other gadgets in your home.  

--- a/content/hardware/02.hero/shields/motor-shield-rev3/product.md
+++ b/content/hardware/02.hero/shields/motor-shield-rev3/product.md
@@ -5,6 +5,7 @@ url_guide: /tutorials/motor-shield-rev3/msr3-controlling-dc-motor
 primary_button_url: /tutorials/motor-shield-rev3/msr3-controlling-dc-motor
 primary_button_title: Get Started
 certifications: [CE, UKCA]
+forumCategorySlug: '/hardware/12'
 ---
 
 The Arduino Motor Shield allows your arduino to drive DC and stepper motors, relays and solenoids.

--- a/content/hardware/03.nano/boards/nano-esp32/product.md
+++ b/content/hardware/03.nano/boards/nano-esp32/product.md
@@ -6,6 +6,7 @@ primary_button_url: /tutorials/nano-esp32/getting-started-nano-esp32
 primary_button_title: Get Started
 core: arduino:esp32
 certifications: [CE, UKCA, RoHS]
+forumCategorySlug: '/hardware/nano-family/nano-esp32/190'
 ---
 
 The Arduino Nano ESP32 is the first ever Arduino board based on a ESP32 microcontroller from [Espressif](https://www.espressif.com/en/products/socs/esp32), the **NORA-W106 module** from u-blox®. USB-C® connector, 16 MB (128 Mbit) of Flash, support for MicroPython & Arduino Cloud enabled, it is a very versatile development board.

--- a/content/hardware/03.nano/carriers/nano-motor-carrier/product.md
+++ b/content/hardware/03.nano/carriers/nano-motor-carrier/product.md
@@ -2,6 +2,7 @@
 title: Nano Motor Carrier
 url_shop: https://store.arduino.cc/nano-motor-carrier
 certifications: [CE, UKCA]
+forumCategorySlug: '/hardware/12'
 ---
 
 The Nano Motor Carrier provides a quick and easy way to connect and control motors in your Engineering Kit Rev2.

--- a/content/hardware/03.nano/carriers/nano-screw-terminal-adapter/product.md
+++ b/content/hardware/03.nano/carriers/nano-screw-terminal-adapter/product.md
@@ -5,6 +5,7 @@ url_guide: /tutorials/nano-screw-terminal-adapter/getting-started-nano-screw-ter
 primary_button_url: /tutorials/nano-screw-terminal-adapter/getting-started-nano-screw-terminal
 primary_button_title: Get Started
 certifications: [CE, FCC, IC, RCM, REACH, RoHS, UKCA, WEEE]
+forumCategorySlug: '/hardware/12'
 ---
 
 The Nano Screw Terminal Adapter is a simple design that allows you to create robust designs with your Nano boards.

--- a/content/hardware/08.edu/carriers/braccio-carrier/product.md
+++ b/content/hardware/08.edu/carriers/braccio-carrier/product.md
@@ -1,6 +1,7 @@
 ---
 title: Braccio Carrier 
 url_shop: https://store.arduino.cc/products/braccioplusplus
+forumCategorySlug: '/hardware/12'
 ---
 
 The Arduino® Braccio Carrier enables you to quickly and efficiently pursue your projects and ideas within e.g. robotics and automation with the Braccio ++. The carrier is equipped with connectors, a display and joystick to enhance the experience.

--- a/content/hardware/10.mega/boards/giga-r1-wifi/product.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/product.md
@@ -6,6 +6,7 @@ primary_button_url: /tutorials/giga-r1-wifi/giga-getting-started
 primary_button_title: Get Started
 core: arduino:mbed_giga
 certifications: [CE, UKCA]
+forumCategorySlug: '/hardware/giga-r1/182'
 ---
 
 The **GIGA R1 WiFi** is a powerful, feature-packed board with a large amount of GPIOs and dedicated connectors. Based on the [STM32H747XI](/resources/datasheets/stm32h747xi.pdf) micro based on the [Mbed OS](https://os.mbed.com/), the GIGA R1 WiFi features 76 GPIOs, a [dual core processor](/tutorials/giga-r1-wifi/giga-dual-core), [advanced ADC/DAC](/tutorials/giga-r1-wifi/giga-audio) features as well as camera & display connectors. It also has a rich [USB interface](/tutorials/giga-r1-wifi/giga-usb) with support for HID via USB-C® and USBHost (keyboard, mass storage) via a dedicated USB-A connector.

--- a/content/hardware/10.mega/boards/mega-2560/product.md
+++ b/content/hardware/10.mega/boards/mega-2560/product.md
@@ -7,6 +7,7 @@ primary_button_title: Get Started
 core: arduino:avr
 productCode: '002'
 certifications: [CE, FCC, UKCA]
+forumCategorySlug: '/hardware/12'
 ---
 
 The 8-bit board with 54 digital pins, 16 analog inputs, and 4 serial ports.

--- a/content/hardware/10.mega/shields/giga-display-shield/product.md
+++ b/content/hardware/10.mega/shields/giga-display-shield/product.md
@@ -5,6 +5,7 @@ url_guide: /tutorials/giga-display-shield/getting-started
 primary_button_url: /tutorials/giga-display-shield/getting-started
 primary_button_title: Get Started
 certifications: [CE, UKCA, RoHS]
+forumCategorySlug: '/hardware/giga-display-shield/191'
 ---
 
 The **GIGA Display Shield** is a touch screen solution for quickly and easily deploying UI and visual solutions to your [GIGA R1 WiFi](/hardware/giga-r1-wifi) projects, with a 800x480 RGB touch display and support for several UI building frameworks.


### PR DESCRIPTION
## What This PR Changes
To make the footer of the products contextual to the product page we are on, we can add the `forumCategorySlug` to link to the relevant forum category.

This PR updates all products under the `maker` umbrella.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
