### PR TITLE
[PC-1490] [PC-1474] Portenta Hat Carrier: User Manual GPIO Information Update

### DIFF
--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2470,53 +2470,55 @@ The __Connector__ column shows the position of each GPIO pin within the Portenta
 
 This logic applies to all listed GPIOs. The GPIOs in the table are controllable, and each pin may have its specific function.
 
-|       **Connector**       | **Pin number** |        **Function**         | **Portenta X8<br>(Linux / Python® [BCM Mode])** | **Portenta X8<br>(Arduino*)** | **Portenta H7** | **Portenta C33** |
-|:-------------------------:|:--------------:|:---------------------------:|:-----------------------------------------------:|:-----------------------------:|:---------------:|:----------------:|
-|  _40-Pin Connector (J5)_  |                |                             |                                                 |                               |                 |                  |
-|                           |       3        |          I2C2 SDA           |                     149 / 2                     |                               |      PH_12      |        39        |
-|                           |       5        |          I2C2 SCL           |                     148 / 3                     |                               |      PH_11      |        40        |
-|                           |       7        |            PWM0             |                     183 / 4                     |             PC_7              |      PA_8       |        0         |
-|                           |       8        |         SERIAL3 TX          |                    157 / 14                     |                               |      PL_8       |        53        |
-|                           |       10       |         SERIAL3 RX          |                    156 / 15                     |                               |      PJ_9       |        54        |
-|                           |       11       |            GPIO2            |                    162 / 17                     |             PF_3              |      PD_4       |        29        |
-|                           |       12       |           I2S CK            |                     87 / 18                     |                               |      PD_3       |        63        |
-|                           |       13       |            GPIO6            |                    166 / 27                     |             PE_11             |      PG_10      |        33        |
-|                           |       15       |   SAI D0 _(OUTPUT ONLY)_    |                    108 / 22                     |                               |      PI_6       |        80        |
-|                           |       16       |   SAI CK _(OUTPUT ONLY)_    |                    107 / 23                     |                               |      PI_5       |        78        |
-|                           |       18       |   SAI FS _(OUTPUT ONLY)_    |                    106 / 24                     |                               |      PI_7       |        79        |
-|                           |       19       | SPI1 COPI _(DTB Activated)_ |                    135 / 10                     |                               |      PC_3       |        46        |
-|                           |       21       | SPI1 CIPO _(DTB Activated)_ |                     136 / 9                     |                               |      PC_2       |        45        |
-|                           |       22       |            PWM1             |                    184 / 25                     |             PA_9              |      PC_6       |        1         |
-|                           |       23       | SPI1 SCK _(DTB Activated)_  |                    134 / 11                     |                               |      PI_0       |        47        |
-|                           |       24       |  SPI1 CE _(DTB Activated)_  |                     137 / 8                     |                               |      PI_1       |        48        |
-|                           |       26       |            PWM2             |                     185 / 7                     |             PA_10             |      PC_7       |        2         |
-|                           |       29       |         SERIAL1 RX          |                     127 / 5                     |                               |      PA_10      |        13        |
-|                           |       31       |            PWM3             |                     186 / 6                     |             PB_10             |      PG_7       |        3         |
-|                           |       32       |         SERIAL1 TX          |                    128 / 12                     |                               |      PA_9       |        14        |
-|                           |       33       |            PWM4             |                    187 / 13                     |             PA_11             |      PJ_11      |        4         |
-|                           |       35       |           I2S WS            |                     86 / 19                     |                               |      PB_9       |        64        |
-|                           |       36       |            PWM5             |                    188 / 16                     |             PD_15             |      PK_1       |        5         |
-|                           |       37       |            PWM6             |                    189 / 26                     |             PA_8              |      PH_15      |        6         |
-|                           |       38       |           I2S SDI           |                     85 / 20                     |                               |      PI_2       |        65        |
-|                           |       40       |           I2S SDO           |                     88 / 21                     |                               |      PI_3       |        66        |
-|  _16-Pin Connector (J6)_  |                |                             |                                                 |                               |                 |                  |
-|                           |       1        |        Analog 0 - A0        |                       167                       |              A0               |   PA_0C / A0    |        15        |
-|                           |       2        |        Analog 1 - A1        |                       168                       |              A1               |   PA_1C / A1    |        16        |
-|                           |       3        |        Analog 2 - A2        |                       169                       |              A2               |   PC_2C / A2    |        17        |
-|                           |       4        |        Analog 3 - A3        |                       170                       |              A3               |   PC_3C / A3    |        18        |
-|                           |       5        |        Analog 4 - A4        |                       171                       |              A4               |    PC_2 / A4    |        19        |
-|                           |       6        |        Analog 5 - A5        |                       172                       |              A5               |    PC_3 / A5    |        20        |
-|                           |       7        |        Analog 6 - A6        |                       173                       |              A6               |    PA_4 / A6    |        21        |
-|                           |       8        |        Analog 7 - A7        |                       174                       |              A7               |    PA_6 / A7    |        22        |
-|                           |       9        |            PWM7             |                       190                       |             PC_6              |      PJ_7       |        7         |
-|                           |       10       |            PWM8             |                       191                       |             PA_12             |      PJ_10      |        8         |
-|                           |       12       |            PWM4             |                       187                       |             PA_11             |      PJ_11      |        4         |
-|                           |       14       |         SERIAL2 TX          |                       155                       |                               |      PG_14      |        49        |
-|                           |       16       |         SERIAL2 RX          |                       154                       |                               |      PG_9       |        50        |
-| _PWM Fan Connector (J11)_ |                |                             |                                                 |                               |                 |                  |
-|                           |       1        |            PWM9             |                       192                       |             PC_8              |      PH_6       |        25        |
-|    _On-Board Element_     |                |                             |                                                 |                               |                 |                  |
-|                           |       -        |      GPIO3 (User LED)       |                       163                       |             PF_4              |      PD_5       |        30        |
+|       **Connector**       | **Pin number** |              **Function**              | **Portenta X8<br>(Linux)** | **Portenta X8<br>(Python® - Modes:<br>BOARD / BCM / IMX / X8)** | **Portenta X8<br>(Arduino)** | **Portenta H7** | **Portenta C33** |
+|:-------------------------:|:--------------:|:--------------------------------------:|:--------------------------:|:---------------------------------------------------------------:|:----------------------------:|:---------------:|:----------------:|
+|  _40-Pin Connector (J5)_  |                |                                        |                            |                                                                 |                              |                 |                  |
+|                           |       3        |                I2C2 SDA                |            149             |                     3 / 2 / 149 / I2C2_SDA                      |              -               |      PH_12      |        39        |
+|                           |       5        |                I2C2 SCL                |            148             |                     5 / 3 / 148 / I2C2_SCL                      |              -               |      PH_11      |        40        |
+|                           |       7        |              PWM0 [1WIRE]              |            183             |                       7 / 4 / 183 / PWM0                        |             PC_7             |      PA_8       |        0         |
+|                           |       8        |               SERIAL3 TX               |            157             |                       8 / 14 / 157 / TX3                        |              -               |      PL_8       |        53        |
+|                           |       10       |               SERIAL3 RX               |            156             |                       10 / 15 / 156 / RX3                       |              -               |      PJ_9       |        54        |
+|                           |       11       |                 GPIO2                  |            162             |                       11 / 17 / - / GPIO2                       |             PF_3             |      PD_4       |        29        |
+|                           |       12       |            I2S CK [PCM_CLK]            |             87             |                      12 / 18 / 87 / I2S_CK                      |              -               |      PD_3       |        63        |
+|                           |       13       |                 GPIO6                  |            166             |                       13 / 27 / - / GPIO6                       |            PE_11             |      PG_10      |        33        |
+|                           |       15       |         SAI D0 _(OUTPUT ONLY)_         |            108             |                     15 / 22 / 108 / SAI_D0                      |              -               |      PI_6       |        80        |
+|                           |       16       |         SAI CK _(OUTPUT ONLY)_         |            107             |                     16 / 23 / 107 / SAI_CK                      |              -               |      PI_5       |        78        |
+|                           |       18       |         SAI FS _(OUTPUT ONLY)_         |            106             |                     18 / 24 / 106 / SAI_FS                      |              -               |      PI_7       |        79        |
+|                           |       19       |      SPI1 COPI _(DTB Activated)_       |            135             |                    19 / 10 / 135 / SPI1_COPI                    |              -               |      PC_3       |        46        |
+|                           |       21       |      SPI1 CIPO _(DTB Activated)_       |            136             |                    21 / 9 / 136 / SPIO1_CIPO                    |              -               |      PC_2       |        45        |
+|                           |       22       |                  PWM1                  |            184             |                      22 / 25 / 184 / PWM1                       |             PA_9             |      PC_6       |        1         |
+|                           |       23       |       SPI1 SCK _(DTB Activated)_       |            134             |                    23 / 11 / 134 / SPI1_SCK                     |              -               |      PI_0       |        47        |
+|                           |       24       | SPI1 CE [SPI1_CE0_N] _(DTB Activated)_ |            137             |                     24 / 8 / 137 / SPI1_CE                      |              -               |      PI_1       |        48        |
+|                           |       26       |           PWM2 [SPI1_CE1_N]            |            185             |                       26 / 7 / 185 / PWM2                       |            PA_10             |      PC_7       |        2         |
+|                           |       27       |                I2C0 SDA                |            147             |                     27 / - / 147 / I2C0_SDA                     |              -               |      PH_8       |        11        |
+|                           |       28       |                I2C0 SCL                |            146             |                     28 / - / 146 / I2C0_SCL                     |              -               |      PH_7       |        12        |
+|                           |       29       |               SERIAL1 RX               |            127             |                       29 / 5 / 127 / RX1                        |              -               |      PA_10      |        13        |
+|                           |       31       |                  PWM3                  |            186             |                       31 / 6 / 186 / PWM3                       |            PB_10             |      PG_7       |        3         |
+|                           |       32       |               SERIAL1 TX               |            128             |                       31 / 12 / 128 / TX1                       |              -               |      PA_9       |        14        |
+|                           |       33       |                  PWM4                  |            187             |                      33 / 13 / 187 / PWM4                       |            PA_11             |      PJ_11      |        4         |
+|                           |       35       |                 I2S WS                 |             86             |                      35 / 19 / 86 / I2S_WS                      |              -               |      PB_9       |        64        |
+|                           |       36       |                  PWM5                  |            188             |                      36 / 16 / 188 / PWM5                       |            PD_15             |      PK_1       |        5         |
+|                           |       37       |                  PWM6                  |            189             |                      37 / 26 / 189 / PWM6                       |             PA_8             |      PH_15      |        6         |
+|                           |       38       |                I2S SDI                 |             85             |                     38 / 20 / 85 / I2S_SDI                      |              -               |      PI_2       |        65        |
+|                           |       40       |                I2S SDO                 |             88             |                     40 / 21 / 88 / I2S_SDO                      |              -               |      PI_3       |        66        |
+|  _16-Pin Connector (J6)_  |                |                                        |                            |                                                                 |                              |                 |                  |
+|                           |       1        |             Analog 0 - A0              |            167             |                                -                                |              A0              |   PA_0C / A0    |        15        |
+|                           |       2        |             Analog 1 - A1              |            168             |                                -                                |              A1              |   PA_1C / A1    |        16        |
+|                           |       3        |             Analog 2 - A2              |            169             |                                -                                |              A2              |   PC_2C / A2    |        17        |
+|                           |       4        |             Analog 3 - A3              |            170             |                                -                                |              A3              |   PC_3C / A3    |        18        |
+|                           |       5        |             Analog 4 - A4              |            171             |                                -                                |              A4              |    PC_2 / A4    |        19        |
+|                           |       6        |             Analog 5 - A5              |            172             |                                -                                |              A5              |    PC_3 / A5    |        20        |
+|                           |       7        |             Analog 6 - A6              |            173             |                                -                                |              A6              |    PA_4 / A6    |        21        |
+|                           |       8        |             Analog 7 - A7              |            174             |                                -                                |              A7              |    PA_6 / A7    |        22        |
+|                           |       9        |                  PWM7                  |            190             |                                -                                |             PC_6             |      PJ_7       |        7         |
+|                           |       10       |                  PWM8                  |            191             |                                -                                |            PA_12             |      PJ_10      |        8         |
+|                           |       12       |                  PWM4                  |            187             |                                -                                |            PA_11             |      PJ_11      |        4         |
+|                           |       14       |               SERIAL2 TX               |            155             |                                -                                |              -               |      PG_14      |        49        |
+|                           |       16       |               SERIAL2 RX               |            154             |                                -                                |              -               |      PG_9       |        50        |
+| _PWM Fan Connector (J11)_ |                |                                        |                            |                                                                 |                              |                 |                  |
+|                           |       1        |                  PWM9                  |            192             |                                -                                |             PC_8             |      PH_6       |        25        |
+|    _On-Board Element_     |                |                                        |                            |                                                                 |                              |                 |                  |
+|                           |       -        |            GPIO3 (User LED)            |            163             |                                -                                |             PF_4             |      PD_5       |        30        |
 
 To effectively understand and use the GPIO (General Purpose Input/Output) designations of the table above, which are specific to combinations of the Portenta family board and the Portenta Hat Carrier, it is important to consider the following details:
 
