### PR TITLE
remove header files

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/led-matrix/led-matrix.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/led-matrix/led-matrix.md
@@ -342,7 +342,6 @@ We've designed a gallery of frames and animations that are included in the libra
 
 ```arduino
 #include "Arduino_LED_Matrix.h"   // Include the LED_Matrix library
-#include "frames.h"               // Include a header file containing some custom icons
 
 ArduinoLEDMatrix matrix;          // Create an instance of the ArduinoLEDMatrix class
 
@@ -380,7 +379,6 @@ Alternatively, play one of the animations on the LED matrix like this:
 
 ```arduino
 #include "Arduino_LED_Matrix.h"   //Include the LED_Matrix library
-#include "animation.h"            //Include animation.h header file
 
 // Create an instance of the ArduinoLEDMatrix class
 ArduinoLEDMatrix matrix;  


### PR DESCRIPTION
## What This PR Changes
This PR removes the header files included in the Frame Gallery examples for the UNO R4 WiFi LED Matrix.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
