### PR TITLE
[PC-1855] Portenta X8: Release Note Documentation Update

### DIFF
--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -55,9 +55,10 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 
 ***For more information on the Foundries Core related to our release, please refer to the [__LmP V93 Release Notes — FoundriesFactory 93 documentation__](https://docs.foundries.io/latest/release-notes/release-notes.html).***
 
-## Older Firmware Versions
+## Available Firmware Versions
 
-Below is a list of deprecated versions before **861: Release arduino-91.2**, along with their release notes highlighting distinctive updates. Updating to the latest version is recommended.
+Below is a list of all available firmware versions with their release notes.
+
 
 ### OS Image 846 - May 15, 2024
 
@@ -192,3 +193,8 @@ Below is a list of deprecated versions before **861: Release arduino-91.2**, alo
 <br></br>
 
 For instructions on how to install or upgrade to the latest firmware version, you can use the [Portenta X8 Out-of-the-box](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#out-of-the-box-experience) or [flash it manually](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#update-using-uuu-tool) downloading the newest version directly from this [link](https://downloads.arduino.cc/portentax8image/image-latest.tar.gz).
+
+
+## Older Firmware Versions
+
+Older versions than version __OS Image 719 - September 27, 2023__ are deprecated. An update to the latest version is recommended.

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -28,7 +28,7 @@ Compatible carriers with the supported device:
 # Firmware Versions
 The following section highlights the critical updates and enhancements introduced in the latest firmware version. It presents the most significant progress and optimizations implemented to improve performance, enhance user experience, and strengthen security.
 
-## Latest Firmware Version: __861__
+## Latest Firmware Version: __861: Release arduino-91.2__
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 
@@ -50,31 +50,22 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 - Fixed RS-485 `ttyX0` not working.
 - Fixed PCIe on kernel 6.1.
 
-## Available Firmware Versions
+***For more information on the Foundries Core related to our release, please refer to the [__LmP V93 Release Notes — FoundriesFactory 93 documentation__](https://docs.foundries.io/latest/release-notes/release-notes.html).***
 
-Below is a list of all available firmware versions with their release notes.
+## Older Firmware Versions
 
-### OS Image 861
+Below is a list of deprecated versions before **861: Release arduino-91.2**, along with their release notes highlighting distinctive updates. Updating to the latest version is recommended.
+
+### OS Image 846 - May 15th, 2024
 
 <details>
-  <summary><strong>OS Image 861: Release arduino-91.2</strong></summary>
+  <summary><strong>OS Image 846: Release arduino-91.1</strong></summary>
 
 #### Image Access
-  - Full image [download](https://downloads.arduino.cc/portentax8image/861.tar.gz)
-
-#### New Features
-  - Added support for Akida Brainchip PCIe module in NPU.
-  - Added support for Hailo 8R PCIe module in NPU.
-  - Support for new panel modules and touchscreen controllers **jadard-ek79202d** and **atmel-mxt-ts** in `MIPI-DSI`.
-
-#### Enhancements
-  - Increased CAN throughput, see details with **x8h7** tags.
-  - [x8h7] Changed low level protocol for **X8H7** to use a fixed packet size and hardware-assisted checksum.
-  - [x8h7] **X8H7** initialization now happens earlier, linked to `sysinit.target`.
+  - Full image [download](https://downloads.arduino.cc/portentax8image/846.tar.gz)
 
 #### Bug Fixes
-  - Fixed RS-485 `ttyX0` not working.
-  - Fixed PCIe on kernel 6.1.
+  - Fixed PU on UART3 (shell) pads in U-Boot.
 
 #### Additional Notes
   - Based on [LmP v91](https://foundries.io/products/releases/91/). It is based on the Yocto manifest. For docker-compose apps, check out [here](https://github.com/arduino/portenta-containers/tree/release).
@@ -82,7 +73,7 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### OS Image 844
+### OS Image 844 - May 10th, 2024
 
 <details>
   <summary><strong>OS Image 844: Release arduino-91</strong></summary>
@@ -113,7 +104,7 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### OS Image 822
+### OS Image 822 - April 8th, 2024
 
 <details>
   <summary><strong>OS Image 822: Release arduino-88.94</strong></summary>
@@ -143,7 +134,7 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### OS Image 746
+### OS Image 746 - October 25th, 2023
 
 <details>
   <summary><strong>OS Image 746: Release arduino-88.91</strong></summary>
@@ -171,7 +162,7 @@ Below is a list of all available firmware versions with their release notes.
 </details>
 <br></br>
 
-### OS Image 719
+### OS Image 719 - September 27th, 2023
 <details>
   <summary><strong>OS Image 719: Release arduino-88.7</strong></summary>
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -8,9 +8,9 @@ hardware:
   - hardware/04.pro/board/portenta-x8
 ---
 
-# Firmware Release Notes
+# Firmware Information
 
-The present document provides detailed release notes for each firmware version of the Portenta X8. Explore the changes, improvements, and fixes for the released firmware.
+The present document provides download links and detailed release notes for each firmware version of the Portenta X8; explaining the changes, improvements, and fixes for each released firmware.
 
 ## Hardware and Software Requirements
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -26,6 +26,7 @@ Compatible carriers with the supported device:
 - [Portenta Mid Carrier](https://store.arduino.cc/products/portenta-mid-carrier)
 
 # Firmware Versions
+
 The following section highlights the critical updates and enhancements introduced in the latest firmware version. It presents the most significant progress and optimizations implemented to improve performance, enhance user experience, and strengthen security.
 
 ## Latest Firmware Version: __861 (Release arduino-91.2)__

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -29,7 +29,7 @@ Compatible carriers with the supported device:
 
 The following section highlights the critical updates and enhancements introduced in the latest firmware version. It presents the most significant progress and optimizations implemented to improve performance, enhance user experience, and strengthen security.
 
-## Latest Firmware Version: __861 (Release arduino-91.2)__
+## Latest Firmware Version: __861 (Release arduino-91.2) - June 26, 2024__
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 
@@ -57,7 +57,7 @@ The listing herein offers a glimpse into the Portenta X8 firmware's continuous i
 
 Below is a list of deprecated versions before **861: Release arduino-91.2**, along with their release notes highlighting distinctive updates. Updating to the latest version is recommended.
 
-### OS Image 846 - May 15th, 2024
+### OS Image 846 - May 15, 2024
 
 <details>
   <summary><strong>OS Image 846: Release arduino-91.1</strong></summary>
@@ -74,7 +74,7 @@ Below is a list of deprecated versions before **861: Release arduino-91.2**, alo
 </details>
 <br></br>
 
-### OS Image 844 - May 10th, 2024
+### OS Image 844 - May 10, 2024
 
 <details>
   <summary><strong>OS Image 844: Release arduino-91</strong></summary>
@@ -105,7 +105,7 @@ Below is a list of deprecated versions before **861: Release arduino-91.2**, alo
 </details>
 <br></br>
 
-### OS Image 822 - April 8th, 2024
+### OS Image 822 - April 8, 2024
 
 <details>
   <summary><strong>OS Image 822: Release arduino-88.94</strong></summary>
@@ -135,7 +135,7 @@ Below is a list of deprecated versions before **861: Release arduino-91.2**, alo
 </details>
 <br></br>
 
-### OS Image 746 - October 25th, 2023
+### OS Image 746 - October 25, 2023
 
 <details>
   <summary><strong>OS Image 746: Release arduino-88.91</strong></summary>
@@ -163,7 +163,7 @@ Below is a list of deprecated versions before **861: Release arduino-91.2**, alo
 </details>
 <br></br>
 
-### OS Image 719 - September 27th, 2023
+### OS Image 719 - September 27, 2023
 <details>
   <summary><strong>OS Image 719: Release arduino-88.7</strong></summary>
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -28,7 +28,7 @@ Compatible carriers with the supported device:
 # Firmware Versions
 The following section highlights the critical updates and enhancements introduced in the latest firmware version. It presents the most significant progress and optimizations implemented to improve performance, enhance user experience, and strengthen security.
 
-## Latest Firmware Version: __861: Release arduino-91.2__
+## Latest Firmware Version: __861 (Release arduino-91.2)__
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/14.x8-firmware-release-notes/x8-firmware-release-notes.md
@@ -29,7 +29,9 @@ Compatible carriers with the supported device:
 
 The following section highlights the critical updates and enhancements introduced in the latest firmware version. It presents the most significant progress and optimizations implemented to improve performance, enhance user experience, and strengthen security.
 
-## Latest Firmware Version: __861 (Release arduino-91.2) - June 26, 2024__
+## Latest Firmware Version: __861 (Release arduino-91.2)__
+
+**Release Date: June 26, 2024**
 
 The listing herein offers a glimpse into the Portenta X8 firmware's continuous improvement and enhancement. You can expect a concise overview of the integrated key new features, major bug fixes, and critical security patches to ensure the highest level of functionality and performance within the Portenta X8 system.
 


### PR DESCRIPTION
## What This PR Changes
Updates the Portenta X8 Release Note documentation with the following changes:
- Clearer differentiation between latest version and old versions
- Added [LmP V93 Release Notes — FoundriesFactory 93 documentation](https://docs.foundries.io/latest/release-notes/release-notes.html) to the latest firmware section
- Added release dates to firmware versions 

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.