@@ -2524,9 +2526,20 @@ To effectively understand and use the GPIO (General Purpose Input/Output) design
   
   For more information, please refer to the [Hello World Using Linux](#hello-world-using-linux) section in this present user manual.
 
-- The __Python®__ GPIO designations for the Portenta X8 are available through the [official __Portenta.GPIO__ library](https://github.com/SuMere/portenta-gpio), using BroadCom SoC GPIO numbers in BCM mode. This applies to the 40-pin Connector (J5) pins compatible with Raspberry Pi® HATs on the Portenta Hat Carrier.
-  
-  To learn about the practical implementation of these designations, please refer to the `gpio.py` example in the [GPIO Pins](#gpio-pins) section of this user manual.
+- The __Python®__ GPIO designations defined for the Portenta X8 are available via different modes through the [official Portenta.GPIO library](https://github.com/SuMere/portenta-gpio). It applies with pins on the 40-pin Connector compatible with Raspberry Pi® HATs (J5) of the Portenta Hat Carrier. These modes, in Python® script, are available as:
+
+* __BOARD__ - e.g. GPIO.setmode(GPIO.BOARD)
+* __BCM__   - e.g. GPIO.setmode(GPIO.BCM)
+* __X8__    - e.g. GPIO.setmode(GPIO.X8)
+* __IMX__   - e.g. GPIO.setmode(GPIO.IMX)
+
+  The initial pair of methods align with the *RPi.GPIO* library's numbering conventions, specifically the **BOARD** and **BCM** modes.
+
+  **BOARD** mode is based on the physical pin layout of the 40-pin GPIO header. Meanwhile, **BCM** mode relies on the Broadcom SoC's GPIO numbering system.
+
+  The other two modes, **X8** and **IMX**, have distinctive approaches. **X8** mode employs strings for identification, consistent with the naming on the Portenta HAT Carrier's serigraphy. While **IMX** mode uses the NXP standard for pin numbering.
+
+  To learn about the practical implementation of these designations, please refer to the `gpio.py` example in the [GPIO Pins](#gpio-pins) section of this user manual. More information about the official Portenta.GPIO library can be found [here](https://github.com/SuMere/portenta-gpio).
 
 - The __Arduino__ GPIO designations for the Portenta X8 are applicable if desired in the Arduino IDE. The GPIO definitions for the Portenta H7, including its H7 Lite and H7 Lite Connected variants and the C33, are directly usable in the Arduino IDE.
   

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2467,8 +2467,6 @@ The __Port Number__ defines the number designation of the corresponding connecto
 |   **Connector**    | **Pin Number** |         **Function**          | **Portenta X8 (Linux/Arduino)** |  **Portenta H7**   | **Portenta C33 (Numeric/Define)** |
 |:------------------:|:--------------:|:-----------------------------:|:-------------------------------:|:------------------:|:---------------------------------:|
 | _40-Pin Connector_ |                |                               |                                 |                    |                                   |
-|                    |       3        |           I2C2 SDA            |              149*               |    PH_12 (124)     |             39 / D39              |
-|                    |       5        |           I2C2 SCL            |              148*               |    PH_11 (123)     |             40 / D40              |
 |                    |       7        |             PWM0              |         183 / PC_7 (39)         |      PA_8 (8)      |              0 / D0               |
 |                    |       8        |          SERIAL3 TX           |               157               |     PL_8 (152)     |             53 / D53              |
 |                    |       10       |          SERIAL3 RX           |               156               |     PJ_9 (153)     |             54 / D54              |
@@ -2484,8 +2482,6 @@ The __Port Number__ defines the number designation of the corresponding connecto
 |                    |       23       | SPI1 SCK **(DTB Activated)**  |               138               |     PI_0 (128)     |             47 / D47              |
 |                    |       24       |  SPI1 CE **(DTB Activated)**  |               141               |     PI_1 (129)     |             48 / D48              |
 |                    |       26       |             PWM2              |        185 / PA_10 (10)         |     PC_7 (39)      |              2 / D2               |
-|                    |       27       |           I2C0 SDA            |                                 |     PH_8 (120)     |             11 / D11              |
-|                    |       28       |           I2C0 SCL            |                                 |     PH_7 (119)     |             12 / D12              |
 |                    |       29       |          SERIAL1 RX           |               127               |     PA_10 (10)     |             13 / D13              |
 |                    |       31       |             PWM3              |        186 / PB_10 (26)         |     PG_7 (103)     |              3 / D3               |
 |                    |       32       |          SERIAL1 TX           |               128               |      PA_9 (9)      |             14 / D14              |
@@ -2507,8 +2503,8 @@ The __Port Number__ defines the number designation of the corresponding connecto
 |                    |       9        |             PWM7              |         190 / PC_6 (38)         |     PJ_7 (151)     |              7 / D7               |
 |                    |       10       |             PWM8              |        191 / PA_12 (12)         |    PJ_10 (154)     |              8 / D8               |
 |                    |       12       |             PWM4              |        187* / PA_11 (11)        |    PJ_11 (155)     |              4 / D4               |
-|                    |       14       |          SERIAL2 TX           |              155*               |    PG_14 (110)     |             49 / D49              |
-|                    |       16       |          SERIAL2 RX           |              154*               |     PG_9 (105)     |             50 / D50              |
+|                    |       14       |          SERIAL2 TX           |               155               |    PG_14 (110)     |             49 / D49              |
+|                    |       16       |          SERIAL2 RX           |               154               |     PG_9 (105)     |             50 / D50              |
 
 In Linux, pins can be controlled using the system's functions via the ADB shell or via the official Python library.
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -3011,6 +3011,7 @@ The Portenta Hat Carrier supports SPI communication via two dedicated ports name
 |       21       |   SPI1 CIPO    |          SPI1_MISO           |        J2-40         |  SPI 1 MISO   |
 |       23       |    SPI1 SCK    |           SPI1_CK            |        J2-38         |   SPI 1 CK    |
 |       24       |    SPI1 CE     |           SPI1_CS            |        J2-36         |   SPI 1 CS    |
+|       26       |    PWM2        |           PWM_2 (SPI1_CE1)   |        J2-63         |               |
 
 Additionally, the __GPIO pins - 19, 21, 23, 24, and 26__ - on the 40-pin connector become operational with the application of a specific Device Tree Source (DTS) layer. For detailed information on configuring this DTS layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2437,13 +2437,13 @@ The GPIO configuration register for the STM32 microcontroller is structured with
 | PE | HYS | PUE | ODE | FSEL |  DSE  |
 
 - __PE (Pull Resistors Enable)__: Controls the use of pull resistors. 0 disables them, while 1 enables them.
-- __HYS (Hysteresis Enable Field)__: Sets the input type. 0 selects CMOS input, 1 selects Schmitt input.
-- __PUE (Control IO ports PS)__: Determines the type of pull resistors used. 0 selects pull-down resistors, 1 selects pull-up resistors.
-- __ODE (Open Drain Enable Field)__: Configures the pin for open-drain mode. 0 disables, 1 enables.
+- __HYS (Hysteresis Enable Field)__: Sets the input type. 0 selects CMOS input, and 1 selects Schmitt input.
+- __PUE (Control IO ports PS)__: Determines the type of pull resistors used. 0 selects pull-down resistors, and 1 selects pull-up resistors.
+- __ODE (Open Drain Enable Field)__: Configures the pin for open-drain mode. 0 turns off, 1 enables.
 - __FSEL (Slew Rate Field)__: Controls the slew rate. 0X is slow, 1X is fast.
 - __DSE (Drive Strength Field)__: Adjusts the drive strength. Options range from X1 to X6, with varying levels of strength.
 
-To control a desired GPIO within the Linux environment of the Portenta X8, based on STM32 microcontroller, the following GPIO chip formula can help get the required GPIO number designation:
+To control a desired GPIO within the Linux environment of the Portenta X8, based on the STM32 microcontroller, the following GPIO chip formula can help get the required GPIO number designation:
 
 ```
 [(<GPIO group> -1) * 32] + <GPIO number>

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -3014,6 +3014,18 @@ Additionally, the __GPIO pins - 19, 21, 23, 24, and 26__ - on the 40-pin connect
 
 Please, refer to the [board pinout section](#pinout) of the user manual to find them on the board.
 
+<ul>
+  <li>sensor.set_pixformat() lets you...
+    <ul>
+      <li>sensor.GRAYSCALE</li>
+      <li>sensor.RGB565</li>
+      <li>sensor.BAYER</li>
+      <li>sensor.YUV422</li>
+    </ul>
+  </li>
+</ul>
+
+
 #### Using Linux
 
 <br></br>

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2349,13 +2349,15 @@ It is characterized as follows:
 
 ### GPIO Pins
 
-Understanding and managing the General-Purpose Input/Output (GPIO) pins on your device can be crucial for many applications. The following script is designed to display all the GPIOs available on the 40-pin connector of the Portenta Hat Carrier paired with Portenta X8.
+Understanding and managing your device's General-Purpose Input/Output (GPIO) pins can be crucial for many applications. The following script is designed to display all the GPIOs available on the 40-pin connector of the Portenta Hat Carrier paired with Portenta X8.
 
 Within the 40-pin connector, certain GPIOs are specifically related to different functionalities:
 
 - __GPIO pins - 15, 16, and 18:__ are associated with the _Serial Audio Interface (SAI)_. These pins are exclusively designated for __OUTPUT__ purposes. As such, these three GPIO pins are not configurable as inputs and are solely used as __OUTPUTS__.
 
-- __GPIO pins - 19, 21, 23, 24, and 26:__ are designated for the _Serial Peripheral Interface (SPI)_. These pins become operational when a specific Device Tree Source (DTS) layer is applied. For more information regarding DTS layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
+- __GPIO pins - 19, 21, 23, 24, and 26:__ are designated for the _Serial Peripheral Interface (SPI)_. These pins become operational when applying a specific Device Tree Source (DTS) layer. For more information regarding the DTS layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
+
+***The __Portenta.GPIO__ library, officially supported and compatible with the Portenta Hat Carrier and Portenta X8, can be found [here](https://pypi.org/project/Portenta.GPIO/).***
 
 #### Using Linux
 
@@ -2419,7 +2421,7 @@ for pin in all_pins_in_header:
 GPIO.cleanup()
 ```
 
-***The latest compatible GPIO library can be found [here](). Make sure to use the latest library for optimal functionality.***
+***The latest compatible GPIO library can be found [here](https://pypi.org/project/Portenta.GPIO/). Make sure to use the latest library for optimal functionality.***
 
 This script will help you verify the following considerations:
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2351,6 +2351,12 @@ It is characterized as follows:
 
 Understanding and managing the General-Purpose Input/Output (GPIO) pins on your device can be crucial for many applications. The following script is designed to display all the GPIOs available on the 40-pin connector of the Portenta Hat Carrier paired with Portenta X8.
 
+Within the 40-pin connector, certain GPIOs are specifically related to different functionalities:
+
+- __GPIO pins - 15, 16, and 18:__ are associated with the _Serial Audio Interface (SAI)_. These pins are exclusively designated for __OUTPUT__ purposes. As such, these three GPIO pins are not configurable as inputs and are solely used as __OUTPUTS__.
+
+- __GPIO pins - 19, 21, 23, 24, and 26:__ are designated for the _Serial Peripheral Interface (SPI)_. These pins become operational when a specific Device Tree Source (DTS) layer is applied. For more information regarding DTS layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
+
 #### Using Linux
 
 <br></br>
@@ -2412,6 +2418,8 @@ for pin in all_pins_in_header:
 
 GPIO.cleanup()
 ```
+
+***The latest compatible GPIO library can be found [here](). Make sure to use the latest library for optimal functionality.***
 
 This script will help you verify the following considerations:
 
@@ -3002,6 +3010,8 @@ The Portenta Hat Carrier supports SPI communication via two dedicated ports name
 |       23       |    SPI1 SCK    |           SPI1_CK            |        J2-38         |   SPI 1 CK    |
 |       24       |    SPI1 CE     |           SPI1_CS            |        J2-36         |   SPI 1 CS    |
 
+Additionally, the __GPIO pins - 19, 21, 23, 24, and 26__ - on the 40-pin connector become operational with the application of a specific Device Tree Source (DTS) layer. For detailed information on configuring this DTS layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
+
 Please, refer to the [board pinout section](#pinout) of the user manual to find them on the board.
 
 #### Using Linux
@@ -3104,11 +3114,11 @@ The pins used in the Portenta Hat Carrier for the I2S communication protocol are
 
 **Serial Audio Interface (SAI)** is a versatile protocol for transmitting audio data between digital components. Unlike the fixed I2S standard, SAI supports multiple audio data formats and configurations. The carrier works with the following data lines:
 
-- **D0**: This serves as the primary data line, transmitting or receiving audio data.
+- **D0**: This is the primary data line, transmitting or receiving audio data.
 - **CK (BCLK)**: The Bit Clock, governing the rate of individual audio data bit transmission or reception.
 - **FS**: Frame Sync, marking the boundary of audio frames, often differentiating channels in stereo audio.
 
-SAI protocol can operate both synchronously and asynchronously, adjusting to various audio system needs. Due to its adaptability, SAI suits complex audio tasks, systems with multi-channel requirements, and specific audio formats.
+SAI protocol can operate synchronously and asynchronously, adjusting to various audio system needs. Due to its adaptability, SAI suits complex audio tasks, systems with multi-channel requirements, and specific audio formats.
 
 In essence, SAI offers greater flexibility than I2S, catering to a broader range of audio system configurations.
 
@@ -3119,6 +3129,8 @@ The pins used in the Portenta Hat Carrier for the SAI protocol are the following
 |       15       |     SAI D0     |            SAI_D0            |        J2-53         |    SAI D0     |
 |       16       |     SAI CK     |            SAI_CK            |        J2-49         |    SAI CK     |
 |       18       |     SAI FS     |            SAI_FS            |        J2-51         |    SAI FS     |
+
+The pins detailed above are exclusively designated for __OUTPUT__ purposes. As such, these three GPIO pins are not configurable as inputs and are solely used as __OUTPUTS__.
 
 ### I2C
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2464,36 +2464,44 @@ For ease of access to all available GPIOs within the Portenta family board and P
 
 The __Port Number__ defines the number designation of the corresponding connector. The __Function__ tells the role of the designated port number. For example, the port number `7` of the `40-Pin connector` is characterized as __`PWM0`__. Thus, on the Portenta X8, it can be handled by using `183` within the ADB shell or `7` within the Python script. The GPIOs mentioned in the following are controllable, while each pin may have its characteristical function.
 
-|   **Connector**    | **Port Number** |       **Function**       | **Portenta X8** | **Portenta H7** | **Portenta C33** |
-|:------------------:|:---------------:|:------------------------:|:---------------:|:---------------:|:----------------:|
-| _40-Pin Connector_ |                 |                          |                 |                 |                  |
-|                    |        3        |         I2C2 SDA         |       XX        |        X        |     36/LEDB      |
-|                    |        5        |         I2C2 SCL         |       XX        |        X        |     36/LEDB      |
-|                    |        7        |           PWM0           |     183 / 7     |        8        |       0/D0       |
-|                    |        8        |        SERIAL3 TX        |       XX        |        X        |     36/LEDB      |
-|                    |       10        |        SERIAL3 RX        |       XX        |        X        |     36/LEDB      |
-|                    |       11        |          GPIO2           |       XX        |        X        |     36/LEDB      |
-|                    |       12        |          I2S CK          |       XX        |        X        |     36/LEDB      |
-|                    |       13        |          GPIO6           |       XX        |        X        |     36/LEDB      |
-|                    |       15        | SAI D0 __(OUTPUT ONLY)__ |       XX        |        X        |     36/LEDB      |
-|                    |       16        | SAI CK __(OUTPUT ONLY)__ |       XX        |        X        |     36/LEDB      |
-|                    |       18        | SAI FS __(OUTPUT ONLY)__ |       XX        |        X        |     36/LEDB      |
-|                    |       22        |           PWM1           |      184 /      |        X        |     36/LEDB      |
-|                    |       29        |        SERIAL1 RX        |       XX        |        X        |     36/LEDB      |
-|                    |       31        |           PWM3           |      186 /      |        X        |     36/LEDB      |
-|                    |       32        |        SERIAL1 TX        |       XX        |        X        |     36/LEDB      |
-|                    |       33        |           PWM4           |      187 /      |        X        |     36/LEDB      |
-|                    |       35        |          I2S WS          |       XX        |        X        |     36/LEDB      |
-|                    |       36        |           PWM5           |      188 /      |        X        |     36/LEDB      |
-|                    |       37        |           PWM6           |      189 /      |        X        |     36/LEDB      |
-|                    |       38        |         I2S SDI          |       XX        |        X        |     36/LEDB      |
-|                    |       40        |         I2S SDO          |       XX        |        X        |     36/LEDB      |
-| _16-Pin Connector_ |                 |                          |                 |                 |                  |
-|                    |        9        |           PWM7           |      190 /      |        X        |     36/LEDB      |
-|                    |       10        |           PWM8           |      191 /      |        X        |     36/LEDB      |
-|                    |       12        |       GPIO0 / PWM4       |       XX        |        X        |     36/LEDB      |
-|                    |       14        |        SERIAL2 TX        |       XX        |        X        |     36/LEDB      |
-|                    |       16        |        SERIAL2 RX        |       XX        |        X        |     36/LEDB      |
+|   **Connector**    | **Pin Number** |       **Function**       | **Portenta X8 (Linux/Arduino)** | **Portenta H7** | **Portenta C33 (Numeric/Define)** |
+|:------------------:|:--------------:|:------------------------:|:-------------------------------:|:---------------:|:---------------------------------:|
+| _40-Pin Connector_ |                |                          |                                 |                 |                                   |
+|                    |       3        |         I2C2 SDA         |               XX                |        X        |              36/LEDB              |
+|                    |       5        |         I2C2 SCL         |               XX                |        X        |              36/LEDB              |
+|                    |       7        |           PWM0           |             183 / 7             |        8        |               0/D0                |
+|                    |       8        |        SERIAL3 TX        |               XX                |        X        |              36/LEDB              |
+|                    |       10       |        SERIAL3 RX        |               XX                |        X        |              36/LEDB              |
+|                    |       11       |          GPIO2           |              162 /              |        X        |              36/LEDB              |
+|                    |       12       |          I2S CK          |               XX                |        X        |              36/LEDB              |
+|                    |       13       |          GPIO6           |              166 /              |        X        |              36/LEDB              |
+|                    |       15       | SAI D0 __(OUTPUT ONLY)__ |               XX                |        X        |              36/LEDB              |
+|                    |       16       | SAI CK __(OUTPUT ONLY)__ |               XX                |        X        |              36/LEDB              |
+|                    |       18       | SAI FS __(OUTPUT ONLY)__ |               XX                |        X        |              36/LEDB              |
+|                    |       22       |           PWM1           |              184 /              |        X        |              36/LEDB              |
+|                    |       29       |        SERIAL1 RX        |               XX                |        X        |              36/LEDB              |
+|                    |       31       |           PWM3           |              186 /              |        X        |              36/LEDB              |
+|                    |       32       |        SERIAL1 TX        |               XX                |        X        |              36/LEDB              |
+|                    |       33       |           PWM4           |              187 /              |        X        |              36/LEDB              |
+|                    |       35       |          I2S WS          |               XX                |        X        |              36/LEDB              |
+|                    |       36       |           PWM5           |              188 /              |        X        |              36/LEDB              |
+|                    |       37       |           PWM6           |              189 /              |        X        |              36/LEDB              |
+|                    |       38       |         I2S SDI          |               XX                |        X        |              36/LEDB              |
+|                    |       40       |         I2S SDO          |               XX                |        X        |              36/LEDB              |
+| _16-Pin Connector_ |                |                          |                                 |                 |                                   |
+|                    |       1        |            A0            |            167 / A0             |    2048 / A0    |              36/LEDB              |
+|                    |       2        |            A1            |            168 / A1             |     1 / A1      |              36/LEDB              |
+|                    |       3        |            A2            |            169 / A2             |     34 / A2     |              36/LEDB              |
+|                    |       4        |            A3            |            170 / A3             |     35 / A3     |              36/LEDB              |
+|                    |       5        |            A4            |            171 / A4             |        X        |              36/LEDB              |
+|                    |       6        |            A5            |            172 / A5             |        X        |              36/LEDB              |
+|                    |       7        |            A6            |            173 / A6             |        X        |              36/LEDB              |
+|                    |       8        |            A7            |            174 / A7             |        X        |              36/LEDB              |
+|                    |       9        |           PWM7           |              190 /              |        X        |              36/LEDB              |
+|                    |       10       |           PWM8           |              191 /              |        X        |              36/LEDB              |
+|                    |       12       |       GPIO0 / PWM4       |              160 /              |        X        |              36/LEDB              |
+|                    |       14       |        SERIAL2 TX        |               XX                |        X        |              36/LEDB              |
+|                    |       16       |        SERIAL2 RX        |               XX                |        X        |              36/LEDB              |
 
 In Linux, pins can be controlled using the system's functions via the ADB shell or via the official Python library.
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2462,51 +2462,51 @@ Each pin is identified by its port and a unique port number. The following table
 
 For ease of access to all available GPIOs within the Portenta family board and Portenta Hat Carrier, the following table enlists every designations that can be used to access directly each individual GPIO.
 
-The __Port Number__ defines the number designation of the corresponding connector. The __Function__ tells the role of the designated pin number. For example, the pin number `7` of the `40-Pin connector` is characterized as __`PWM0`__. Thus, on the Portenta X8, it can be handled by using `183` within the ADB shell, `7` within the Python script, or `PC_7` within the Arduino IDE. The GPIOs mentioned in the following are controllable, while each pin may have its characteristical function.
+The __Port Number__ defines the number designation of the corresponding connector. The __Function__ tells the role of the designated pin number. For example, the pin number `7` of the `40-Pin connector` is characterized as __`PWM0`__. Thus, on the Portenta X8, it can be handled by using `183` within the ADB shell, `7` within the Python® script, or `PC_7` within the Arduino IDE. The GPIOs mentioned in the following are controllable, while each pin may have its characteristical function.
 
-|   **Connector**    | **Pin Number** |         **Function**          | **Portenta X8 (Linux/Arduino)** |  **Portenta H7**   | **Portenta C33 (Numeric/Define)** |
-|:------------------:|:--------------:|:-----------------------------:|:-------------------------------:|:------------------:|:---------------------------------:|
-| _40-Pin Connector_ |                |                               |                                 |                    |                                   |
-|                    |       7        |             PWM0              |         183 / PC_7 (39)         |      PA_8 (8)      |              0 / D0               |
-|                    |       8        |          SERIAL3 TX           |               157               |     PL_8 (152)     |             53 / D53              |
-|                    |       10       |          SERIAL3 RX           |               156               |     PJ_9 (153)     |             54 / D54              |
-|                    |       11       |             GPIO2             |         162 / PF_3 (83)         |     PD_4 (52)      |             29 / D29              |
-|                    |       12       |            I2S CK             |               87                |     PD_3 (51)      |             63 / D63              |
-|                    |       13       |             GPIO6             |        166 / PE_11 (75)         |    PG_10 (106)     |             33 / D33              |
-|                    |       15       |   SAI D0 **(OUTPUT ONLY)**    |               108               |     PI_6 (134)     |             80 / D80              |
-|                    |       16       |   SAI CK **(OUTPUT ONLY)**    |               107               |     PI_5 (133)     |             78 / D78              |
-|                    |       18       |   SAI FS **(OUTPUT ONLY)**    |               106               |     PI_7 (135)     |             79 / D79              |
-|                    |       19       | SPI1 COPI **(DTB Activated)** |               139               |     PC_3 (35)      |             46 / D46              |
-|                    |       21       | SPI1 CIPO **(DTB Activated)** |               140               |     PC_2 (34)      |             45 / D45              |
-|                    |       22       |             PWM1              |         184 / PA_9 (9)          |     PC_6 (38)      |              1 / D1               |
-|                    |       23       | SPI1 SCK **(DTB Activated)**  |               138               |     PI_0 (128)     |             47 / D47              |
-|                    |       24       |  SPI1 CE **(DTB Activated)**  |               141               |     PI_1 (129)     |             48 / D48              |
-|                    |       26       |             PWM2              |        185 / PA_10 (10)         |     PC_7 (39)      |              2 / D2               |
-|                    |       29       |          SERIAL1 RX           |               127               |     PA_10 (10)     |             13 / D13              |
-|                    |       31       |             PWM3              |        186 / PB_10 (26)         |     PG_7 (103)     |              3 / D3               |
-|                    |       32       |          SERIAL1 TX           |               128               |      PA_9 (9)      |             14 / D14              |
-|                    |       33       |             PWM4              |        187 / PA_11 (11)         |    PJ_11 (155)     |              4 / D4               |
-|                    |       35       |            I2S WS             |              128*               |     PB_9 (25)      |             64 / D64              |
-|                    |       36       |             PWM5              |        188 / PD_15 (63)         |     PK_1 (161)     |              5 / D5               |
-|                    |       37       |             PWM6              |         189 / PA_8 (8)          |    PH_15 (127)     |              6 / D6               |
-|                    |       38       |            I2S SDI            |               85                |     PI_2 (130)     |             65 / D65              |
-|                    |       40       |            I2S SDO            |               88                |     PI_3 (131)     |             66 / D66              |
-| _16-Pin Connector_ |                |                               |                                 |                    |                                   |
-|                    |       1        |              A0               |            167 / A0             | PA_0_C (2048) / A0 |             15 / D15              |
-|                    |       2        |              A1               |            168 / A1             | PA_1_C (2049) / A1 |             16 / D16              |
-|                    |       3        |              A2               |            169 / A2             | PC_2_C (2082) / A2 |             17 / D17              |
-|                    |       4        |              A3               |            170 / A3             | PC_3_C (2083) / A3 |             18 / D18              |
-|                    |       5        |              A4               |            171 / A4             |   PC_2 (34) / A4   |             19 / D19              |
-|                    |       6        |              A5               |            172 / A5             |   PC_3 (35) / A5   |             20 / D20              |
-|                    |       7        |              A6               |            173 / A6             |   PA_4 (4) / A6    |             21 / D21              |
-|                    |       8        |              A7               |            174 / A7             |   PA_6 (6) / A7    |             22 / D22              |
-|                    |       9        |             PWM7              |         190 / PC_6 (38)         |     PJ_7 (151)     |              7 / D7               |
-|                    |       10       |             PWM8              |        191 / PA_12 (12)         |    PJ_10 (154)     |              8 / D8               |
-|                    |       12       |             PWM4              |        187* / PA_11 (11)        |    PJ_11 (155)     |              4 / D4               |
-|                    |       14       |          SERIAL2 TX           |               155               |    PG_14 (110)     |             49 / D49              |
-|                    |       16       |          SERIAL2 RX           |               154               |     PG_9 (105)     |             50 / D50              |
+|   **Connector**    | **Pin Number** |         **Function**          | **Portenta X8 (Linux/Arduino)** |  **Portenta H7**   | **Portenta C33** |
+|:------------------:|:--------------:|:-----------------------------:|:-------------------------------:|:------------------:|:----------------:|
+| _40-Pin Connector_ |                |                               |                                 |                    |                  |
+|                    |       7        |             PWM0              |         183 / PC_7 (39)         |      PA_8 (8)      |        0         |
+|                    |       8        |          SERIAL3 TX           |               157               |     PL_8 (152)     |        53        |
+|                    |       10       |          SERIAL3 RX           |               156               |     PJ_9 (153)     |        54        |
+|                    |       11       |             GPIO2             |         162 / PF_3 (83)         |     PD_4 (52)      |        29        |
+|                    |       12       |            I2S CK             |               87                |     PD_3 (51)      |        63        |
+|                    |       13       |             GPIO6             |        166 / PE_11 (75)         |    PG_10 (106)     |        33        |
+|                    |       15       |   SAI D0 **(OUTPUT ONLY)**    |               108               |     PI_6 (134)     |        80        |
+|                    |       16       |   SAI CK **(OUTPUT ONLY)**    |               107               |     PI_5 (133)     |        78        |
+|                    |       18       |   SAI FS **(OUTPUT ONLY)**    |               106               |     PI_7 (135)     |        79        |
+|                    |       19       | SPI1 COPI **(DTB Activated)** |               139               |     PC_3 (35)      |        46        |
+|                    |       21       | SPI1 CIPO **(DTB Activated)** |               140               |     PC_2 (34)      |        45        |
+|                    |       22       |             PWM1              |         184 / PA_9 (9)          |     PC_6 (38)      |        1         |
+|                    |       23       | SPI1 SCK **(DTB Activated)**  |               138               |     PI_0 (128)     |        47        |
+|                    |       24       |  SPI1 CE **(DTB Activated)**  |               141               |     PI_1 (129)     |        48        |
+|                    |       26       |             PWM2              |        185 / PA_10 (10)         |     PC_7 (39)      |        2         |
+|                    |       29       |          SERIAL1 RX           |               127               |     PA_10 (10)     |        13        |
+|                    |       31       |             PWM3              |        186 / PB_10 (26)         |     PG_7 (103)     |        3         |
+|                    |       32       |          SERIAL1 TX           |               128               |      PA_9 (9)      |        14        |
+|                    |       33       |             PWM4              |        187 / PA_11 (11)         |    PJ_11 (155)     |        4         |
+|                    |       35       |            I2S WS             |              128*               |     PB_9 (25)      |        64        |
+|                    |       36       |             PWM5              |        188 / PD_15 (63)         |     PK_1 (161)     |        5         |
+|                    |       37       |             PWM6              |         189 / PA_8 (8)          |    PH_15 (127)     |        6         |
+|                    |       38       |            I2S SDI            |               85                |     PI_2 (130)     |        65        |
+|                    |       40       |            I2S SDO            |               88                |     PI_3 (131)     |        66        |
+| _16-Pin Connector_ |                |                               |                                 |                    |                  |
+|                    |       1        |              A0               |            167 / A0             | PA_0_C (2048) / A0 |        15        |
+|                    |       2        |              A1               |            168 / A1             | PA_1_C (2049) / A1 |        16        |
+|                    |       3        |              A2               |            169 / A2             | PC_2_C (2082) / A2 |        17        |
+|                    |       4        |              A3               |            170 / A3             | PC_3_C (2083) / A3 |        18        |
+|                    |       5        |              A4               |            171 / A4             |   PC_2 (34) / A4   |        19        |
+|                    |       6        |              A5               |            172 / A5             |   PC_3 (35) / A5   |        20        |
+|                    |       7        |              A6               |            173 / A6             |   PA_4 (4) / A6    |        21        |
+|                    |       8        |              A7               |            174 / A7             |   PA_6 (6) / A7    |        22        |
+|                    |       9        |             PWM7              |         190 / PC_6 (38)         |     PJ_7 (151)     |        7         |
+|                    |       10       |             PWM8              |        191 / PA_12 (12)         |    PJ_10 (154)     |        8         |
+|                    |       12       |             PWM4              |        187* / PA_11 (11)        |    PJ_11 (155)     |        4         |
+|                    |       14       |          SERIAL2 TX           |               155               |    PG_14 (110)     |        49        |
+|                    |       16       |          SERIAL2 RX           |               154               |     PG_9 (105)     |        50        |
 
-In Linux, pins can be controlled using the system's functions via the ADB shell or via the official Python library.
+In Linux, pins can be controlled using the system's functions via the ADB shell or via the official Python® library.
 
 #### Using Linux With Shell
 <br></br>
@@ -2580,7 +2580,7 @@ This measure is crucial for preventing unintentional modifications to the config
 #### Using Linux With Library
 <br></br>
 
-The General-Purpose Input/Output (GPIO) features of the Portenta X8 can also be efficiently managed using the [__Portenta.GPIO__ library](https://pypi.org/project/Portenta.GPIO/). This library facilitates an accessible means to control the GPIOs, an aspect that is particularly advantageous when integrating GPIO management within Python scripts.
+The General-Purpose Input/Output (GPIO) features of the Portenta X8 can also be efficiently managed using the [__Portenta.GPIO__ library](https://pypi.org/project/Portenta.GPIO/). This library facilitates an accessible means to control the GPIOs, an aspect that is particularly advantageous when integrating GPIO management within Python® scripts.
 
 The functionality of the GPIO management using this library will be illustrated by presenting an example that demonstrates how to retrieve the status of all available GPIOs on a Portenta X8 mounted on the Portenta Hat Carrier. This example is available in the `x8-devel` container, where the required environmental configuration is established.
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -3014,18 +3014,6 @@ Additionally, the __GPIO pins - 19, 21, 23, 24, and 26__ - on the 40-pin connect
 
 Please, refer to the [board pinout section](#pinout) of the user manual to find them on the board.
 
-<ul>
-  <li>sensor.set_pixformat() lets you...
-    <ul>
-      <li>sensor.GRAYSCALE</li>
-      <li>sensor.RGB565</li>
-      <li>sensor.BAYER</li>
-      <li>sensor.YUV422</li>
-    </ul>
-  </li>
-</ul>
-
-
 #### Using Linux
 
 <br></br>

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2360,7 +2360,6 @@ Within the 40-pin connector, certain GPIOs are specifically related to different
 ***The __Portenta.GPIO__ library, officially supported and compatible with the Portenta Hat Carrier and Portenta X8, can be found [here](https://pypi.org/project/Portenta.GPIO/).***
 
 #### Using Linux
-
 <br></br>
 
 Next conditions will help you properly set the hardware to test GPIO controls:
@@ -2430,6 +2429,89 @@ This script will help you verify the following considerations:
 - By staying within the specified voltage range, you ensure the longevity of your device and prevent potential damages.
 
 - With the default pull-ups, you can be confident in your readings, knowing that unintentional fluctuations are minimized.
+
+The GPIO configuration register for the STM32 microcontroller is structured with various fields that control different aspects of GPIO functionality:
+
+|  8 |  7  |  6  |  5  |  4 3 | 2 1 0 |
+|:--:|:---:|:---:|:---:|:----:|:-----:|
+| PE | HYS | PUE | ODE | FSEL |  DSE  |
+
+- __PE (Pull Resistors Enable)__: Controls the use of pull resistors. 0 disables them, while 1 enables them.
+- __HYS (Hysteresis Enable Field)__: Sets the input type. 0 selects CMOS input, 1 selects Schmitt input.
+- __PUE (Control IO ports PS)__: Determines the type of pull resistors used. 0 selects pull-down resistors, 1 selects pull-up resistors.
+- __ODE (Open Drain Enable Field)__: Configures the pin for open-drain mode. 0 disables, 1 enables.
+- __FSEL (Slew Rate Field)__: Controls the slew rate. 0X is slow, 1X is fast.
+- __DSE (Drive Strength Field)__: Adjusts the drive strength. Options range from X1 to X6, with varying levels of strength.
+
+To control a desired GPIO within the Linux environment of the Portenta X8, based on STM32 microcontroller, the following GPIO chip formula can help get the required GPIO number designation:
+
+```
+[(<GPIO group> -1) * 32] + <GPIO number>
+```
+
+Each GPIO chip manages a specific range of GPIO numbers, facilitating organized and efficient access to the GPIO functionality of the STM32 microcontroller. The GPIO groups for the Portenta X8 are segmented in the following manner:
+
+| **GPIO Chip** | **Corresponding GPIO Number** |
+|---------------|-------------------------------|
+| _gpiochip0_   | GPIOs 0-31                    |
+| _gpiochip1_   | GPIOs 32-63                   |
+| _gpiochip2_   | GPIOs 64-95                   |
+| _gpiochip3_   | GPIOs 96-127                  |
+| _gpiochip4_   | GPIOs 128-159                 |
+| _gpiochip5_   | GPIOs 160-193 (H7 GPIOs)      |
+
+The STM32 microcontroller includes various GPIO ports, each with a specific set of pins. The enumeration of these GPIO ports is as follows:
+
+- __Port A__: PA6, PA8, PA9, PA10, PA11, PA12
+- __Port B__: PB1, PB5, PB6, PB10
+- __Port C__: PC4, PC6, PC7, PC8
+- __Port D__: PD0, PD1, PD3, PD4, PD5, PD6, PD15
+- __Port E__: PE10, PE11
+- __Port F__: PF3, PF4, PF5, PF6, PF7, PF8, PF9, PF11, PF12, PF13
+
+Each pin is identified by its port and a unique port number.
+
+| **Port** | **Port Number** | **Port Name** | **Function / Role** |
+|----------|-----------------|---------------|---------------------|
+| _Port A_ |                 |               |                     |
+|          | 168             | PA6           | ADC_CH1 (A1)        |
+|          | 189             | PA8           | PWM_3               |
+|          | 184             | PA9           | PWM_1               |
+|          | 185             | PA10          | PWM_2               |
+|          | 187             | PA11          | PWM_4               |
+|          | 191             | PA12          | PWM_8               |
+| _Port B_ |                 |               |                     |
+|          | 170             | PB1           | ADC_CH3 (A3)        |
+|          | 178             | PB5           | FDCAN2_RX           |
+|          | 177             | PB6           | FDCAN2_TX           |
+|          | 186             | PB10          | PWM_3               |
+| _Port C_ |                 |               |                     |
+|          | 171             | PC4           | ADC_CH4 (A4)        |
+|          | 190             | PC6           | PWM_7               |
+|          | 183             | PC7           | PWM_0               |
+|          | 192             | PC8           | PWM_9               |
+| _Port D_ |                 |               |                     |
+|          | 176             | PD0           | FDCAN1_RX           |
+|          | 175             | PD1           | FDCAN1_TX           |
+|          | 182             | PD3           | USART2_CTS          |
+|          | 181             | PD4           | USART2_RTS          |
+|          | 189             | PD5           | USART2_TX           |
+|          | 180             | PD6           | USART2_RX           |
+|          | 188             | PD15          |                     |
+| _Port E_ |                 |               |                     |
+|          | 165             | PE10          | GPIO_5              |
+|          | 166             | PE11          | GPIO_6              |
+| _Port F_ |                 |               |                     |
+|          | 162             | PF3           | GPIO_2              |
+|          | 163             | PF4           | GPIO_3              |
+|          | 174             | PF5           | ADC_CH7 (A7)        |
+|          | 161             | PF6           | GPIO_1              |
+|          | 172             | PF7           | ADC_CH5 (A5)        |
+|          | 160             | PF8           | GPIO_0              |
+|          | 173             | PF9           | ADC_CH6 (A6)        |
+|          | 167             | PF11          | ADC_CH0 (A0)        |
+|          | 164             | PF12          | GPIO_4              |
+|          | 169             | PF13          | ADC_CH2 (A2)        |
 
 By employing this script, not only do you gain a deeper insight into the state of your GPIOs, but you also save valuable time and reduce the margin for error.
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -332,7 +332,6 @@ To set the pin to `HIGH`:
 
 ```
 echo 1 >/sys/class/gpio/gpio163/value
-echo 0 >/sys/class/gpio/gpio163/value
 ```
 
 To set the pin to `LOW`:
@@ -2355,80 +2354,11 @@ Within the 40-pin connector, certain GPIOs are specifically related to different
 
 - __GPIO pins - 15, 16, and 18:__ are associated with the _Serial Audio Interface (SAI)_. These pins are exclusively designated for __OUTPUT__ purposes. As such, these three GPIO pins are not configurable as inputs and are solely used as __OUTPUTS__.
 
-- __GPIO pins - 19, 21, 23, 24, and 26:__ are designated for the _Serial Peripheral Interface (SPI)_. These pins become operational when applying a specific Device Tree Source (DTS) layer. For more information regarding the DTS layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
+- __GPIO pins - 19, 21, 23, 24, and 26:__ are allocated for the _Serial Peripheral Interface (SPI)_. By implementing a specific Device Tree Blob (DTB) layer, these pins can be activated as GPIOs. The relevant DTB layers for this purpose are __`ov_som_lbee5kl1dx`__ and __`ov_som_x8h7`__.
+  
+  For more information regarding the DTB layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
 
-***The __Portenta.GPIO__ library, officially supported and compatible with the Portenta Hat Carrier and Portenta X8, can be found [here](https://pypi.org/project/Portenta.GPIO/).***
-
-#### Using Linux
-<br></br>
-
-Next conditions will help you properly set the hardware to test GPIO controls:
-
-1. Begin by positioning the Portenta-X8 securely onto the Portenta Hat Carrier. Make sure the High-Density connectors are securely connected.
-
-2. Each GPIO on the Portenta Hat Carrier is versatile and robust, designed to safely accept input voltages ranging between 0.0 V and 3.3 V. This input range ensures compatibility with an array of sensors and external devices.
-
-3. To prevent floating states and offer a consistent and predictable behavior, internal pull-ups are automatically enabled on all input pins. This default configuration means that, unless actively driven low, the pins will naturally read as high (or 3.3 V).
-
-When all conditions are set and in place, access the Portenta X8's shell with admin (root) access as follows:
-
-```bash
-adb shell
-sudo su -
-```
-
-Enter the password `fio` when prompted. Next, access the `x8-devel` Docker container with the command:
-
-```bash
-docker exec -it x8-devel sh
-```
-
-Navigate to the directory containing the GPIO example, named `gpios.py`:
-
-```bash
-cd root/examples/portenta-hat-carrier
-```
-
-Run the `gpios.py` script to read the status of all available GPIOs on the 40-pin header:
-
-```python
-#!/usr/bin/env python3
-
-# created 12 October 2023
-# by Riccardo Mereu & Massimo Pennazio
-
-import os
-
-if os.environ['CARRIER_NAME'] != "rasptenta":
-    print("This script requires Portenta HAT carrier")
-    exit(1)
-
-import Portenta.GPIO as GPIO
-
-GPIO.setmode(GPIO.BCM)
-
-all_pins_in_header = [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27]
-
-GPIO.setup(all_pins_in_header, GPIO.IN)
-
-for pin in all_pins_in_header:
-    try:
-        print(GPIO.input(pin))
-    except RuntimeError as e:
-        print("Error reading GPIO %s: %s" % (str(pin), str(e)))
-
-GPIO.cleanup()
-```
-
-***The latest compatible GPIO library can be found [here](https://pypi.org/project/Portenta.GPIO/). Make sure to use the latest library for optimal functionality.***
-
-This script will help you verify the following considerations:
-
-- Avoid manually checking each pin by having a consolidated overview of all GPIOs' statuses.
-
-- By staying within the specified voltage range, you ensure the longevity of your device and prevent potential damages.
-
-- With the default pull-ups, you can be confident in your readings, knowing that unintentional fluctuations are minimized.
+The __Portenta.GPIO__ library, officially supported and compatible with the Portenta Hat Carrier and Portenta X8, can be found [here](https://pypi.org/project/Portenta.GPIO/).
 
 The GPIO configuration register for the STM32 microcontroller is structured with various fields that control different aspects of GPIO functionality:
 
@@ -2526,6 +2456,190 @@ Each pin is identified by its port and a unique port number. The following table
 |          | 167             | PF11          | ADC_CH0 (A0)        |
 |          | 164             | PF12          | GPIO_4              |
 |          | 169             | PF13          | ADC_CH2 (A2)        |
+
+#### GPIO Global Map
+<br></br>
+
+For ease of access to all available GPIOs within the Portenta family board and Portenta Hat Carrier, the following table enlists every designations that can be used to access directly each individual GPIO.
+
+The __Port Number__ defines the number designation of the corresponding connector. The __Function__ tells the role of the designated port number. For example, the port number `7` of the `40-Pin connector` is characterized as __`PWM0`__. Thus, on the Portenta X8, it can be handled by using `183` within the ADB shell or `7` within the Python script. The GPIOs mentioned in the following are controllable, while each pin may have its characteristical function.
+
+|   **Connector**    | **Port Number** |       **Function**       | **Portenta X8** | **Portenta H7** | **Portenta C33** |
+|:------------------:|:---------------:|:------------------------:|:---------------:|:---------------:|:----------------:|
+| _40-Pin Connector_ |                 |                          |                 |                 |                  |
+|                    |        3        |         I2C2 SDA         |       XX        |        X        |     36/LEDB      |
+|                    |        5        |         I2C2 SCL         |       XX        |        X        |     36/LEDB      |
+|                    |        7        |           PWM0           |     183 / 7     |        8        |       0/D0       |
+|                    |        8        |        SERIAL3 TX        |       XX        |        X        |     36/LEDB      |
+|                    |       10        |        SERIAL3 RX        |       XX        |        X        |     36/LEDB      |
+|                    |       11        |          GPIO2           |       XX        |        X        |     36/LEDB      |
+|                    |       12        |          I2S CK          |       XX        |        X        |     36/LEDB      |
+|                    |       13        |          GPIO6           |       XX        |        X        |     36/LEDB      |
+|                    |       15        | SAI D0 __(OUTPUT ONLY)__ |       XX        |        X        |     36/LEDB      |
+|                    |       16        | SAI CK __(OUTPUT ONLY)__ |       XX        |        X        |     36/LEDB      |
+|                    |       18        | SAI FS __(OUTPUT ONLY)__ |       XX        |        X        |     36/LEDB      |
+|                    |       22        |           PWM1           |      184 /      |        X        |     36/LEDB      |
+|                    |       29        |        SERIAL1 RX        |       XX        |        X        |     36/LEDB      |
+|                    |       31        |           PWM3           |      186 /      |        X        |     36/LEDB      |
+|                    |       32        |        SERIAL1 TX        |       XX        |        X        |     36/LEDB      |
+|                    |       33        |           PWM4           |      187 /      |        X        |     36/LEDB      |
+|                    |       35        |          I2S WS          |       XX        |        X        |     36/LEDB      |
+|                    |       36        |           PWM5           |      188 /      |        X        |     36/LEDB      |
+|                    |       37        |           PWM6           |      189 /      |        X        |     36/LEDB      |
+|                    |       38        |         I2S SDI          |       XX        |        X        |     36/LEDB      |
+|                    |       40        |         I2S SDO          |       XX        |        X        |     36/LEDB      |
+| _16-Pin Connector_ |                 |                          |                 |                 |                  |
+|                    |        9        |           PWM7           |      190 /      |        X        |     36/LEDB      |
+|                    |       10        |           PWM8           |      191 /      |        X        |     36/LEDB      |
+|                    |       12        |       GPIO0 / PWM4       |       XX        |        X        |     36/LEDB      |
+|                    |       14        |        SERIAL2 TX        |       XX        |        X        |     36/LEDB      |
+|                    |       16        |        SERIAL2 RX        |       XX        |        X        |     36/LEDB      |
+
+In Linux, pins can be controlled using the system's functions via the ADB shell or via the official Python library.
+
+#### Using Linux With Shell
+<br></br>
+
+The GPIOs of the Portenta X8 can be controlled via the ADB shell. The initial procedure involves accessing elevated access to the Portenta X8's shell, a necessary step to adjust system settings protected by administrative privileges.
+
+Subsequently, the command below must be executed to export the GPIO device located within the directory `/sys/class/`. It is important to note that in this particular instance, _GPIO3_ is synonymous with _163_, which is linked to the LED programmable by the user:
+
+```bash
+echo 163 > /sys/class/gpio/export
+```
+
+To ascertain the availability of GPIO elements, the following command is advised:
+
+```bash
+ls /sys/class/gpio
+```
+
+This command will enumerate all GPIOs that the system has initialized. Additionally, the command below provides detailed information about _163_ (equivalent to _GPIO3_), which was previously exported:
+
+```bash
+ls /sys/class/gpio/gpio163
+```
+
+It is possible to configure GPIO3 after exporting it. The ensuing command provides for the specification of the I/O state of the pin, with the options being _Input_ (denoted as `in`) or _Output_ (designated as `out`):
+
+```bash
+echo <I/O> >/sys/class/gpio/gpio163/direction
+```
+
+For this example, the `<I/O>` field will be replaced with `out`:
+
+```bash
+echo out >/sys/class/gpio/gpio163/direction
+```
+
+To verify the pin configuration, use the `cat` command. If the configuration is correct, the command will display the set value.
+
+```bash
+cat /sys/class/gpio/gpio163/direction
+```
+
+Upon setting the GPIO as an output, it becomes possible to manipulate its state. Assigning the value `1` sets the pin __High__, whereas assigning `0` sets it __Low__. The following command adjusts the pin's state.
+
+For __High__ state:
+
+```bash
+echo 1 >/sys/class/gpio/gpio163/value
+```
+
+For __Low__ state:
+
+```bash
+echo 0 >/sys/class/gpio/gpio163/value
+```
+
+After using the GPIO, it is recommended to unexport it using the following command to remove it from the userspace:
+
+```bash
+echo 163 >/sys/class/gpio/unexport
+```
+
+To confirm that the GPIO has been unexported correctly, the following command can help ensure its state:
+
+```bash
+ls /sys/class/gpio
+```
+
+This measure is crucial for preventing unintentional modifications to the configuration of the GPIO. By adhering to these guidelines, one can effectively and securely manage the GPIO settings on the Portenta X8, from obtaining administrative privileges to the eventual safe unexporting of the GPIO.
+
+#### Using Linux With Library
+<br></br>
+
+The General-Purpose Input/Output (GPIO) features of the Portenta X8 can also be efficiently managed using the [__Portenta.GPIO__ library](https://pypi.org/project/Portenta.GPIO/). This library facilitates an accessible means to control the GPIOs, an aspect that is particularly advantageous when integrating GPIO management within Python scripts.
+
+The functionality of the GPIO management using this library will be illustrated by presenting an example that demonstrates how to retrieve the status of all available GPIOs on a Portenta X8 mounted on the Portenta Hat Carrier. This example is available in the `x8-devel` container, where the required environmental configuration is established.
+
+In preparation for this, the following conditions are recommended to ensure the hardware is correctly configured for testing GPIO controls:
+
+1. Begin by positioning the Portenta-X8 securely onto the Portenta Hat Carrier. Make sure the High-Density connectors are securely connected.
+
+2. Each GPIO on the Portenta Hat Carrier is versatile and robust, designed to safely accept input voltages ranging between 0.0 V and 3.3 V. This input range ensures compatibility with an array of sensors and external devices.
+
+3. To prevent floating states and offer a consistent and predictable behavior, internal pull-ups are automatically enabled on all input pins. This default configuration means that, unless actively driven low, the pins will naturally read as high (or 3.3 V).
+
+When all conditions are set and in place, access the Portenta X8's shell with admin (root) access as follows:
+
+```bash
+adb shell
+sudo su -
+```
+
+Enter the password `fio` when prompted. Next, access the `x8-devel` Docker container with the command:
+
+```bash
+docker exec -it x8-devel sh
+```
+
+Navigate to the directory containing the GPIO example, named `gpios.py`:
+
+```bash
+cd root/examples/portenta-hat-carrier
+```
+
+Run the `gpios.py` script to read the status of all available GPIOs on the 40-pin header:
+
+```python
+#!/usr/bin/env python3
+
+# created 12 October 2023
+# by Riccardo Mereu & Massimo Pennazio
+
+import os
+
+if os.environ['CARRIER_NAME'] != "rasptenta":
+    print("This script requires Portenta HAT carrier")
+    exit(1)
+
+import Portenta.GPIO as GPIO
+
+GPIO.setmode(GPIO.BCM)
+
+all_pins_in_header = [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27]
+
+GPIO.setup(all_pins_in_header, GPIO.IN)
+
+for pin in all_pins_in_header:
+    try:
+        print(GPIO.input(pin))
+    except RuntimeError as e:
+        print("Error reading GPIO %s: %s" % (str(pin), str(e)))
+
+GPIO.cleanup()
+```
+
+***The latest compatible GPIO library can be found [here](https://pypi.org/project/Portenta.GPIO/). Make sure to use the latest library for optimal functionality.***
+
+This script will help you verify the following considerations:
+
+- Avoid manually checking each pin by having a consolidated overview of all GPIOs' statuses.
+
+- By staying within the specified voltage range, you ensure the longevity of your device and prevent potential damages.
+
+- With the default pull-ups, you can be confident in your readings, knowing that unintentional fluctuations are minimized.
 
 By employing this script, not only do you gain a deeper insight into the state of your GPIOs, but you also save valuable time and reduce the margin for error.
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2358,7 +2358,7 @@ Within the 40-pin connector, certain GPIOs are specifically related to different
   
   For more information regarding the DTB layer, please refer to the [Device Tree Blob (DTB) Overlays](#understanding-device-tree-blobs-dtb-overlays) section.
 
-The __Portenta.GPIO__ library, officially supported and compatible with the Portenta Hat Carrier and Portenta X8, can be found [here](https://pypi.org/project/Portenta.GPIO/).
+The __Portenta.GPIO__ library, officially supported and compatible with the Portenta Hat Carrier and Portenta X8, can be found [here](https://github.com/SuMere/portenta-gpio).
 
 The GPIO configuration register for the STM32 microcontroller is structured with various fields that control different aspects of GPIO functionality:
 
@@ -2460,53 +2460,77 @@ Each pin is identified by its port and a unique port number. The following table
 #### GPIO Global Map
 <br></br>
 
-For ease of access to all available GPIOs within the Portenta family board and Portenta Hat Carrier, the following table enlists every designations that can be used to access directly each individual GPIO.
+For easy access to the available GPIOs on the Portenta Hat Carrier, the table below lists each designation that allows direct access to each GPIO when using a board from the Portenta family.
 
-The __Port Number__ defines the number designation of the corresponding connector. The __Function__ tells the role of the designated pin number. For example, the pin number `7` of the `40-Pin connector` is characterized as __`PWM0`__. Thus, on the Portenta X8, it can be handled by using `183` within the ADB shell, `7` within the Python® script, or `PC_7` within the Arduino IDE. The GPIOs mentioned in the following are controllable, while each pin may have its characteristical function.
+The __Connector__ column shows the position of each GPIO pin within the Portenta Hat Carrier. The [carrier topology](#carrier-topology) section can help in identifying the connectors' locations. The __Pin Number__ column identifies the position of each GPIO pin on its respective connector. The __Function__ column describes the role of each pin. For instance, pin `7` on the _40-pin connector_ is characterized as `PWM0`. The access methods for each Portenta board are as follows:
 
-|   **Connector**    | **Pin Number** |         **Function**          | **Portenta X8 (Linux/Arduino)** |  **Portenta H7**   | **Portenta C33** |
-|:------------------:|:--------------:|:-----------------------------:|:-------------------------------:|:------------------:|:----------------:|
-| _40-Pin Connector_ |                |                               |                                 |                    |                  |
-|                    |       7        |             PWM0              |         183 / PC_7 (39)         |      PA_8 (8)      |        0         |
-|                    |       8        |          SERIAL3 TX           |               157               |     PL_8 (152)     |        53        |
-|                    |       10       |          SERIAL3 RX           |               156               |     PJ_9 (153)     |        54        |
-|                    |       11       |             GPIO2             |         162 / PF_3 (83)         |     PD_4 (52)      |        29        |
-|                    |       12       |            I2S CK             |               87                |     PD_3 (51)      |        63        |
-|                    |       13       |             GPIO6             |        166 / PE_11 (75)         |    PG_10 (106)     |        33        |
-|                    |       15       |   SAI D0 **(OUTPUT ONLY)**    |               108               |     PI_6 (134)     |        80        |
-|                    |       16       |   SAI CK **(OUTPUT ONLY)**    |               107               |     PI_5 (133)     |        78        |
-|                    |       18       |   SAI FS **(OUTPUT ONLY)**    |               106               |     PI_7 (135)     |        79        |
-|                    |       19       | SPI1 COPI **(DTB Activated)** |               139               |     PC_3 (35)      |        46        |
-|                    |       21       | SPI1 CIPO **(DTB Activated)** |               140               |     PC_2 (34)      |        45        |
-|                    |       22       |             PWM1              |         184 / PA_9 (9)          |     PC_6 (38)      |        1         |
-|                    |       23       | SPI1 SCK **(DTB Activated)**  |               138               |     PI_0 (128)     |        47        |
-|                    |       24       |  SPI1 CE **(DTB Activated)**  |               141               |     PI_1 (129)     |        48        |
-|                    |       26       |             PWM2              |        185 / PA_10 (10)         |     PC_7 (39)      |        2         |
-|                    |       29       |          SERIAL1 RX           |               127               |     PA_10 (10)     |        13        |
-|                    |       31       |             PWM3              |        186 / PB_10 (26)         |     PG_7 (103)     |        3         |
-|                    |       32       |          SERIAL1 TX           |               128               |      PA_9 (9)      |        14        |
-|                    |       33       |             PWM4              |        187 / PA_11 (11)         |    PJ_11 (155)     |        4         |
-|                    |       35       |            I2S WS             |              128*               |     PB_9 (25)      |        64        |
-|                    |       36       |             PWM5              |        188 / PD_15 (63)         |     PK_1 (161)     |        5         |
-|                    |       37       |             PWM6              |         189 / PA_8 (8)          |    PH_15 (127)     |        6         |
-|                    |       38       |            I2S SDI            |               85                |     PI_2 (130)     |        65        |
-|                    |       40       |            I2S SDO            |               88                |     PI_3 (131)     |        66        |
-| _16-Pin Connector_ |                |                               |                                 |                    |                  |
-|                    |       1        |              A0               |            167 / A0             | PA_0_C (2048) / A0 |        15        |
-|                    |       2        |              A1               |            168 / A1             | PA_1_C (2049) / A1 |        16        |
-|                    |       3        |              A2               |            169 / A2             | PC_2_C (2082) / A2 |        17        |
-|                    |       4        |              A3               |            170 / A3             | PC_3_C (2083) / A3 |        18        |
-|                    |       5        |              A4               |            171 / A4             |   PC_2 (34) / A4   |        19        |
-|                    |       6        |              A5               |            172 / A5             |   PC_3 (35) / A5   |        20        |
-|                    |       7        |              A6               |            173 / A6             |   PA_4 (4) / A6    |        21        |
-|                    |       8        |              A7               |            174 / A7             |   PA_6 (6) / A7    |        22        |
-|                    |       9        |             PWM7              |         190 / PC_6 (38)         |     PJ_7 (151)     |        7         |
-|                    |       10       |             PWM8              |        191 / PA_12 (12)         |    PJ_10 (154)     |        8         |
-|                    |       12       |             PWM4              |        187* / PA_11 (11)        |    PJ_11 (155)     |        4         |
-|                    |       14       |          SERIAL2 TX           |               155               |    PG_14 (110)     |        49        |
-|                    |       16       |          SERIAL2 RX           |               154               |     PG_9 (105)     |        50        |
+- _Portenta X8_: Accessible using `183` in the ADB shell and `4` in Python® scripts using the [official __Portenta.GPIO__ library](https://github.com/SuMere/portenta-gpio) in BCM mode or `PC_7` in the Arduino IDE.
+- _Portenta H7 / H7 Lite / H7 Lite Connected_: Controllable by calling `PA_8` in the Arduino IDE.
+- _Portenta C33_: Accessible using `0` in the Arduino IDE
 
-In Linux, pins can be controlled using the system's functions via the ADB shell or via the official Python® library.
+This logic applies to all listed GPIOs. The GPIOs in the table are controllable, and each pin may have its specific function.
+
+|       **Connector**       | **Pin number** |        **Function**         | **Portenta X8<br>(Linux / Python® [BCM Mode])** | **Portenta X8<br>(Arduino*)** | **Portenta H7** | **Portenta C33** |
+|:-------------------------:|:--------------:|:---------------------------:|:-----------------------------------------------:|:-----------------------------:|:---------------:|:----------------:|
+|  _40-Pin Connector (J5)_  |                |                             |                                                 |                               |                 |                  |
+|                           |       3        |          I2C2 SDA           |                     149 / 2                     |                               |      PH_12      |        39        |
+|                           |       5        |          I2C2 SCL           |                     148 / 3                     |                               |      PH_11      |        40        |
+|                           |       7        |            PWM0             |                     183 / 4                     |             PC_7              |      PA_8       |        0         |
+|                           |       8        |         SERIAL3 TX          |                    157 / 14                     |                               |      PL_8       |        53        |
+|                           |       10       |         SERIAL3 RX          |                    156 / 15                     |                               |      PJ_9       |        54        |
+|                           |       11       |            GPIO2            |                    162 / 17                     |             PF_3              |      PD_4       |        29        |
+|                           |       12       |           I2S CK            |                     87 / 18                     |                               |      PD_3       |        63        |
+|                           |       13       |            GPIO6            |                    166 / 27                     |             PE_11             |      PG_10      |        33        |
+|                           |       15       |   SAI D0 _(OUTPUT ONLY)_    |                    108 / 22                     |                               |      PI_6       |        80        |
+|                           |       16       |   SAI CK _(OUTPUT ONLY)_    |                    107 / 23                     |                               |      PI_5       |        78        |
+|                           |       18       |   SAI FS _(OUTPUT ONLY)_    |                    106 / 24                     |                               |      PI_7       |        79        |
+|                           |       19       | SPI1 COPI _(DTB Activated)_ |                    135 / 10                     |                               |      PC_3       |        46        |
+|                           |       21       | SPI1 CIPO _(DTB Activated)_ |                     136 / 9                     |                               |      PC_2       |        45        |
+|                           |       22       |            PWM1             |                    184 / 25                     |             PA_9              |      PC_6       |        1         |
+|                           |       23       | SPI1 SCK _(DTB Activated)_  |                    134 / 11                     |                               |      PI_0       |        47        |
+|                           |       24       |  SPI1 CE _(DTB Activated)_  |                     137 / 8                     |                               |      PI_1       |        48        |
+|                           |       26       |            PWM2             |                     185 / 7                     |             PA_10             |      PC_7       |        2         |
+|                           |       29       |         SERIAL1 RX          |                     127 / 5                     |                               |      PA_10      |        13        |
+|                           |       31       |            PWM3             |                     186 / 6                     |             PB_10             |      PG_7       |        3         |
+|                           |       32       |         SERIAL1 TX          |                    128 / 12                     |                               |      PA_9       |        14        |
+|                           |       33       |            PWM4             |                    187 / 13                     |             PA_11             |      PJ_11      |        4         |
+|                           |       35       |           I2S WS            |                     86 / 19                     |                               |      PB_9       |        64        |
+|                           |       36       |            PWM5             |                    188 / 16                     |             PD_15             |      PK_1       |        5         |
+|                           |       37       |            PWM6             |                    189 / 26                     |             PA_8              |      PH_15      |        6         |
+|                           |       38       |           I2S SDI           |                     85 / 20                     |                               |      PI_2       |        65        |
+|                           |       40       |           I2S SDO           |                     88 / 21                     |                               |      PI_3       |        66        |
+|  _16-Pin Connector (J6)_  |                |                             |                                                 |                               |                 |                  |
+|                           |       1        |        Analog 0 - A0        |                       167                       |              A0               |   PA_0C / A0    |        15        |
+|                           |       2        |        Analog 1 - A1        |                       168                       |              A1               |   PA_1C / A1    |        16        |
+|                           |       3        |        Analog 2 - A2        |                       169                       |              A2               |   PC_2C / A2    |        17        |
+|                           |       4        |        Analog 3 - A3        |                       170                       |              A3               |   PC_3C / A3    |        18        |
+|                           |       5        |        Analog 4 - A4        |                       171                       |              A4               |    PC_2 / A4    |        19        |
+|                           |       6        |        Analog 5 - A5        |                       172                       |              A5               |    PC_3 / A5    |        20        |
+|                           |       7        |        Analog 6 - A6        |                       173                       |              A6               |    PA_4 / A6    |        21        |
+|                           |       8        |        Analog 7 - A7        |                       174                       |              A7               |    PA_6 / A7    |        22        |
+|                           |       9        |            PWM7             |                       190                       |             PC_6              |      PJ_7       |        7         |
+|                           |       10       |            PWM8             |                       191                       |             PA_12             |      PJ_10      |        8         |
+|                           |       12       |            PWM4             |                       187                       |             PA_11             |      PJ_11      |        4         |
+|                           |       14       |         SERIAL2 TX          |                       155                       |                               |      PG_14      |        49        |
+|                           |       16       |         SERIAL2 RX          |                       154                       |                               |      PG_9       |        50        |
+| _PWM Fan Connector (J11)_ |                |                             |                                                 |                               |                 |                  |
+|                           |       1        |            PWM9             |                       192                       |             PC_8              |      PH_6       |        25        |
+|    _On-Board Element_     |                |                             |                                                 |                               |                 |                  |
+|                           |       -        |      GPIO3 (User LED)       |                       163                       |             PF_4              |      PD_5       |        30        |
+
+To effectively understand and use the GPIO (General Purpose Input/Output) designations of the table above, which are specific to combinations of the Portenta family board and the Portenta Hat Carrier, it is important to consider the following details:
+
+- The __Linux__ GPIO designations for the Portenta X8 are applicable in the ADB shell. These designations can also be used in Python® scripts by constructing a path to the GPIO pin in the system's file system.
+  
+  For more information, please refer to the [Hello World Using Linux](#hello-world-using-linux) section in this present user manual.
+
+- The __Python®__ GPIO designations for the Portenta X8 are available through the [official __Portenta.GPIO__ library](https://github.com/SuMere/portenta-gpio), using BroadCom SoC GPIO numbers in BCM mode. This applies to the 40-pin Connector (J5) pins compatible with Raspberry Pi® HATs on the Portenta Hat Carrier.
+  
+  To learn about the practical implementation of these designations, please refer to the `gpio.py` example in the [GPIO Pins](#gpio-pins) section of this user manual.
+
+- The __Arduino__ GPIO designations for the Portenta X8 are applicable if desired in the Arduino IDE. The GPIO definitions for the Portenta H7, including its H7 Lite and H7 Lite Connected variants and the C33, are directly usable in the Arduino IDE.
+  
+  For more information, refer to this user manual's [Hello World Using Arduino](#hello-world-using-arduino) section.
 
 #### Using Linux With Shell
 <br></br>

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2443,11 +2443,25 @@ The GPIO configuration register for the STM32 microcontroller is structured with
 - __FSEL (Slew Rate Field)__: Controls the slew rate. 0X is slow, 1X is fast.
 - __DSE (Drive Strength Field)__: Adjusts the drive strength. Options range from X1 to X6, with varying levels of strength.
 
-To control a desired GPIO within the Linux environment of the Portenta X8, based on the STM32 microcontroller, the following GPIO chip formula can help get the required GPIO number designation:
+To control a desired GPIO within the Linux environment of the Portenta X8, the following GPIO chip formula can help get the required number designation:
 
 ```
 [(<GPIO group> -1) * 32] + <GPIO number>
 ```
+
+For example, __PA0__ is one available GPIO pin from __Port A__ within i.MX8M Mini found with the Portenta X8. Its GPIO designation is defined as `GPIO1_IO07`. Such port relationship can be found within the provided [schematics of the Portenta X8](https://docs.arduino.cc/resources/schematics/ABX00049-schematics.pdf), that can be exposed to be used with the Portenta Hat Carrier.
+
+Applying the formula to the GPIO designation, the formula field is seen as follows:
+
+```
+# Illustrative form
+[(GPIO1 - 1) * 32] + IO07
+
+# Numeric form
+[(1 - 1) * 32] + 7 = 7
+```
+
+With this, it is possible to recognize that __PA0__, known as `GPIO1_IO07`, can be accessed as __`7`__, representing a numeric designation for this specific GPIO.
 
 Each GPIO chip manages a specific range of GPIO numbers, facilitating organized and efficient access to the GPIO functionality of the STM32 microcontroller. The GPIO groups for the Portenta X8 are segmented in the following manner:
 
@@ -2469,13 +2483,13 @@ The STM32 microcontroller includes various GPIO ports, each with a specific set 
 - __Port E__: PE10, PE11
 - __Port F__: PF3, PF4, PF5, PF6, PF7, PF8, PF9, PF11, PF12, PF13
 
-Each pin is identified by its port and a unique port number.
+Each pin is identified by its port and a unique port number. The following table shows the numeric designations of the GPIOs handled by the STM32 microcontroller.
 
 | **Port** | **Port Number** | **Port Name** | **Function / Role** |
 |----------|-----------------|---------------|---------------------|
 | _Port A_ |                 |               |                     |
 |          | 168             | PA6           | ADC_CH1 (A1)        |
-|          | 189             | PA8           | PWM_3               |
+|          | 189             | PA8           | PWM_6               |
 |          | 184             | PA9           | PWM_1               |
 |          | 185             | PA10          | PWM_2               |
 |          | 187             | PA11          | PWM_4               |

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -2462,46 +2462,53 @@ Each pin is identified by its port and a unique port number. The following table
 
 For ease of access to all available GPIOs within the Portenta family board and Portenta Hat Carrier, the following table enlists every designations that can be used to access directly each individual GPIO.
 
-The __Port Number__ defines the number designation of the corresponding connector. The __Function__ tells the role of the designated port number. For example, the port number `7` of the `40-Pin connector` is characterized as __`PWM0`__. Thus, on the Portenta X8, it can be handled by using `183` within the ADB shell or `7` within the Python script. The GPIOs mentioned in the following are controllable, while each pin may have its characteristical function.
+The __Port Number__ defines the number designation of the corresponding connector. The __Function__ tells the role of the designated pin number. For example, the pin number `7` of the `40-Pin connector` is characterized as __`PWM0`__. Thus, on the Portenta X8, it can be handled by using `183` within the ADB shell, `7` within the Python script, or `PC_7` within the Arduino IDE. The GPIOs mentioned in the following are controllable, while each pin may have its characteristical function.
 
-|   **Connector**    | **Pin Number** |       **Function**       | **Portenta X8 (Linux/Arduino)** | **Portenta H7** | **Portenta C33 (Numeric/Define)** |
-|:------------------:|:--------------:|:------------------------:|:-------------------------------:|:---------------:|:---------------------------------:|
-| _40-Pin Connector_ |                |                          |                                 |                 |                                   |
-|                    |       3        |         I2C2 SDA         |               XX                |        X        |              36/LEDB              |
-|                    |       5        |         I2C2 SCL         |               XX                |        X        |              36/LEDB              |
-|                    |       7        |           PWM0           |             183 / 7             |        8        |               0/D0                |
-|                    |       8        |        SERIAL3 TX        |               XX                |        X        |              36/LEDB              |
-|                    |       10       |        SERIAL3 RX        |               XX                |        X        |              36/LEDB              |
-|                    |       11       |          GPIO2           |              162 /              |        X        |              36/LEDB              |
-|                    |       12       |          I2S CK          |               XX                |        X        |              36/LEDB              |
-|                    |       13       |          GPIO6           |              166 /              |        X        |              36/LEDB              |
-|                    |       15       | SAI D0 __(OUTPUT ONLY)__ |               XX                |        X        |              36/LEDB              |
-|                    |       16       | SAI CK __(OUTPUT ONLY)__ |               XX                |        X        |              36/LEDB              |
-|                    |       18       | SAI FS __(OUTPUT ONLY)__ |               XX                |        X        |              36/LEDB              |
-|                    |       22       |           PWM1           |              184 /              |        X        |              36/LEDB              |
-|                    |       29       |        SERIAL1 RX        |               XX                |        X        |              36/LEDB              |
-|                    |       31       |           PWM3           |              186 /              |        X        |              36/LEDB              |
-|                    |       32       |        SERIAL1 TX        |               XX                |        X        |              36/LEDB              |
-|                    |       33       |           PWM4           |              187 /              |        X        |              36/LEDB              |
-|                    |       35       |          I2S WS          |               XX                |        X        |              36/LEDB              |
-|                    |       36       |           PWM5           |              188 /              |        X        |              36/LEDB              |
-|                    |       37       |           PWM6           |              189 /              |        X        |              36/LEDB              |
-|                    |       38       |         I2S SDI          |               XX                |        X        |              36/LEDB              |
-|                    |       40       |         I2S SDO          |               XX                |        X        |              36/LEDB              |
-| _16-Pin Connector_ |                |                          |                                 |                 |                                   |
-|                    |       1        |            A0            |            167 / A0             |    2048 / A0    |              36/LEDB              |
-|                    |       2        |            A1            |            168 / A1             |     1 / A1      |              36/LEDB              |
-|                    |       3        |            A2            |            169 / A2             |     34 / A2     |              36/LEDB              |
-|                    |       4        |            A3            |            170 / A3             |     35 / A3     |              36/LEDB              |
-|                    |       5        |            A4            |            171 / A4             |        X        |              36/LEDB              |
-|                    |       6        |            A5            |            172 / A5             |        X        |              36/LEDB              |
-|                    |       7        |            A6            |            173 / A6             |        X        |              36/LEDB              |
-|                    |       8        |            A7            |            174 / A7             |        X        |              36/LEDB              |
-|                    |       9        |           PWM7           |              190 /              |        X        |              36/LEDB              |
-|                    |       10       |           PWM8           |              191 /              |        X        |              36/LEDB              |
-|                    |       12       |       GPIO0 / PWM4       |              160 /              |        X        |              36/LEDB              |
-|                    |       14       |        SERIAL2 TX        |               XX                |        X        |              36/LEDB              |
-|                    |       16       |        SERIAL2 RX        |               XX                |        X        |              36/LEDB              |
+|   **Connector**    | **Pin Number** |         **Function**          | **Portenta X8 (Linux/Arduino)** |  **Portenta H7**   | **Portenta C33 (Numeric/Define)** |
+|:------------------:|:--------------:|:-----------------------------:|:-------------------------------:|:------------------:|:---------------------------------:|
+| _40-Pin Connector_ |                |                               |                                 |                    |                                   |
+|                    |       3        |           I2C2 SDA            |              149*               |    PH_12 (124)     |             39 / D39              |
+|                    |       5        |           I2C2 SCL            |              148*               |    PH_11 (123)     |             40 / D40              |
+|                    |       7        |             PWM0              |         183 / PC_7 (39)         |      PA_8 (8)      |              0 / D0               |
+|                    |       8        |          SERIAL3 TX           |               157               |     PL_8 (152)     |             53 / D53              |
+|                    |       10       |          SERIAL3 RX           |               156               |     PJ_9 (153)     |             54 / D54              |
+|                    |       11       |             GPIO2             |         162 / PF_3 (83)         |     PD_4 (52)      |             29 / D29              |
+|                    |       12       |            I2S CK             |               87                |     PD_3 (51)      |             63 / D63              |
+|                    |       13       |             GPIO6             |        166 / PE_11 (75)         |    PG_10 (106)     |             33 / D33              |
+|                    |       15       |   SAI D0 **(OUTPUT ONLY)**    |               108               |     PI_6 (134)     |             80 / D80              |
+|                    |       16       |   SAI CK **(OUTPUT ONLY)**    |               107               |     PI_5 (133)     |             78 / D78              |
+|                    |       18       |   SAI FS **(OUTPUT ONLY)**    |               106               |     PI_7 (135)     |             79 / D79              |
+|                    |       19       | SPI1 COPI **(DTB Activated)** |               139               |     PC_3 (35)      |             46 / D46              |
+|                    |       21       | SPI1 CIPO **(DTB Activated)** |               140               |     PC_2 (34)      |             45 / D45              |
+|                    |       22       |             PWM1              |         184 / PA_9 (9)          |     PC_6 (38)      |              1 / D1               |
+|                    |       23       | SPI1 SCK **(DTB Activated)**  |               138               |     PI_0 (128)     |             47 / D47              |
+|                    |       24       |  SPI1 CE **(DTB Activated)**  |               141               |     PI_1 (129)     |             48 / D48              |
+|                    |       26       |             PWM2              |        185 / PA_10 (10)         |     PC_7 (39)      |              2 / D2               |
+|                    |       27       |           I2C0 SDA            |                                 |     PH_8 (120)     |             11 / D11              |
+|                    |       28       |           I2C0 SCL            |                                 |     PH_7 (119)     |             12 / D12              |
+|                    |       29       |          SERIAL1 RX           |               127               |     PA_10 (10)     |             13 / D13              |
+|                    |       31       |             PWM3              |        186 / PB_10 (26)         |     PG_7 (103)     |              3 / D3               |
+|                    |       32       |          SERIAL1 TX           |               128               |      PA_9 (9)      |             14 / D14              |
+|                    |       33       |             PWM4              |        187 / PA_11 (11)         |    PJ_11 (155)     |              4 / D4               |
+|                    |       35       |            I2S WS             |              128*               |     PB_9 (25)      |             64 / D64              |
+|                    |       36       |             PWM5              |        188 / PD_15 (63)         |     PK_1 (161)     |              5 / D5               |
+|                    |       37       |             PWM6              |         189 / PA_8 (8)          |    PH_15 (127)     |              6 / D6               |
+|                    |       38       |            I2S SDI            |               85                |     PI_2 (130)     |             65 / D65              |
+|                    |       40       |            I2S SDO            |               88                |     PI_3 (131)     |             66 / D66              |
+| _16-Pin Connector_ |                |                               |                                 |                    |                                   |
+|                    |       1        |              A0               |            167 / A0             | PA_0_C (2048) / A0 |             15 / D15              |
+|                    |       2        |              A1               |            168 / A1             | PA_1_C (2049) / A1 |             16 / D16              |
+|                    |       3        |              A2               |            169 / A2             | PC_2_C (2082) / A2 |             17 / D17              |
+|                    |       4        |              A3               |            170 / A3             | PC_3_C (2083) / A3 |             18 / D18              |
+|                    |       5        |              A4               |            171 / A4             |   PC_2 (34) / A4   |             19 / D19              |
+|                    |       6        |              A5               |            172 / A5             |   PC_3 (35) / A5   |             20 / D20              |
+|                    |       7        |              A6               |            173 / A6             |   PA_4 (4) / A6    |             21 / D21              |
+|                    |       8        |              A7               |            174 / A7             |   PA_6 (6) / A7    |             22 / D22              |
+|                    |       9        |             PWM7              |         190 / PC_6 (38)         |     PJ_7 (151)     |              7 / D7               |
+|                    |       10       |             PWM8              |        191 / PA_12 (12)         |    PJ_10 (154)     |              8 / D8               |
+|                    |       12       |             PWM4              |        187* / PA_11 (11)        |    PJ_11 (155)     |              4 / D4               |
+|                    |       14       |          SERIAL2 TX           |              155*               |    PG_14 (110)     |             49 / D49              |
+|                    |       16       |          SERIAL2 RX           |              154*               |     PG_9 (105)     |             50 / D50              |
 
 In Linux, pins can be controlled using the system's functions via the ADB shell or via the official Python library.
 


### PR DESCRIPTION
## What This PR Changes
Updates GPIO information within the Portenta Hat Carrier User Manual:
- SAI pins
- SPI pins
- GPIO library link update

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.