### PR TITLE
Use refname for cache key

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -50,7 +50,7 @@ jobs:
         id: gatsby-cache-folder
         with:
           path: .cache
-          key: ${{ runner.os }}-cache-gatsby-${{ github.ref }}
+          key: ${{ runner.os }}-cache-gatsby-${{ github.refname }}
           restore-keys: |
             ${{ runner.os }}-cache-gatsby-main
 
@@ -59,7 +59,7 @@ jobs:
         id: gatsby-public-folder
         with:
           path: public/
-          key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
+          key: ${{ runner.os }}-public-gatsby-${{ github.refname }}
           restore-keys: |
             ${{ runner.os }}-public-gatsby-main
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -49,7 +49,7 @@ jobs:
         id: gatsby-cache-folder
         with:
           path: .cache
-          key: ${{ runner.os }}-cache-gatsby-${{ github.ref }}
+          key: ${{ runner.os }}-cache-gatsby-${{ github.refname }}
           restore-keys: |
             ${{ runner.os }}-cache-gatsby-main
 
@@ -58,7 +58,7 @@ jobs:
         id: gatsby-public-folder
         with:
           path: public/
-          key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
+          key: ${{ runner.os }}-public-gatsby-${{ github.refname }}
           restore-keys: |
             ${{ runner.os }}-public-gatsby-main
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -69,7 +69,7 @@ jobs:
         id: gatsby-cache-folder
         with:
           path: .cache
-          key: ${{ runner.os }}-cache-gatsby-${{ github.ref }}
+          key: ${{ runner.os }}-cache-gatsby-${{ github.refname }}
           restore-keys: |
             ${{ runner.os }}-cache-gatsby-main
 
@@ -78,7 +78,7 @@ jobs:
         id: gatsby-public-folder
         with:
           path: public/
-          key: ${{ runner.os }}-public-gatsby-${{ github.ref }}
+          key: ${{ runner.os }}-public-gatsby-${{ github.refname }}
           restore-keys: |
             ${{ runner.os }}-public-gatsby-main
 


### PR DESCRIPTION
Instead of the full ref (so it can actually match with the `-main` fallback)