### PR TITLE
Replace links to ephemeral file URLs with relative paths

### DIFF
--- a/content/hardware/03.nano/boards/nano-matter/tutorials/user-manual/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/user-manual/content.md
@@ -86,7 +86,7 @@ The complete schematics are available and downloadable as PDF from the link belo
 
 The complete STEP files are available and downloadable from the link below:
 
-- [Nano Matter STEP files](https://docs.arduino.cc/static/96e7dacc4383cd4a4a928872eca9e3da/ABX00112-step.zip)
+- [Nano Matter STEP files](../../downloads/ABX00112-step.zip)
 
 
 ### Form Factor

--- a/content/hardware/04.pro/boards/portenta-c33/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/boards/portenta-c33/tutorials/user-manual/content.md
@@ -90,7 +90,7 @@ The complete schematics are available and downloadable as PDF from the link belo
 
 The complete STEP files are available and downloadable from the link below:
 
-- [Portenta C33 STEP files](https://docs.arduino.cc/static/0d1ade945a6d5105667ee3a0e50b96c7/ABX00074-step.zip)
+- [Portenta C33 STEP files](../../downloads/ABX00074-step.zip)
 
 ## First Use
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/01.user-manual/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/01.user-manual/content.md
@@ -91,7 +91,7 @@ The full schematics are available and downloadable as PDF from the link below:
 ### STEP Files
 
 The full _STEP_ files are available and downloadable from the link below:
-* [Portenta X8 STEP files](https://docs.arduino.cc/static/5d95e348688a9678e04d6f4d0b994844/ABX00049-step.zip)
+* [Portenta X8 STEP files](../../downloads/ABX00049-step.zip)
 
 ### Linux Environment
 

--- a/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/tutorials/user-manual/content.md
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/portenta-machine-control/tutorials/user-manual/content.md
@@ -149,7 +149,7 @@ The complete datasheet is available and downloadable as PDF from the link below:
 
 The complete STEP files are available and downloadable from the link below:
 
-- [Portenta Machine Control STEP files](https://docs.arduino.cc/static/142bd938b340c767b9343451485aa5d2/AKX00032-step.zip)
+- [Portenta Machine Control STEP files](../../downloads/AKX00032-step.zip)
 
 ## First Use
 

--- a/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/user-manual/content.md
+++ b/content/hardware/06.nicla/boards/nicla-sense-me/tutorials/user-manual/content.md
@@ -84,7 +84,7 @@ The complete schematics are available and downloadable as PDF from the link belo
 
 The complete STEP files are available and downloadable from the link below:
 
-- [Nicla Sense ME STEP files](https://docs.arduino.cc/static/10c0953581f489a9a136ff00f2d2fa9d/ABX00050-step.zip)
+- [Nicla Sense ME STEP files](../../downloads/ABX00050-step.zip)
 
 
 ## First Use

--- a/content/hardware/06.nicla/boards/nicla-vision/tutorials/user-manual/content.md
+++ b/content/hardware/06.nicla/boards/nicla-vision/tutorials/user-manual/content.md
@@ -150,7 +150,7 @@ The complete schematics are available and downloadable as PDF from the link belo
 
 The complete STEP files are available and downloadable from the link below:
 
-- [Nicla Vision STEP files](https://docs.arduino.cc/static/24f56d94c6040c9c3a4a187375cf7601/ABX00051-step.zip)
+- [Nicla Vision STEP files](../../downloads/ABX00051-step.zip)
 
 ## First Use
 ### Powering the Board

--- a/content/hardware/06.nicla/boards/nicla-voice/tutorials/user-manual/content.md
+++ b/content/hardware/06.nicla/boards/nicla-voice/tutorials/user-manual/content.md
@@ -87,7 +87,7 @@ The complete schematics are available and downloadable as PDF from the link belo
 
 The complete STEP files are available and downloadable from the link below:
 
-- [Nicla Voice STEP files](https://docs.arduino.cc/static/6329da6a0adf61028fa0c8b63a122f04/ABX00061-step.zip)
+- [Nicla Voice STEP files](../../downloads/ABX00061-step.zip)
 
 ## First Use
 

--- a/content/hardware/07.opta/opta-family/opta/tutorials/01.user-manual/content.md
+++ b/content/hardware/07.opta/opta-family/opta/tutorials/01.user-manual/content.md
@@ -130,7 +130,7 @@ The complete datasheet (for all Opta™ variants) is available and downloadable 
 
 The complete STEP files (for all Opta™ variants) are available and downloadable from the link below:
 
-- [Opta™ STEP files](https://docs.arduino.cc/static/805141cc64a9a27e4e73a94065fa0703/AFX00001-AFX00002-AFX00003-step.zip)  
+- [Opta™ STEP files](../../downloads/AFX00001-AFX00002-AFX00003-step.zip)  
 
 ## First Use
 


### PR DESCRIPTION
## What This PR Changes

In addition to the Markdown content source files, this repository hosts non-text files. These are linked to in the content.

The website publishing system hosts these non-text files in paths under the `static` subfolder of the website (e.g., https://docs.arduino.cc/static/96e7dacc4383cd4a4a928872eca9e3da/ABX00112-step.zip). The path of the published file includes the file's [MD5 hash](https://en.wikipedia.org/wiki/MD5) (e.g., `96e7dacc4383cd4a4a928872eca9e3da`). This means that the URL will change every time the file is modified. For this reason, hardcoding links to these URLs in the content should be avoided whenever possible.

The website generation system automatically replaces links to relative paths with the equivalent ephemeral URL under the `static` subfolder of the website. This means that a link to the relative path of the file is functionally equivalent to linking the hardcoded ephemeral URL.

Although a relative path link is still prone to breakage if the content or target file is moved to a different location in the repository, this will probably occur less frequently than modifications to the files, making the relative path approach superior to the alternative of hardcoding the ephemeral URL.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.

## Additional Context

This proposal addresses the concern raised at https://github.com/arduino/docs-content/pull/1881#discussion_r1568782232. An alternative solution is described at https://github.com/arduino/docs-content/pull/1881#discussion_r1570926638.