### PR TITLE
Updated SKU of product

### DIFF
--- a/content/hardware/04.pro/carriers/portenta-breakout/tech-specs.yml
+++ b/content/hardware/04.pro/carriers/portenta-breakout/tech-specs.yml
@@ -1,6 +1,6 @@
 Board:
   Name: Arduino® Portenta Breakout
-  SKU: AKX00031
+  SKU: ASX00031
 USB port: USBA
 Ethernet: RJ45 GBit
 Memory slot: Micro SD card


### PR DESCRIPTION
## What This PR Changes
Portenta Breakout showed the wrong SKU in the tech specs table

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
