### PR TITLE
Update ble-cheat-sheet.md

### DIFF
--- a/content/hardware/03.nano/boards/nano-33-ble-sense/tutorials/cheat-sheet/ble-cheat-sheet.md
+++ b/content/hardware/03.nano/boards/nano-33-ble-sense/tutorials/cheat-sheet/ble-cheat-sheet.md
@@ -354,20 +354,22 @@ If you want to learn more on how to use the Microphone, please check out the tut
 
 ## RGB
 
-To turn ON the pixels, write a `HIGH` state to the LED:
+The Nano 33 BLE Sense's RGB LEDs are active-LOW, so they are switched in the opposite way to the LED_BUILTIN.
 
-```arduino
-digitalWrite(LEDR, HIGH); //RED
-digitalWrite(LEDG, HIGH); //GREEN
-digitalWrite(LEDB, HIGH); //BLUE
-```
-
-To turn OFF the pixels, write a `LOW` state to the LED:
+To turn ON the pixels, write a `LOW` state to the LED.
 
 ```arduino
 digitalWrite(LEDR, LOW); //RED
 digitalWrite(LEDG, LOW); //GREEN
 digitalWrite(LEDB, LOW); //BLUE
+```
+
+To turn OFF the pixels, write a `HIGH` state to the LED:
+
+```arduino
+digitalWrite(LEDR, HIGH); //RED
+digitalWrite(LEDG, HIGH); //GREEN
+digitalWrite(LEDB, HIGH); //BLUE
 ```
 
 We can also choose a value between 255 - 0 to write to the LED:


### PR DESCRIPTION
Fixed the RGB description and example code to reflect the fact that they are active-LOW and not active-HIGH. 

## What This PR Changes
- The description and example code actually does the opposite of what it says it does.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
