### PR TITLE
Removing validation on main

### DIFF
--- a/.github/workflows/workflow-validate.yaml
+++ b/.github/workflows/workflow-validate.yaml
@@ -3,9 +3,6 @@ name: Validate Content
 on:
   repository_dispatch:
     types: deploy
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 


### PR DESCRIPTION
## What This PR Changes
We 're spending a lot of minutes of GH action also slowing down other jobs for content validation on main.
It is not really important because the validation is already performed on PRs, and the content can not be merged if the validation in PR fails.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
