### PR TITLE
[PC-1557] - Portenta H7 MTBF information (datasheet) 

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -682,9 +682,9 @@ MTBF, which stands for Mean Time Between Failure, is calculated according to sta
 
 The MTBF figure (in hours) for the Portenta H7 (all variants) can be found in the table below. The MTBF figure was calculated according to the MIL217F part count method.  
 
-|      **Standard**      | **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** |         **Environmental Conditions**         |
-|:----------------------:|:---------------:|:--------------------:|:------------------------------:|:--------------------------------------------:|
-| **MTBF MIL HDBK 217F** |  XXXXh<br>XXXXh |    XXXXh<br>XXXXh    |         XXXXh<br>XXXXh         | 25 ºC, Ground Benign<br>40 ºC, Ground Benign |
+| **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** | **Environmental Conditions** |
+|:---------------:|:--------------------:|:------------------------------:|:----------------------------:|
+|      XXXXh      |         XXXXh        |              XXXXh             |     25 ºC, Ground Benign     |
 
 ## Mechanical Information
 

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -676,6 +676,14 @@ Depending on the variant, some of the components does not apply. The image below
 
 ![Portenta H7 Power Tree](assets/portentaH7powerT.svg)
 
+## Mean Time Between Failure (MTBF)
+
+MTBF, which stands for Mean Time Between Failure, is calculated according to statistical device failures and indicates the reliability of a device. **Important note**: MTBF is the statistical representation of the likelihood of a unit failing and _does not necessarily represent a product's life_. The MTBF figure (in hours) for the Portenta H7 (all variants) can be found in the following table: 
+
+|      **Standard**      | **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** |         **Environmental Conditions**         |
+|:----------------------:|:---------------:|:--------------------:|:------------------------------:|:--------------------------------------------:|
+| **MTBF MIL HDBK 217F** |  XXXXh<br>XXXXh |    XXXXh<br>XXXXh    |         XXXXh<br>XXXXh         | 25 ºC, Ground Benign<br>40 ºC, Ground Benign |
+
 ## Mechanical Information
 
 ### Board Outline
@@ -688,6 +696,8 @@ Depending on the variant, some of the components does not apply. The image below
 ![Connectors positions top](assets/portentaH7_connectors_top.png)
 
 ![Connectors positions bottom](assets/portentaH7_connectors_bot.png)
+
+<div style="break-after:page"></div>
 
 ## Certifications
 <table>

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -917,7 +917,8 @@ Hereby, Arduino S.r.l. declares that this product is in compliance with essentia
 ## Revision History
 
 | Date       | **Revision** | **Changes**                         |
-| ---------- | ------------ | ----------------------------------- |
+|------------|--------------|-------------------------------------|
+| 06/02/2024 | 6            | MTBF information                    |
 | 05/12/2023 | 5            | Accessories section updated         |
 | 17/10/2023 | 4            | I2C ports information section added |
 | 27/01/2023 | 3            | Add power consumption information   |

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -678,7 +678,9 @@ Depending on the variant, some of the components does not apply. The image below
 
 ## Mean Time Between Failure (MTBF)
 
-MTBF, which stands for Mean Time Between Failure, is calculated according to statistical device failures and indicates the reliability of a device. **Important note**: MTBF is the statistical representation of the likelihood of a unit failing and _does not necessarily represent a product's life_. The MTBF figure (in hours) for the Portenta H7 (all variants) can be found in the following table: 
+MTBF, which stands for Mean Time Between Failure, is calculated according to statistical device failures and indicates the reliability of a device. **Important note**: MTBF is the statistical representation of the likelihood of a unit failing and _does not necessarily represent a product's life_. 
+
+The MTBF figure (in hours) for the Portenta H7 (all variants) can be found in the table below. The MTBF figure was calculated according to the MIL217F part count method.  
 
 |      **Standard**      | **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** |         **Environmental Conditions**         |
 |:----------------------:|:---------------:|:--------------------:|:------------------------------:|:--------------------------------------------:|

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -682,9 +682,9 @@ MTBF, which stands for Mean Time Between Failure, is calculated according to sta
 
 The MTBF figure (in hours/years) for the Portenta H7 (all variants) can be found in the table below. The MTBF figure was calculated according to the MIL-HDBK-217F part count method.  
 
