### PR TITLE
[PC-1665] Full pinout added to H7 Lite and Connected versions

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/downloads/ABX00042-full-pinout.pdf
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/downloads/ABX00042-full-pinout.pdf
@@ -1,0 +1,1 @@
+../../../../04.pro/boards/portenta--h7/downloads/ABX00042-full-pinout.pdf

--- a/content/hardware/04.pro/boards/portenta-h7-lite/downloads/ABX00042-full-pinout.pdf
+++ b/content/hardware/04.pro/boards/portenta-h7-lite/downloads/ABX00042-full-pinout.pdf
@@ -1,0 +1,1 @@
+../../../../04.pro/boards/portenta--h7/downloads/ABX00042-full-pinout.pdf


### PR DESCRIPTION
## What This PR Changes
- @jhansson-ard and @sebromero noticed there are not full pinouts for the lite and connected versions of the Portenta H7
- This PR put them in case we consider makes sense
- However **let's keep in mind all the boards share the pinout but not all the boards have all the modules, which can create confusion in some final users**
- Therefore @martab1994 please tell me if you want to do it or not, and I will merge or archive the PR

Thanks

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
