### PR TITLE
Correct `MKRIoTCarrier::display.print` snippets

### DIFF
--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier-rev2/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier-rev2/tutorials/cheat-sheet/cheat-sheet.md
@@ -359,7 +359,7 @@ carrier.display.setCursor(x, y);
 This method is very important, as it indicates where on the printing starts on the display. It is indicated by pixels, so, if **0, 0** are used for example, it will start printing in the top left corner.
 
 ```arduino
-display.print("text");
+carrier.display.print("text");
 ```
 
 This method will print the text inside the string at the current cursor position.

--- a/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
+++ b/content/hardware/01.mkr/03.carriers/mkr-iot-carrier/tutorials/mkr-iot-carrier-01-technical-reference/mkr-iot-carrier-01-technical-reference.md
@@ -363,7 +363,7 @@ carrier.display.setCursor(x, y);
 This method is very important, as it indicates where on the printing starts on the display. It is indicated by pixels, so, if **0, 0** are used for example, it will start printing in the top left corner.
 
 ```arduino
-display.print("text");
+carrier.display.print("text");
 ```
 
 This method will print the text inside the string at the current cursor position.


### PR DESCRIPTION
## What This PR Changes

Previously the `carrier` object component of the statement was missing from the code snippets demonstrating the use of the "Arduino_MKRIoTCarrier" library's `MKRIoTCarrier::display.print` function. This would cause compilation of the snippet to fail:

```text
error: 'display' was not declared in this scope
   display.print("text");
   ^~~~~~~
```

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.

## Additional context

Originally reported at:

https://forum.arduino.cc/t/arduino-mkriotcarrier-greenhouse-iotcloud/1255358/4?u=ptillisch