### PR TITLE
Updating deployment GH actions and adding concurrency management

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
 jobs:
   build:
     if: "github.repository == 'arduino/docs-content'"
@@ -15,10 +19,10 @@ jobs:
       APP_ENV: prod
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "npm"
@@ -36,7 +40,7 @@ jobs:
           find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
 
       - name: Gatsby main cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: gatsby-cache-folder
         with:
           path: .cache
@@ -45,7 +49,7 @@ jobs:
             ${{ runner.os }}-cache-gatsby-
 
       - name: Gatsby Public Folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: gatsby-public-folder
         with:
           path: public/

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - ghaction
 
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,11 +18,11 @@ jobs:
       APP_ENV: staging
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git log -1 --pretty=format:%aI content/learn/04.electronics/05.servo-motors/servo-motors.md
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: "npm"
@@ -36,7 +40,7 @@ jobs:
           find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
 
       - name: Gatsby main cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: gatsby-cache-folder
         with:
           path: .cache
@@ -45,7 +49,7 @@ jobs:
             ${{ runner.os }}-cache-gatsby-
 
       - name: Gatsby Public Folder
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: gatsby-public-folder
         with:
           path: public/


### PR DESCRIPTION
## What This PR Changes
At the moment the Deployment actions are executed in parallels causing cache issues and also many minutes consumptions.
With this PR I'm adding concurrency management, so from today, a new deployment will stop the current in progress one. 
In this way, when multiple PRs are merged, the main branch will be deployed only one time


## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
