### PR TITLE
[MKC-1719] Remove mentions of Arduino SIM

### DIFF
--- a/content/arduino-cloud/02.hardware/05.cellular/cellular.md
+++ b/content/arduino-cloud/02.hardware/05.cellular/cellular.md
@@ -17,8 +17,6 @@ A number of Arduino boards are able to connect to the Arduino Cloud using a sim 
 
 Connection through cellular networks can be considered in remote areas where there's no Wi-Fi, or in mobile projects (such as cargo tracking).
 
-***For more information, visit the [Arduino SIM page](https://store.arduino.cc/digital/sim).***
-
 ***Note that a secured connection is a memory intense operation, so there's not a lot of memory for the user application (e.g. around 2.6 kB on the MKR GSM 1400). Using a lot of Arduino Cloud variables may cause the sketch to run out of memory on boards which don't offload the SSL stack and make it crash.***
 
 ## Setup
@@ -36,12 +34,3 @@ To configure a cellular board, follow the steps below:
 Your board is now configured and ready to be used in the Arduino Cloud. 
 
 To get started, check out the official [Getting Started (Arduino / C++)](/arduino-cloud/guides/arduino-c) guide. This will guide you to successfully send data between your board and Arduino Cloud.
-
-## Network Configuration
-
-When you attach your board to a Thing, you will need to enter some credentials. With an Arduino SIM, configure it as:
-
-- **APN** - `prepay.pelion`
-- **PIN** - `0000`
-- **Username** - `arduino`
-- **Password** - `arduino`

--- a/content/hardware/01.mkr/01.boards/mkr-gsm-1400/tutorials/gsm-send-sms/gsm-send-sms.md
+++ b/content/hardware/01.mkr/01.boards/mkr-gsm-1400/tutorials/gsm-send-sms/gsm-send-sms.md
@@ -26,8 +26,6 @@ In this tutorial, we will create a simple sketch that allows us to send a text m
 
 The sketch will be programmed to record input from the Serial Monitor, where we can enter a number and a message, and send it. 
 
->**Note:** The Arduino SIM card does not work with this tutorial. A SIM card with a plan from an operator in your country is required. 
-
 ## Goals
 
 The goals of this tutorial are:

--- a/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-send-sms/nb-send-sms.md
+++ b/content/hardware/01.mkr/01.boards/mkr-nb-1500/tutorials/nb-send-sms/nb-send-sms.md
@@ -29,8 +29,6 @@ The message is sent over Narrow Band IoT (NB IoT) or LTE CAT M1 network.
 
 The sketch will be setup to record input from the Serial Monitor, where we can enter a number and a message, and send it. 
 
->**Note:** The Arduino SIM card does not work with this tutorial. A SIM card with a plan from an operator in your country is required. 
-
 ## Goals
 
 The goals of this tutorial are:


### PR DESCRIPTION
## What This PR Changes
- The Arduino SIM is no longer being sold, so we're removing references to it from our cloud docs
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
