### PR TITLE
Update Arduino IDE 2.x debugger tutorials for compatibility with versions >=2.3.0

### DIFF
--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/atmel-ice/using-an-atmel-ice-with-the-ide-v2.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/atmel-ice/using-an-atmel-ice-with-the-ide-v2.md
@@ -115,6 +115,8 @@ Let's start by opening the Arduino IDE 2 and connecting our MKR WiFi 1010 board 
 
 ![The board and port recognized by the Arduino IDE 2.](assets/ide_v2_t1_img05.png)
 
+Select **Tools > Programmer > Atmel-ICE** from the Arduino IDE menus.
+
 ### 2. Creating the Test Code
 
 Let's try the example code show below, it is a simple program that blinks the onboard LED of our board and changes the value of variables `x` and `y` while running. Open a new sketch, copy and paste the code show below:

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -75,9 +75,11 @@ Now go to the folder where the sketch is located. Add a `.json` file in the same
 [
   {
     "configId": "arduino:samd:mkrwifi1010:programmer=jlink",
+    "server": "jlink",
     "servertype": "jlink",
     "device": "ATSAMD21G18",
     "interface": "SWD",
+    "serverPath": "C:/Program Files/SEGGER/JLink/JLinkGDBServerCL",
     "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServerCL"
   }
 ]

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -67,6 +67,8 @@ Now we are ready to start debugging our sketch. Connect the power to the MKR boa
 
 Then create or open the sketch that you want to debug. If you don't already have a sketch in mind, feel free to use the example sketch found at the end of this tutorial.
 
+Select **Tools > Programmer > Segger J-Link** from the Arduino IDE menus.
+
 Now go to the folder where the sketch is located. Add a `.json` file in the same folder as your sketch and name it `debug_custom.json`. The easiest way would be to create a text file and rename it `debug_custom.json`. In the `.json` file, add the following lines:
 
 ```arduino

--- a/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
+++ b/content/hardware/01.mkr/01.boards/mkr-wifi-1010/tutorials/mkr-jlink-setup/mkr-jlink.md
@@ -9,7 +9,7 @@ description: This tutorial teaches you how to set up a MKR board with the Segger
 This tutorial will show you how to debug an Arduino sketch using an Arduino MKR board and the Segger J-Link probe. It will go through how to connect these and use the Arduino IDE 2 to then debug a sketch.
 
 ### Required Hardware and Software
--   [Arduino IDE 2](https://www.arduino.cc/en/software)
+-   [Arduino IDE](https://www.arduino.cc/en/software) version 2.3.0 or higher
 -   Segger J-link device ([EDU](https://store.arduino.cc/products/j-link-edu) or [BASE](https://store.arduino.cc/products/j-link-base-compact))
 -   [Arduino MKR WiFi 1010](https://store.arduino.cc/mkr-wifi-1010) (other boards from the MKR family works as well).
 -   Soldering equipment
@@ -72,13 +72,18 @@ Select **Tools > Programmer > Segger J-Link** from the Arduino IDE menus.
 Now go to the folder where the sketch is located. Add a `.json` file in the same folder as your sketch and name it `debug_custom.json`. The easiest way would be to create a text file and rename it `debug_custom.json`. In the `.json` file, add the following lines:
 
 ```arduino
-{
-  "servertype": "jlink",
-  "device": "ATSAMD21G18",
-  "interface": "SWD",
-  "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServerCL"
-}
+[
+  {
+    "configId": "arduino:samd:mkrwifi1010:programmer=jlink",
+    "servertype": "jlink",
+    "device": "ATSAMD21G18",
+    "interface": "SWD",
+    "serverpath": "C:/Program Files/SEGGER/JLink/JLinkGDBServerCL"
+  }
+]
 ```
+
+If you are using a board other than the **MKR WiFi 1010**, you will need to adjust the `arduino:samd:mkrwifi1010` part of the `configId` field. Hover the mouse pointer over the board selection in the Arduino IDE toolbar in order to learn the correct identifier for the board you are using.
 
 The `"serverpath"` field needs to be set to the path of the "J-Link GDB Server CL" tool executable file that is located under the folder of the J-Link package you installed in the previous step. The file is named:
 

--- a/content/hardware/02.hero/boards/zero/tutorials/debugging-with-zero/debugging-with-zero.md
+++ b/content/hardware/02.hero/boards/zero/tutorials/debugging-with-zero/debugging-with-zero.md
@@ -22,7 +22,9 @@ For this this tutorial we will be using the Arduino Zero's built-in debugger int
 
 ***Important: You should connect the Arduino Zero through its programming USB port.***
 
-**2.** Select the board from the board/port list. When we select the Arduino Zero, the debugger icon close to the upload button will also become more visible.
+**2.** Select the board from the board/port list.
+
+**3.** Select **Tools > Programmer > Atmel EDBG**. The debugger icon close to the upload button will now become more visible.
 
 ![Debugger icon available if board is supported.](assets/icon-available.png)
 


### PR DESCRIPTION
## Background

A major reworking of the debugger configuration system was released in Arduino IDE 2.3.0 (https://github.com/arduino/arduino-ide/pull/2281). This caused several breaking changes to the Arduino IDE user interface which rendered debugger tutorials outdated:

### **Tools > Programmer** Menu Selection Required

The IDE is now configured for the debug probe hardware in use via the **Tools > Programmer** menu selection.

As a side effect of that change, it is now mandatory for the user to make the appropriate selection from that menu in order to use the debugger. If no selection is made, the IDE disables the "Start Debugging" button. For this reason, it will be important for the debugger tutorials to include this.

Arduino IDE versions prior to 2.3.0 did not use the "Programmer" selection for configuration of the debugger. Although selecting a programmer before starting the debugger is not mandatory for users of older versions of the IDE, it also will not cause any harm and that menu was present in those versions of the IDE as well. So the inclusion of a **Programmer** menu selection step in the tutorials does not break their compatibility with previous versions of Arduino IDE 2.x.

### Change to `debug_custom.json` Format

There was a breaking change to the data structure of the `debug_custom.json` file that allows the user to adjust the debugger configuration.

The tutorial for using the IDE 2.x debugger with a J-Link debug probe requires the use of the `debug_custom.json` feature. The change to the file's data structure rendered that part of the tutorial outdated.

### Bug in `debug_custom.json` Feature

A regression was introduced in Arduino IDE 2.3.0 that causes the configuration defined in certain fields of `debug_custom.json` to no longer have an effect (https://github.com/arduino/vscode-arduino-tools/issues/48), causing the J-Link tutorial to no longer be usable.

A fix for the IDE bug is now in progress (https://github.com/arduino/vscode-arduino-tools/pull/49), but it will likely be some time before this can be shipped in a new Arduino IDE release.

## What This PR Changes

- Add instructions for configuring debug probe via **Tools > Programmer** menu.
- Update J-Link tutorial for new `debug_custom.json` format.
- Add alternative fields to J-Link `debug_custom.json` to work around tutorial-breaking IDE bug.

## Contribution Guidelines

- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
