### PR TITLE
opta/tutorials/mac-address: add note for older bootloader versions

### DIFF
--- a/content/hardware/07.opta/opta-family/opta/tutorials/16.mac-address/content.md
+++ b/content/hardware/07.opta/opta-family/opta/tutorials/16.mac-address/content.md
@@ -229,6 +229,8 @@ To upload the code, click the **Verify** button to compile the sketch and check 
 
 The code above retrieves information from an Opta™ device, including its MAC address, and prints it to the Arduino IDE's Serial Monitor. The information shown includes the bootloader version and identifier, secure board information, and general board information.
 
+***Please note that there are versions of the Opta™ with bootloader version `<v24`, which do not store the bootloader identifier at `0x80002F0`. Therefore, it will show `v255`, since the memory area is empty.***
+
 ![Opta™ device information shown in the Arduino IDE Serial Monitor.](assets/serial-monitor-1.png)
 
 - The `printOptaSecureInfo()` function checks if the magic number of the `OptaBoardInfo` structure is `0xB5`, indicating that secure information is available. If it is, it prints the secure information to the IDE's Serial Monitor, including the board's functionalities (Ethernet, Wi-Fi®/Bluetooth® capabilities, and RS-485 capabilities), QSPI memory size, board revision, VID, PID, and the MAC address of the Ethernet port. If the board has Wi-Fi®/Bluetooth® capabilities, the function will also print the MAC address of the Wi-Fi®/Bluetooth® module. 


### PR DESCRIPTION
Add a note that older bootloader versions don't have the version number stored at this address, and the code of this example will not work and return v255.

## What This PR Changes
- This PR adds a note in the Arduino docs, that the value for the bootloader version as reported by the docs is not always valid (See this issue: https://github.com/arduino/ArduinoCore-mbed/issues/887).

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
