### PR TITLE
Disabling automatic run of cloudflare builds

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -1,10 +1,7 @@
 name: Cloudflare Pages
 
 on:
-  push:
-    branches: ["main"]
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
 
 jobs:
   run:


### PR DESCRIPTION
## What This PR Changes
We are over 20K files, so Cloudflare upload continuously fails.
I'm disabling its automatic execution

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
