### PR TITLE
Update introduction-to-the-serial-peripheral-interface.md

### DIFF
--- a/content/tutorials/generic/introduction-to-the-serial-peripheral-interface/introduction-to-the-serial-peripheral-interface.md
+++ b/content/tutorials/generic/introduction-to-the-serial-peripheral-interface/introduction-to-the-serial-peripheral-interface.md
@@ -51,7 +51,7 @@ With an SPI connection there is always one Controller device (usually a microcon
 | Slave Select pin (SS)      | Chip Select Pin (CS)                 |
 
 
-The difficult part about SPI is that the standard is loose and each device implements it a little differently. This means you have to pay special attention to the datasheet when writing your interface code. Generally speaking there are three modes of transmission numbered 0 - 3. These modes control whether data is shifted in and out on the rising or falling edge of the data clock signal, and whether the clock is idle when high or low.
+The difficult part about SPI is that the standard is loose and each device implements it a little differently. This means you have to pay special attention to the datasheet when writing your interface code. Generally speaking there are four modes of transmission numbered 0 - 3. These modes control whether data is shifted in and out on the rising or falling edge of the data clock signal, and whether the clock is idle when high or low.
 
 All SPI settings are determined by the Arduino SPI Control Register (SPCR). A register is just a byte of microcontroller memory that can be read from or written to. Registers generally serve three purposes, control, data and  status.
 


### PR DESCRIPTION
previously it wrote "there are three mode of transmission". but it's FOUR as a result of combination of two different configurations of CPOL and  two different configurations of  CPHA.

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
