### PR TITLE
Use standardized pin macros in Nano ESP32 "default" sketch

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/03.nano/boards/nano-esp32/tutorials/cheat-sheet/cheat-sheet.md
@@ -112,41 +112,33 @@ If you need to reflash the bootloader, you can follow the steps of this [Help Ce
 The default sketch loaded on the Nano ESP32 board is found in the code snippet below:
 
 ```arduino
-#define LEDR 46
-#define LEDG 45
-#define LEDB 0
-#ifdef LED_BUILTIN
-#undef LED_BUILTIN
-#define LED_BUILTIN 48
-#endif
-
 void setup() {
   // put your setup code here, to run once:
-  pinMode(LEDR, OUTPUT);
-  pinMode(LEDG, OUTPUT);
-  pinMode(LEDB, OUTPUT);
+  pinMode(LED_RED, OUTPUT);
+  pinMode(LED_GREEN, OUTPUT);
+  pinMode(LED_BLUE, OUTPUT);
   pinMode(LED_BUILTIN, OUTPUT);
 }
 
 void loop() {
   digitalWrite(LED_BUILTIN, HIGH);
-  digitalWrite(LEDR, LOW);
-  digitalWrite(LEDG, HIGH);
-  digitalWrite(LEDB, HIGH);
+  digitalWrite(LED_RED, LOW);
+  digitalWrite(LED_GREEN, HIGH);
+  digitalWrite(LED_BLUE, HIGH);
 
   delay(1000);
 
   digitalWrite(LED_BUILTIN, LOW);
-  digitalWrite(LEDR, HIGH);
-  digitalWrite(LEDG, LOW);
-  digitalWrite(LEDB, HIGH);
+  digitalWrite(LED_RED, HIGH);
+  digitalWrite(LED_GREEN, LOW);
+  digitalWrite(LED_BLUE, HIGH);
 
   delay(1000);
 
   digitalWrite(LED_BUILTIN, HIGH);
-  digitalWrite(LEDR, HIGH);
-  digitalWrite(LEDG, HIGH);
-  digitalWrite(LEDB, LOW);
+  digitalWrite(LED_RED, HIGH);
+  digitalWrite(LED_GREEN, HIGH);
+  digitalWrite(LED_BLUE, LOW);
 
   delay(1000);
   digitalWrite(LED_BUILTIN, LOW);


### PR DESCRIPTION
This sketch is intended to produce the LED blinking behavior the board has when shipped. Previously, bespoke pin name macros were defined in the sketch, which were problematic:

The green and blue LED pin numbers were only appropriate for the [first limited run of the board that used a different RGB LED](https://support.arduino.cc/hc/en-us/articles/9589073738012-About-Nano-ESP32-boards-with-inverted-green-and-blue-pins) than the LED on subsequent runs of the board, which the majority of customers will have.

The pin numbers were not correct when the development tool had the "**By Arduino pin (default)**" [pin numbering configuration](https://docs.arduino.cc/tutorials/nano-esp32/pin-setup/).

## What This PR Changes

The "**Arduino ESP32 Boards**" core provides [pin macros for all four of the LEDs](https://github.com/arduino/arduino-esp32/blob/2.0.13/variants/arduino_nano_nora/pins_arduino.h#L81-L98). Using these macros in the sketch sets an example of best practices programming for the reader and fixes both the problems that were present in the previous version of the sketch:

The `LED_GREEN` and `LED_BLUE` macros are the correct pin numbers for the LEDs on the majority of the Nano ESP32 boards.

These macros are configured to be correct for both pin numbering configurations.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.

---

Originally reported at https://forum.arduino.cc/t/confusing-pin-numbering-in-the-default-sketch/1260852

