### PR TITLE
Update esp-now document

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/tutorials/esp-now/esp-now.md
+++ b/content/hardware/03.nano/boards/nano-esp32/tutorials/esp-now/esp-now.md
@@ -235,7 +235,7 @@ typedef struct struct_message {
 struct_message myData;
 
 // callback function that will be executed when data is received
-void OnDataRecv(const uint8_t * mac, const uint8_t *incomingData, int len) {
+void OnDataRecv(const esp_now_recv_info_t *info, const uint8_t *incomingData, int len) {
   memcpy(&myData, incomingData, sizeof(myData));
   Serial.print("Bytes received: ");
   Serial.println(len);


### PR DESCRIPTION
## What This PR Changes
the callback function of receiving the ESPNOW data is "esp_err_t esp_now_register_recv_cb(esp_now_recv_cb_t cb)",and the define of esp_now_recv_cb_t is "typedef void (*esp_now_recv_cb_t)(const esp_now_recv_info_t *esp_now_info, const uint8_t *data, int data_len)"which is not"typedef void (*esp_now_recv_cb_t)(const uint8_t *macAddress, const uint8_t *data, int data_len)"

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
