### PR TITLE
[PC-1806][PC-1830][PC-1831] Portenta X8: Firmware Release Notes Update w/ FW Download Links

### DIFF
--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -35,6 +35,8 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 **Image Access:**
 - Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
 
+***__You can download the latest firmware version [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__ If you need instructions on updating the Portenta X8, you can follow [this guide](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#update-using-uuu-tool) using the __uuu__ tool.***
+
 **New Features:**
 - Added support for Akida Brainchip PCIe module in NPU.
 - Added support for Hailo 8R PCIe module in NPU.
@@ -48,8 +50,6 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 **Bug Fixes:**
 - Fixed RS-485 `ttyX0` not working.
 - Fixed PCIe on kernel 6.1.
-
-***__You can download the latest firmware version [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__ If you need instructions on updating the Portenta X8, you can follow [this guide](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#update-using-uuu-tool) using the __uuu__ tool.***
 
 ## Available Firmware Versions
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -28,12 +28,11 @@ Compatible carriers with the supported device:
 # Firmware Versions
 The following section highlights the critical updates and enhancements introduced in the latest firmware version. It presents the most significant progress and optimizations implemented to improve performance, enhance user experience, and strengthen security.
 
-## Latest Firmware Version: __859__
+## Latest Firmware Version: __861__
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 
 **Image Access:**
-- Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
 
 ***__You can download the latest firmware version [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__ If you need instructions on updating the Portenta X8, you can follow [this guide](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#update-using-uuu-tool) using the __uuu__ tool.***
 
@@ -55,13 +54,13 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 
 Below is a list of all available firmware versions with their release notes.
 
-### OS Image 859
+### OS Image 861
 
 <details>
-  <summary><strong>OS Image 859: Release arduino-91.2</strong></summary>
+  <summary><strong>OS Image 861: Release arduino-91.2</strong></summary>
 
 #### Image Access
-  - Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
+  - Full image [download](https://downloads.arduino.cc/portentax8image/861.tar.gz)
 
 #### New Features
   - Added support for Akida Brainchip PCIe module in NPU.

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -6,7 +6,6 @@ description: 'This article contains release notes of the existing Portenta X8 fi
 author: Taddy Ho Chung
 hardware:
   - hardware/04.pro/board/portenta-x8
-
 ---
 
 # Firmware Release Notes
@@ -47,7 +46,7 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 - Fixed RS-485 `ttyX0` not working.
 - Fixed PCIe on kernel 6.1.
 
-***__You can access the latest version of the firmware [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__***
+***__You can download the latest firmware version [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__ If you need instructions on updating the Portenta X8, you can follow [this guide](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#update-using-uuu-tool) using the __uuu__ tool.***
 
 ## Available Firmware Versions
 
@@ -60,7 +59,6 @@ Below is a list of all available firmware versions with their release notes.
 
 #### Image Access
   - Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
-  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-859.tar.gz)
 
 #### New Features
   - Added support for Akida Brainchip PCIe module in NPU.
@@ -89,7 +87,6 @@ Below is a list of all available firmware versions with their release notes.
 
 #### Image Access
   - Full image [download](https://downloads.arduino.cc/portentax8image/844.tar.gz)
-  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-844.tar.gz)
 
 #### New Features
   - Implemented a configurable *NCM* gadget from `/etc/default/usbgx` .
@@ -121,7 +118,6 @@ Below is a list of all available firmware versions with their release notes.
 
 #### Image Access
   - Full image [download](https://downloads.arduino.cc/portentax8image/822.tar.gz)
-  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-822.tar.gz)
 
 #### New Features
   - Added `libgpiod` to enhance functionality across both software images.
@@ -152,7 +148,6 @@ Below is a list of all available firmware versions with their release notes.
 
 #### Image Access
   - Full image [download](https://downloads.arduino.cc/portentax8image/746.tar.gz)
-  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-746.tar.gz)
 
 #### New Features
   - Added the Portenta HAT Carrier support
@@ -174,14 +169,12 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-
 ### OS Image 719
 <details>
   <summary><strong>OS Image 719: Release arduino-88.7</strong></summary>
 
 #### Image Access
   - Full image [download](https://downloads.arduino.cc/portentax8image/719.tar.gz)
-  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-719.tar.gz)
 
 #### New Features
   - Added PWM fan support

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -32,19 +32,22 @@ The following section highlights the critical updates and enhancements introduce
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 
+* **Image Access**
+  - Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
+
 * **New Features:**
-- Added support for Akida Brainchip PCIe module in NPU.
-- Added support for Hailo 8R PCIe module in NPU.
-- Support for new panel modules and touchscreen controllers **jadard-ek79202d** and **atmel-mxt-ts** in `MIPI-DSI`.
+  - Added support for Akida Brainchip PCIe module in NPU.
+  - Added support for Hailo 8R PCIe module in NPU.
+  - Support for new panel modules and touchscreen controllers **jadard-ek79202d** and **atmel-mxt-ts** in `MIPI-DSI`.
 
 * **Enhancements:**
-- Increased CAN throughput, see details with **x8h7** tags.
-- [x8h7] Changed low level protocol for **X8H7** to use a fixed packet size and hardware-assisted checksum.
-- [x8h7] **X8H7** initialization now happens earlier, linked to `sysinit.target`.
+  - Increased CAN throughput, see details with **x8h7** tags.
+  - [x8h7] Changed low level protocol for **X8H7** to use a fixed packet size and hardware-assisted checksum.
+  - [x8h7] **X8H7** initialization now happens earlier, linked to `sysinit.target`.
 
 * **Bug Fixes:**
-- Fixed RS-485 `ttyX0` not working.
-- Fixed PCIe on kernel 6.1.
+  - Fixed RS-485 `ttyX0` not working.
+  - Fixed PCIe on kernel 6.1.
 
 ***__You can download the latest firmware version [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__ If you need instructions on updating the Portenta X8, you can follow [this guide](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#update-using-uuu-tool) using the __uuu__ tool.***
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -29,25 +29,23 @@ Compatible carriers with the supported device:
 # Firmware Versions
 The following section highlights the critical updates and enhancements introduced in the latest firmware version. It presents the most significant progress and optimizations implemented to improve performance, enhance user experience, and strengthen security.
 
-## Latest Firmware Version: __844__
+## Latest Firmware Version: __859__
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 
 * **New Features:**
-- Implemented a configurable *NCM* gadget from `/etc/default/usbgx` .
-- Created *udev* rules to map devices with Arduino standard names.
+- Added support for Akida Brainchip PCIe module in NPU.
+- Added support for Hailo 8R PCIe module in NPU.
+- Support for new panel modules and touchscreen controllers **jadard-ek79202d** and **atmel-mxt-ts** in `MIPI-DSI`.
 
 * **Enhancements:**
-- Updated Wi-Fi® chipset 1DX firmware.
-- Enabled GPU and VPUs through the `ov_som_gpu_vpus` overlay.
-- Allowed dynamic frequency scaling (*DVFS*) to scale system frequency down to 100 MHz per core.
-- Upgraded CAN and X8H7 in general with the latest source and firmware.
+- Increased CAN throughput, see details with **x8h7** tags.
+- [x8h7] Changed low level protocol for **X8H7** to use a fixed packet size and hardware-assisted checksum.
+- [x8h7] **X8H7** initialization now happens earlier, linked to `sysinit.target`.
 
 * **Bug Fixes:**
-- Fixed **EC200A-EU** *udev* rules and *systemd* services.
-
-* **Security Updates:**
-- Forced password change at first login.
+- Fixed RS-485 `ttyX0` not working.
+- Fixed PCIe on kernel 6.1.
 
 ***__You can access the latest version of the firmware [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__***
 
@@ -55,7 +53,32 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 
 Below is a list of all available firmware versions with their release notes.
 
-### OS Image 844
+### [OS Image 859](https://downloads.arduino.cc/portentax8image/859.tar.gz)
+
+<details>
+  <summary><strong>OS Image 859: Release arduino-91.2</strong></summary>
+
+#### New Features
+  - Added support for Akida Brainchip PCIe module in NPU.
+  - Added support for Hailo 8R PCIe module in NPU.
+  - Support for new panel modules and touchscreen controllers **jadard-ek79202d** and **atmel-mxt-ts** in `MIPI-DSI`.
+
+#### Enhancements
+  - Increased CAN throughput, see details with **x8h7** tags.
+  - [x8h7] Changed low level protocol for **X8H7** to use a fixed packet size and hardware-assisted checksum.
+  - [x8h7] **X8H7** initialization now happens earlier, linked to `sysinit.target`.
+
+#### Bug Fixes
+  - Fixed RS-485 `ttyX0` not working.
+  - Fixed PCIe on kernel 6.1.
+
+#### Additional Notes
+  - Based on [LmP v91](https://foundries.io/products/releases/91/). It is based on the Yocto manifest. For docker-compose apps, check out [here](https://github.com/arduino/portenta-containers/tree/release).
+
+</details>
+<br></br>
+
+### [OS Image 844](https://downloads.arduino.cc/portentax8image/844.tar.gz)
 
 <details>
   <summary><strong>OS Image 844: Release arduino-91</strong></summary>
@@ -83,7 +106,7 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### OS Image 822
+### [OS Image 822](https://downloads.arduino.cc/portentax8image/822.tar.gz)
 
 <details>
   <summary><strong>OS Image 822: Release arduino-88.94</strong></summary>
@@ -110,7 +133,7 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### OS Image 746
+### [OS Image 746](https://downloads.arduino.cc/portentax8image/746.tar.gz)
 
 <details>
   <summary><strong>OS Image 746: Release arduino-88.91</strong></summary>
@@ -136,7 +159,7 @@ Below is a list of all available firmware versions with their release notes.
 <br></br>
 
 
-### OS Image 719
+### [OS Image 719](https://downloads.arduino.cc/portentax8image/719.tar.gz)
 <details>
   <summary><strong>OS Image 719: Release arduino-88.7</strong></summary>
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -53,10 +53,14 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 
 Below is a list of all available firmware versions with their release notes.
 
-### [OS Image 859](https://downloads.arduino.cc/portentax8image/859.tar.gz)
+### OS Image 859
 
 <details>
   <summary><strong>OS Image 859: Release arduino-91.2</strong></summary>
+
+#### Image Access
+  - Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
+  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-859.tar.gz)
 
 #### New Features
   - Added support for Akida Brainchip PCIe module in NPU.
@@ -78,10 +82,14 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### [OS Image 844](https://downloads.arduino.cc/portentax8image/844.tar.gz)
+### OS Image 844
 
 <details>
   <summary><strong>OS Image 844: Release arduino-91</strong></summary>
+
+#### Image Access
+  - Full image [download](https://downloads.arduino.cc/portentax8image/844.tar.gz)
+  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-844.tar.gz)
 
 #### New Features
   - Implemented a configurable *NCM* gadget from `/etc/default/usbgx` .
@@ -106,10 +114,14 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### [OS Image 822](https://downloads.arduino.cc/portentax8image/822.tar.gz)
+### OS Image 822
 
 <details>
   <summary><strong>OS Image 822: Release arduino-88.94</strong></summary>
+
+#### Image Access
+  - Full image [download](https://downloads.arduino.cc/portentax8image/822.tar.gz)
+  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-822.tar.gz)
 
 #### New Features
   - Added `libgpiod` to enhance functionality across both software images.
@@ -133,10 +145,14 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### [OS Image 746](https://downloads.arduino.cc/portentax8image/746.tar.gz)
+### OS Image 746
 
 <details>
   <summary><strong>OS Image 746: Release arduino-88.91</strong></summary>
+
+#### Image Access
+  - Full image [download](https://downloads.arduino.cc/portentax8image/746.tar.gz)
+  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-746.tar.gz)
 
 #### New Features
   - Added the Portenta HAT Carrier support
@@ -159,9 +175,13 @@ Below is a list of all available firmware versions with their release notes.
 <br></br>
 
 
-### [OS Image 719](https://downloads.arduino.cc/portentax8image/719.tar.gz)
+### OS Image 719
 <details>
   <summary><strong>OS Image 719: Release arduino-88.7</strong></summary>
+
+#### Image Access
+  - Full image [download](https://downloads.arduino.cc/portentax8image/719.tar.gz)
+  - Update package [download](https://downloads.arduino.cc/portentax8image/offline-update-719.tar.gz)
 
 #### New Features
   - Added PWM fan support

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -32,22 +32,22 @@ The following section highlights the critical updates and enhancements introduce
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 
-* **Image Access**
-  - Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
+**Image Access:**
+- Full image [download](https://downloads.arduino.cc/portentax8image/859.tar.gz)
 
-* **New Features:**
-  - Added support for Akida Brainchip PCIe module in NPU.
-  - Added support for Hailo 8R PCIe module in NPU.
-  - Support for new panel modules and touchscreen controllers **jadard-ek79202d** and **atmel-mxt-ts** in `MIPI-DSI`.
+**New Features:**
+- Added support for Akida Brainchip PCIe module in NPU.
+- Added support for Hailo 8R PCIe module in NPU.
+- Support for new panel modules and touchscreen controllers **jadard-ek79202d** and **atmel-mxt-ts** in `MIPI-DSI`.
 
-* **Enhancements:**
-  - Increased CAN throughput, see details with **x8h7** tags.
-  - [x8h7] Changed low level protocol for **X8H7** to use a fixed packet size and hardware-assisted checksum.
-  - [x8h7] **X8H7** initialization now happens earlier, linked to `sysinit.target`.
+**Enhancements:**
+- Increased CAN throughput, see details with **x8h7** tags.
+- [x8h7] Changed low level protocol for **X8H7** to use a fixed packet size and hardware-assisted checksum.
+- [x8h7] **X8H7** initialization now happens earlier, linked to `sysinit.target`.
 
-* **Bug Fixes:**
-  - Fixed RS-485 `ttyX0` not working.
-  - Fixed PCIe on kernel 6.1.
+**Bug Fixes:**
+- Fixed RS-485 `ttyX0` not working.
+- Fixed PCIe on kernel 6.1.
 
 ***__You can download the latest firmware version [here](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).__ If you need instructions on updating the Portenta X8, you can follow [this guide](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#update-using-uuu-tool) using the __uuu__ tool.***
 


### PR DESCRIPTION
## What This PR Changes
Updates the Portenta X8's Release note documentation with the 859 version and adds firmware download links for older firmware.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.