### PR TITLE
[MKC-1702] The "next chapter" text to was fixed (Python Crash Course)

### DIFF
--- a/content/micropython/02.micropython-course/course/02.introduction-python/02.intro-to-micropython.md
+++ b/content/micropython/02.micropython-course/course/02.introduction-python/02.intro-to-micropython.md
@@ -253,4 +253,4 @@ If the error persists, you can try to "soft-reset" the board, by clicking the **
 
 In this chapter, we learned a little bit about the key components in the MicroPython environment.
 
-- [Next chapter: An Introduction to MicroPython](/micropython/micropython-course/course/python-cc)
+- [Next chapter: Python Crash Course](/micropython/micropython-course/course/python-cc)


### PR DESCRIPTION
## What This PR Changes
- change "Next chapter: An Introduction to MicroPython "
with the correct one "Next chapter: Python Crash Course"

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
