### PR TITLE
Fix broken links to Arduino IDE 2.x docs parent page

### DIFF
--- a/content/software/ide-v2/tutorials/02.ide-v2-board-manager/ide-v2-board-manager.md
+++ b/content/software/ide-v2/tutorials/02.ide-v2-board-manager/ide-v2-board-manager.md
@@ -254,4 +254,4 @@ For source code and reporting issues, please visit the official GitHub repositor
 
 ## More Tutorials
 
-You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide-v2/).
+You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide/#ide-v2).

--- a/content/software/ide-v2/tutorials/ide-v2-autocomplete-feature/ide-v2-autocomplete-feature.md
+++ b/content/software/ide-v2/tutorials/ide-v2-autocomplete-feature/ide-v2-autocomplete-feature.md
@@ -72,4 +72,4 @@ The autocompletion tool can be a real time-saver, while also helping you develop
 
 ### More Tutorials
 
-You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide-v2/).
+You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide/#ide-v2).

--- a/content/software/ide-v2/tutorials/ide-v2-cloud-sketch-sync/ide-v2-cloud-sketch-sync.md
+++ b/content/software/ide-v2/tutorials/ide-v2-cloud-sketch-sync/ide-v2-cloud-sketch-sync.md
@@ -200,7 +200,7 @@ The integration of the Remote Sketchbook in the IDE 2 is an important milestone.
 
 ## Next Steps
 
-You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide-v2/).
+You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide/#ide-v2).
 
 ## FAQ
 

--- a/content/software/ide-v2/tutorials/ide-v2-customize-auto-formatter/content.md
+++ b/content/software/ide-v2/tutorials/ide-v2-customize-auto-formatter/content.md
@@ -73,4 +73,4 @@ In this tutorial we went through how to customize the behavior of the `CTRL + T`
 
 ### More Tutorials
 
-You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide-v2/).
+You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide/#ide-v2).

--- a/content/software/ide-v2/tutorials/ide-v2-installing-a-library/ide-v2-installing-a-library.md
+++ b/content/software/ide-v2/tutorials/ide-v2-installing-a-library/ide-v2-installing-a-library.md
@@ -70,4 +70,4 @@ The chosen example will now open up in a new window, and you can start using it 
 
 ### More Tutorials
 
-You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide-v2/).
+You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide/#ide-v2).

--- a/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
+++ b/content/software/ide-v2/tutorials/ide-v2-serial-monitor/ide-v2-serial-monitor.md
@@ -114,4 +114,4 @@ Congratulations, you can now check what is going on with two boards simultaneous
 
 ### More Tutorials
 
-You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide-v2/).
+You can find more tutorials in the [Arduino IDE 2 documentation page](/software/ide/#ide-v2).


### PR DESCRIPTION
The URL of the parent page for the Arduino IDE 2.x documentation was changed from [`/software/ide-v2/`](https://docs.arduino.cc/software/ide-v2/) to [`/software/ide/#ide-v2`](https://docs.arduino.cc/software/ide/#ide-v2) through a recent reorganization of the documentation website.

A redirect was set up, but it did not work for these particular links due to them having a trailing slash, which caused them to lead to the "Oops! There's nothing here" page. 

## What This PR Changes

Update the broken links to point directly to the new URL of the target page.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.

## Additional Context

Originally reported by @dougp2 at https://forum.arduino.cc/t/change-ide-2-3-auto-format-option/1222330/5