### PR TITLE
Update DO to D0

### DIFF
--- a/content/hardware/07.opta/opta-family/opta/tutorials/15.home-automation-application-note/content.md
+++ b/content/hardware/07.opta/opta-family/opta/tutorials/15.home-automation-application-note/content.md
@@ -181,7 +181,7 @@ void setup() {
   // Digital inputs, digital outputs, built-in LEDs initialization
   pinMode(LED_D0, OUTPUT);
   pinMode(LED_D1, OUTPUT);
-  pinMode(DO, OUTPUT);
+  pinMode(D0, OUTPUT);
   pinMode(D1, OUTPUT);
   pinMode(A2, INPUT);
   pinMode(A3, INPUT);


### PR DESCRIPTION
Letter "O" used instead of number "0"

## What This PR Changes
- Fixes typo for Opta relay designated as D0 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