-| **Standard** | **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** | **Environmental Conditions** |
-|:---:|:---:|:---:|:---:|:---:|
-| MIL-HDBK-217F | XXXX h/XX years | XXXX h/XX years | XXXX h/XX years | 25 ºC |
+| **Standard** | **Portenta H7** | **Environmental Conditions** |
+|:---:|:---:|:---:|
+| MIL-HDBK-217F | 639717 h/73 years | 25 ºC |
 
 **Important note**: MTBF is the statistical representation of the likelihood of a unit failing and _does not necessarily represent a product's life_. 
 

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -680,11 +680,11 @@ Depending on the variant, some of the components does not apply. The image below
 
 MTBF, which stands for Mean Time Between Failure, is calculated according to statistical device failures and indicates the reliability of a device.
 
-The MTBF figure (in hours) for the Portenta H7 (all variants) can be found in the table below. The MTBF figure was calculated according to the MIL-HDBK-217F part count method.  
+The MTBF figure (in hours/years) for the Portenta H7 (all variants) can be found in the table below. The MTBF figure was calculated according to the MIL-HDBK-217F part count method.  
 
-|  **Standard** | **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** | **Environmental Conditions** |
-|:-------------:|:---------------:|:--------------------:|:------------------------------:|:----------------------------:|
-| MIL-HDBK-217F |      XXXX h     |        XXXX h        |             XXXX h             |     25 ºC, Ground Benign     |
+| **Standard** | **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** | **Environmental Conditions** |
+|:---:|:---:|:---:|:---:|:---:|
+| MIL-HDBK-217F | XXXX h/XX years | XXXX h/XX years | XXXX h/XX years | 25 ºC |
 
 **Important note**: MTBF is the statistical representation of the likelihood of a unit failing and _does not necessarily represent a product's life_. 
 

--- a/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
+++ b/content/hardware/04.pro/boards/portenta-h7/datasheets/datasheet.md
@@ -678,13 +678,15 @@ Depending on the variant, some of the components does not apply. The image below
 
 ## Mean Time Between Failure (MTBF)
 
-MTBF, which stands for Mean Time Between Failure, is calculated according to statistical device failures and indicates the reliability of a device. **Important note**: MTBF is the statistical representation of the likelihood of a unit failing and _does not necessarily represent a product's life_. 
+MTBF, which stands for Mean Time Between Failure, is calculated according to statistical device failures and indicates the reliability of a device.
 
-The MTBF figure (in hours) for the Portenta H7 (all variants) can be found in the table below. The MTBF figure was calculated according to the MIL217F part count method.  
+The MTBF figure (in hours) for the Portenta H7 (all variants) can be found in the table below. The MTBF figure was calculated according to the MIL-HDBK-217F part count method.  
 
-| **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** | **Environmental Conditions** |
-|:---------------:|:--------------------:|:------------------------------:|:----------------------------:|
-|      XXXXh      |         XXXXh        |              XXXXh             |     25 ºC, Ground Benign     |
+|  **Standard** | **Portenta H7** | **Portenta H7 Lite** | **Portenta H7 Lite Connected** | **Environmental Conditions** |
+|:-------------:|:---------------:|:--------------------:|:------------------------------:|:----------------------------:|
+| MIL-HDBK-217F |      XXXX h     |        XXXX h        |             XXXX h             |     25 ºC, Ground Benign     |
+
+**Important note**: MTBF is the statistical representation of the likelihood of a unit failing and _does not necessarily represent a product's life_. 
 
 ## Mechanical Information
 


### PR DESCRIPTION
## What This PR Changes
- This PR adds MTBF information of Portenta H7 devices to its datasheet.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
