### PR TITLE
Corrected typo in Arduino API documentation

### DIFF
--- a/content/learn/03.programming/00.reference/reference.md
+++ b/content/learn/03.programming/00.reference/reference.md
@@ -371,7 +371,7 @@ Compact version of the [Arduino Language Reference](https://www.arduino.cc/refer
 | `<< (bitshift left)`  | Shifts bits to the left.                       |
 | `>> (bitshift right)` | Shifts bits to the right.                      |
 | `^ (bitwise xor)`     | Performs bitwise XOR (exclusive OR) operation. |
-| `(bitwise or)`        | Performs bitwise OR operation.                 |
+| `\| (bitwise or)`     | Performs bitwise OR operation.                 |
 | `~ (bitwise not)`     | Inverts all bits.                              |
 
 
@@ -388,5 +388,5 @@ Compact version of the [Arduino Language Reference](https://www.arduino.cc/refer
 | `-= (compound subtraction)`    | Subtracts the right operand from the left operand and assigns the result to the left operand. |
 | `/= (compound division)`       | Divides the left operand by the right operand and assigns the result to the left operand.     |
 | `^= (compound bitwise xor)`    | Performs a bitwise XOR operation and assigns the result to the left operand.                  |
-| `= (compound bitwise or)`      | Performs a bitwise OR operation and assigns the result to the left operand.                   |
+| `\|= (compound bitwise or)`    | Performs a bitwise OR operation and assigns the result to the left operand.                   |
 


### PR DESCRIPTION
## What This PR Changes
- Rows regarding "bitwise or" and "compound bitwise or" operators had a pipe ("|") missing from their definition in the Arduino API documentation. The pipe character is escaped in order to make it visible.
I encountered this typo in the [Arduino API documentation](https://docs.arduino.cc/learn/programming/reference), Programming section in the "Learn" resource.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
