### PR TITLE
Create folder for model files during build

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Copy Static Files
         run: |
-          mkdir -p static/resources/datasheets static/resources/schematics static/resources/pinouts
+          mkdir -p static/resources/datasheets static/resources/schematics static/resources/pinouts static/resources/models
           find ./content/hardware -type f -name "*-schematics.pdf" -exec cp {} ./static/resources/schematics/ \;
           find ./content/hardware -type f -name "*-datasheet.pdf" -exec cp {} ./static/resources/datasheets/ \;
           find ./content/hardware -type f -name "*-full-pinout.pdf" -exec cp {} ./static/resources/pinouts/ \;


### PR DESCRIPTION
## What This PR Changes
- Likely the copy process of STEP files fails silently because there is no directory in which to copy the files. This PR creates that folder as part of the build process.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
