### PR TITLE
Correct minimum macOS version for Arduino IDE 2.x

### DIFF
--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -17,7 +17,7 @@ You can easily download the editor from the [Arduino Software page](https://www.
 
 - **Windows** - Win 10 and newer, 64 bits
 - **Linux** - 64 bits
-- **Mac OS X** - Version 10.14: "Mojave" or newer, 64 bits
+- **Mac OS X** - Version 10.15: "Catalina" or newer, 64 bits
 
 ### The Arduino IDE 2
 

--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -17,7 +17,7 @@ You can easily download the editor from the [Arduino Software page](https://www.
 
 - **Windows** - Win 10 and newer, 64 bits
 - **Linux** - 64 bits
-- **Mac OS X** - Version 10.15: "Catalina" or newer, 64 bits
+- **macOS** - Version 10.15: "Catalina" or newer, 64 bits
 
 ### The Arduino IDE 2
 


### PR DESCRIPTION
Compatibility with macOS Mojave was lost in Arduino IDE 2.3.0. The minimum compatible macOS version is now Catalina.

## What This PR Changes

Update the minimum requirements information in the installation tutorial to reflect this change.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
