### PR TITLE
[PC-1863] - Opta Interrupt Pin Number Update

### DIFF
--- a/content/hardware/07.opta/opta-family/opta/tutorials/01.user-manual/content.md
+++ b/content/hardware/07.opta/opta-family/opta/tutorials/01.user-manual/content.md
@@ -1196,7 +1196,7 @@ You should be able now to connect to your Opta™ using a central device. The Bl
 
 Interrupts are particularly useful when reacting instantly to an external event, such as a button press or a sensor signal. Without interrupts, you would have to constantly poll the status of a button or a sensor in the main loop of your running sketch. With interrupts, you can let your Opta's microcontroller do other tasks and only react when a desired event occurs.
 
-***Due to Opta's microcontroller interrupt structure, interrupts in terminals `I1` (`A0`) and `I4` (`A3`) cannot be used **simultaneously** to avoid operational issues. It is important to note that, despite this limitation, any other combination of inputs can be used for interrupt detection. However, this means that, at most, seven of the eight available inputs can be used simultaneously for interrupts, as combinations containing both `I1` and `I4` are excluded from viable configurations.***
+***Due to Opta's microcontroller interrupt structure, interrupts in terminals `I1` (`A0`) and `I4` (`A3`) cannot be used simultaneously to avoid operational issues. It is important to note that, despite this limitation, any other combination of inputs can be used for interrupt detection. However, this means that, at most, seven of the eight available inputs can be used simultaneously for interrupts, as combinations containing both `I1` and `I4` are excluded from viable configurations.***
 
 Interrupts can be used through the built-in functions of the Arduino programming language. To enable interrupts in your Opta's analog/digital programmable inputs and user-programmable button:
 

--- a/content/hardware/07.opta/opta-family/opta/tutorials/01.user-manual/content.md
+++ b/content/hardware/07.opta/opta-family/opta/tutorials/01.user-manual/content.md
@@ -1192,11 +1192,11 @@ You should be able now to connect to your Opta™ using a central device. The Bl
 
 ## Interrupts
 
-**Opta's analog/digital programmable inputs and user-programmable **button are **interrupt-capable. An interrupt is a signal that prompts Opta's microcontroller to stop its current execution and start executing a special routine known as the Interrupt Service Routine (ISR). Once the ISR finishes, the microcontroller resumes executing its previous routine.
+**Opta's analog/digital programmable inputs and user-programmable button are interrupt-capable**. An interrupt is a signal that prompts Opta's microcontroller to stop its execution and start executing a special routine known as the Interrupt Service Routine (ISR). Once the ISR finishes, the microcontroller resumes executing its previous routine.
 
 Interrupts are particularly useful when reacting instantly to an external event, such as a button press or a sensor signal. Without interrupts, you would have to constantly poll the status of a button or a sensor in the main loop of your running sketch. With interrupts, you can let your Opta's microcontroller do other tasks and only react when a desired event occurs.
 
-***Due to Opta's microcontroller interrupt structure, interrupts in terminals `I1` (`A0`) and `I4` (`A4`) cannot be used simultaneously to avoid operational issues. It is important to note that, despite this limitation, any other combination of inputs can be used for interrupt detection. However, this means that, at most, seven of the eight available inputs can be used simultaneously for interrupts, as combinations containing both `I1` and `I4` are excluded from viable configurations.***
+***Due to Opta's microcontroller interrupt structure, interrupts in terminals `I1` (`A0`) and `I4` (`A3`) cannot be used **simultaneously** to avoid operational issues. It is important to note that, despite this limitation, any other combination of inputs can be used for interrupt detection. However, this means that, at most, seven of the eight available inputs can be used simultaneously for interrupts, as combinations containing both `I1` and `I4` are excluded from viable configurations.***
 
 Interrupts can be used through the built-in functions of the Arduino programming language. To enable interrupts in your Opta's analog/digital programmable inputs and user-programmable button:
 

--- a/content/hardware/07.opta/opta-family/opta/tutorials/04.getting-started-with-interrupts/content.md
+++ b/content/hardware/07.opta/opta-family/opta/tutorials/04.getting-started-with-interrupts/content.md
@@ -70,7 +70,7 @@ Now that you have a better knowledge about interrupts, let's see how to use inte
 
 - Add the `attachInterrupt(digitalPinToInterrupt(pin), ISR, mode)`  instruction in your sketch's `setup()` function. Notice that the `pin` parameter can be `A0`, `A1`, `A2`, `A3`, `A4`, `A5`, `A6`, `A7`, or `BTN_USER`; the `ISR` parameter is the ISR function to call when the interrupt occurs, and the `mode` parameter defines when the interrupt should be triggered (`LOW`, `CHANGE`, `RISING`, or `FALLING`). 
 
-***Due to Opta's microcontroller interrupt structure, terminals `I1` (`A0`) and `I4` (`A4`) interrupts cannot be used simultaneously to avoid operational issues. It is important to note that, despite this limitation, any other combination of inputs can be used for interrupt detection. However, this means that, at most, seven of the eight available inputs can be used simultaneously for interrupts, as combinations containing `I1` and `I4` are excluded from viable configurations.***
+***Due to Opta's microcontroller interrupt structure, terminals `I1` (`A0`) and `I4` (`A3`) interrupts cannot be used simultaneously to avoid operational issues. It is important to note that, despite this limitation, any other combination of inputs can be used for interrupt detection. However, this means that, at most, seven of the eight available inputs can be used simultaneously for interrupts, as combinations containing `I1` and `I4` are excluded from viable configurations.***
 
 ## Instructions
 


### PR DESCRIPTION
## What This PR Changes
- This PR updates the interrupt-capable pin designator of Opta (A3 instead of A4). Changes made to Opta's User Manual and Interrupts tutorial. 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
