### PR TITLE
Update built-in-examples.md

### DIFF
--- a/content/programming/03.built-in-examples/built-in-examples.md
+++ b/content/programming/03.built-in-examples/built-in-examples.md
@@ -7,7 +7,7 @@ links:
   [
     {
       title: "How to Wire and Program a Button",
-      url: /built-in-examples/digita/Button,
+      url: /built-in-examples/digital/Button,
     },
     { title: "Blink", url: /built-in-examples/basics/Blink },
     {


### PR DESCRIPTION
There was a Typo in the file causing a 404 page not found for the link to "How to Wire and Program a Button" I updated the url from /build-in-examples/digita/Button to /build-in-examples/digital/Button.

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
