### PR TITLE
Add config to ignore _unlisted folders

### DIFF
--- a/scripts/validation/config/config-generic.yml
+++ b/scripts/validation/config/config-generic.yml
@@ -23,3 +23,6 @@ debug: false
 
 # Defines rules for what links not to check. Usually relative links should not be checked.
 brokenLinkExcludePatterns: [^./, ^../, ^#, ^chrome://, localhost , ^assets/, ^images/]
+
+# Define a list of foldernames that get ignored during folder name validation
+folderNameIgnoreList: ["_unlisted"]

--- a/scripts/validation/package-lock.json
+++ b/scripts/validation/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "content-lint": "^1.1.3"
+        "content-lint": "^1.2.0"
       }
     },
     "node_modules/ansi-styles": {
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/content-lint": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/content-lint/-/content-lint-1.1.3.tgz",
-      "integrity": "sha512-Z5KJywQPEXMYMf3gDXFpwt94Pw0QVwcRiknL2GwVh5eERusUEYDUabk3uVP0i7Dx8zYzKocioVuRUDi3dxq/Iw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/content-lint/-/content-lint-1.2.0.tgz",
+      "integrity": "sha512-hVT1e2VvZpqhzegH9iPYvFB+36wRbaGgGARoNMKBrEyfaLarfkJnoJZpconoIU/Kf2hVdMVv+IV7LZGpkzCh6g==",
       "dependencies": {
         "command-line-args": "^5.1.3",
         "front-matter": "^4.0.2",
@@ -749,9 +749,9 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "content-lint": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/content-lint/-/content-lint-1.1.3.tgz",
-      "integrity": "sha512-Z5KJywQPEXMYMf3gDXFpwt94Pw0QVwcRiknL2GwVh5eERusUEYDUabk3uVP0i7Dx8zYzKocioVuRUDi3dxq/Iw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/content-lint/-/content-lint-1.2.0.tgz",
+      "integrity": "sha512-hVT1e2VvZpqhzegH9iPYvFB+36wRbaGgGARoNMKBrEyfaLarfkJnoJZpconoIU/Kf2hVdMVv+IV7LZGpkzCh6g==",
       "requires": {
         "command-line-args": "^5.1.3",
         "front-matter": "^4.0.2",

--- a/scripts/validation/package.json
+++ b/scripts/validation/package.json
@@ -10,6 +10,6 @@
   "author": "Sebastian Romero",
   "license": "ISC",
   "dependencies": {
-    "content-lint": "^1.1.3"
+    "content-lint": "^1.2.0"
   }
 }

--- a/scripts/validation/validate.js
+++ b/scripts/validation/validate.js
@@ -57,7 +57,7 @@ if(configManager.options.checkBrokenLinks){
 };
 
 // Verify if articles contain discouraged foldernames (which translate into URLs)
-validator.addValidation(allArticles, validateFolderName);
+validator.addValidation(allArticles, validateFolderName, configManager.getConfig("generic").folderNameIgnoreList);
 
 // Verify that all files in the assets folder are referenced
 validator.addValidation(allArticles, validateReferencedAssets);


### PR DESCRIPTION
## What This PR Changes
- Uses the new feature of the content linter to ignore "_unlisted" folders. This requires updating to 1.2 once https://github.com/arduino/content-lint/pull/6 is merged. Do not merge without updating the dependency!

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
