### PR TITLE
[PC-1958] Portenta X8: USB-C® to USB-A Requirement Update

### DIFF
--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/03.uploading-sketches-m4/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/03.uploading-sketches-m4/content.md
@@ -26,7 +26,7 @@ In this tutorial, we will go through the process of uploading sketches to the M4
 ### Required Hardware and Software
 
 - [Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2](https://www.arduino.cc/en/software), or [Arduino CLI](https://github.com/arduino/arduino-cli)
 - Latest "Arduino Mbed OS Portenta Boards" Core
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/04.python-arduino-data-exchange/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/04.python-arduino-data-exchange/content.md
@@ -30,6 +30,7 @@ You will be guided on how to achieve this setup. It is recommendable to familiar
 - [Portenta X8](https://store.arduino.cc/products/portenta-x8)
 - [Portenta breakout](https://docs.arduino.cc/hardware/portenta-breakout)
 - Any sensor (in this example, we will use an [BME680](https://www.bosch-sensortec.com/products/environmental-sensors/gas-sensors/bme680/) I<sup>2</sup>C module)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2](https://www.arduino.cc/en/software), or [Arduino Cloud Editor](https://create.arduino.cc/editor)
 
 ## Python® on the X8

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/05.docker-container/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/05.docker-container/content.md
@@ -32,7 +32,7 @@ In this tutorial, we will go through the steps of how to install, run, and remov
 ### Hardware and Software Requirements
 
 - [Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - Wi-Fi® Access Point with Internet Access
 - ADB: [Check how to connect to your Portenta X8](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#out-of-the-box-experience)
 - [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2](https://www.arduino.cc/en/software), or [Arduino Cloud Editor](https://create.arduino.cc/editor)

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/06.waves-fleet-managment/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/06.waves-fleet-managment/content.md
@@ -26,7 +26,7 @@ This tutorial will show you how to define fleets and how to construct a Wave tha
 ### Required Hardware and Software
 
 - [Arduino Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - Arduino Create account
 - Arduino Cloud for business subscription with Portenta X8 Manager add-on: [Learn more about here](https://cloud.arduino.cc/plans#business)
 - Foundries.io™ account (linked with the Arduino Cloud for business subscription)

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/07.custom-container/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/07.custom-container/content.md
@@ -23,7 +23,7 @@ In this tutorial, we will create a Docker container for the Arduino Portenta X8.
 
 - [Portenta X8](https://store.arduino.cc/portenta-x8)
 - ADB: [Check how to connect to your Portenta X8](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#out-of-the-box-experience)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - [Arduino Cloud Subscription](https://cloud.arduino.cc/)
 - [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2](https://www.arduino.cc/en/software), or [Arduino Cloud Editor](https://create.arduino.cc/editor)
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/08.image-building/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/08.image-building/content.md
@@ -31,6 +31,7 @@ This tutorial targets customers that are not FoundriesFactory subscribers, but s
 ### Required Hardware and Software
 
 - [Portenta X8](https://store.arduino.cc/products/portenta-x8)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - [Docker Engine](https://docs.docker.com/engine/install/)
 - ~60GB of available storage space on your machine
 

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/09.image-flashing/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/09.image-flashing/content.md
@@ -25,7 +25,7 @@ In this tutorial, you will learn how to manually flash your Portenta X8 with the
 ### Required Hardware and Software
 
 - [Arduino Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - Portenta Family Carrier (Optional):
 - [Arduino Portenta Breakout Board](https://store.arduino.cc/products/arduino-portenta-breakout)
 - [Arduino Portenta Max Carrier](https://store.arduino.cc/products/portenta-max-carrier)

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/10.datalogging-iot/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/10.datalogging-iot/content.md
@@ -41,7 +41,7 @@ These four blocks will be running locally on the [Arduino® Portenta X8](https:/
 
 - [Arduino® Portenta X8](https://store.arduino.cc/products/portenta-x8)
 - [Arduino® MKR WiFi 1010](https://store.arduino.cc/products/arduino-mkr-wifi-1010)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - Wi-Fi® Access Point (AP) with Internet access
 - ADB or SSH
 - Command-line interface

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/11.display-output-webgl/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/11.display-output-webgl/content.md
@@ -31,7 +31,7 @@ In this tutorial, we will render web content from the internet using WebGL and d
 ### Required Hardware and Software
 
 - [Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - USB-C® hub with HDMI
 - External monitor
 - HDMI cable

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/12.multi-protocol-gateway/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/12.multi-protocol-gateway/content.md
@@ -33,7 +33,7 @@ In this tutorial, we will go through the steps on how to set up both the Linux a
 
 - [Arduino Portenta X8](https://store.arduino.cc/products/portenta-x8)
 - [Arduino Portenta Max Carrier](https://store.arduino.cc/products/portenta-max-carrier)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - Wi-Fi® Access Point with Internet Access
 - 868-915 MHz antenna with SMA connector
 - ADB: [Check how to connect to your Portenta X8](https://docs.arduino.cc/tutorials/portenta-x8/user-manual#out-of-the-box-experience)

--- a/content/hardware/04.pro/boards/portenta-x8/tutorials/13.wordpress-webserver/content.md
+++ b/content/hardware/04.pro/boards/portenta-x8/tutorials/13.wordpress-webserver/content.md
@@ -29,7 +29,7 @@ You will learn to set up and access a WordPress site hosted on the X8 via a web 
 ### Required Hardware and Software
 
 - [Portenta X8](https://store.arduino.cc/products/portenta-x8)
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - The [docker-compose.yml](assets/docker-compose.rar) file used in this tutorial
 
 ## Instructions

--- a/content/hardware/04.pro/carriers/portenta-breakout/tutorials/breakout-jlink-setup/breakout-jlink-setup.md
+++ b/content/hardware/04.pro/carriers/portenta-breakout/tutorials/breakout-jlink-setup/breakout-jlink-setup.md
@@ -19,7 +19,8 @@ This tutorial will show you how to debug an Arduino sketch using the Portenta H7
 
 - [Portenta H7 board](https://store.arduino.cc/portenta-h7)
 - [Portenta Breakout board](https://store.arduino.cc/portenta-breakout)
-- Arduino IDE 1.8.10+ or Arduino Pro IDE 0.0.4+
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software) or [Arduino IDE 2.0+](https://www.arduino.cc/en/software)
 - J-link adapter
 - Segger J-link device
 - Segger Ozone

--- a/content/hardware/04.pro/carriers/portenta-breakout/tutorials/getting-started/content.md
+++ b/content/hardware/04.pro/carriers/portenta-breakout/tutorials/getting-started/content.md
@@ -21,12 +21,12 @@ The Arduino Portenta Breakout is a versatile tool designed for developing, testi
 
 - [Arduino Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Arduino Portenta Breakout](https://store.arduino.cc/portenta-breakout)
-- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - Breadboard & Cables
 - Pin headers for the Portenta Breakout
 - LED & Resistor
 - Potentiometer
-- Arduino IDE 1.8.10+
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software) or [Arduino IDE 2.0+](https://www.arduino.cc/en/software)
 
 ## Instructions
 

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -43,7 +43,7 @@ To use the [Portenta Hat Carrier](https://store.arduino.cc/products/portenta-hat
 
 Additionally, the following accessories are needed:
 
-- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 - Wi-Fi® Access Point or Ethernet with Internet access (x1)
 
 ### Software Requirements

--- a/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-hat-carrier/tutorials/user-manual/content.md
@@ -43,7 +43,7 @@ To use the [Portenta Hat Carrier](https://store.arduino.cc/products/portenta-hat
 
 Additionally, the following accessories are needed:
 
-- USB-C® cable (USB-C® to USB-A cable) (x1)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 - Wi-Fi® Access Point or Ethernet with Internet access (x1)
 
 ### Software Requirements

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
@@ -38,6 +38,7 @@ The goals of this project are:
 - Antenna with GSM 850 / 900 / 1800 / 1900 MHz range and the ability to connect via SMA
 - DC 4.5-20V power supply with barrel jack.
 - [Portenta Max carrier](https://store.arduino.cc/products/portenta-max-carrier)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 
 ## Instructions
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/catm1-and-nbiot/content.md
@@ -33,12 +33,12 @@ The goals of this project are:
 
 ## Hardware & Software Needed
 
-- Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software)).
 - [Portenta H7](https://store.arduino.cc/products/portenta-h7)
 - Antenna with GSM 850 / 900 / 1800 / 1900 MHz range and the ability to connect via SMA
 - DC 4.5-20V power supply with barrel jack.
 - [Portenta Max carrier](https://store.arduino.cc/products/portenta-max-carrier)
 - [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software) or [Arduino IDE 2.0+](https://www.arduino.cc/en/software)
 
 ## Instructions
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/connecting-to-ttn/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/connecting-to-ttn/content.md
@@ -28,13 +28,13 @@ This tutorial explains how to connect your [Arduino® Max Carrier](http://store.
 
 ### Required Hardware and Software
 
-- [Portenta H7](https://store.arduino.cc/products/portenta-h7).
-- [Portenta Max Carrier](http://store.arduino.cc/portenta-max-carrier).
-- 868-915 MHz antenna with SMA connector.
-- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®).
-- Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software)).
-- [Arduino MKRWAN library](https://github.com/arduino-libraries/MKRWAN).  
-- An active account in [TTN](https://www.thethingsnetwork.org/).
+- [Portenta H7](https://store.arduino.cc/products/portenta-h7)
+- [Portenta Max Carrier](http://store.arduino.cc/portenta-max-carrier)
+- 868-915 MHz antenna with SMA connector
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2.0+](https://www.arduino.cc/en/software), or [Arduino Cloud Editor](https://create.arduino.cc/editor)
+- [Arduino MKRWAN library](https://github.com/arduino-libraries/MKRWAN)
+- An active account in [TTN](https://www.thethingsnetwork.org/)
 
 ## The Arduino® Portenta Max Carrier LoRaWAN® Module
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/mpcie-4g-modem/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/mpcie-4g-modem/content.md
@@ -39,7 +39,7 @@ The hands-on part of this tutorial will walk you through performing a speed test
 
 The following accessories are needed:
 
-- USB-C® cable (USB-A to USB-C®) (x1)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 - Wi-Fi® Access Point or Ethernet with Internet access (x1)
 - External antenna: Main antenna, GNSS antenna, and Rx-Diversity antenna
 - Power cables: Wires with a cross-sectional area ranging from 0.82 mm² to 1.3 mm², corresponding to AWG sizes 18 to 16

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/mpcie-4g-modem/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/mpcie-4g-modem/content.md
@@ -34,7 +34,7 @@ The hands-on part of this tutorial will walk you through performing a speed test
 
 * [Portenta Max Carrier](https://store.arduino.cc/products/portenta-max-carrier) (x1)
 * [Portenta X8](https://store.arduino.cc/products/portenta-x8) (x1)
-* Pro 4G Module (GNSS Module Global / EMEA) (x1)
+* Pro 4G Module ([GNSS Module Global](https://store.arduino.cc/products/4g-module-global?queryID=undefined) / [EMEA](https://store.arduino.cc/products/4g-module-emea?queryID=undefined)) (x1)
 * Compatible antennas like the [Arduino Pro 4G Module Antennas Kit](https://store.arduino.cc/products/4g-module-antenna) (x1)
 
 The following accessories are needed:

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/user-manual/content.md
@@ -41,7 +41,7 @@ This user manual offers a detailed guide on the Portenta Max Carrier, consolidat
 * [Portenta X8](https://store.arduino.cc/products/portenta-x8) (x1)
 * [Portenta C33](https://store.arduino.cc/products/portenta-c33) (x1)
 * [Portenta H7](https://store.arduino.cc/products/portenta-h7) (x1)
-* USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®) (x1)
+* [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 * Wi-Fi® Access Point or Ethernet with Internet access (x1)
 * Compatible antennas like the [Arduino Pro 4G Module Antennas Kit](https://store.arduino.cc/products/4g-module-antenna) (x1)
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/user-manual/content.md
@@ -41,7 +41,7 @@ This user manual offers a detailed guide on the Portenta Max Carrier, consolidat
 * [Portenta X8](https://store.arduino.cc/products/portenta-x8) (x1)
 * [Portenta C33](https://store.arduino.cc/products/portenta-c33) (x1)
 * [Portenta H7](https://store.arduino.cc/products/portenta-h7) (x1)
-* [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
+* [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 * Wi-Fi® Access Point or Ethernet with Internet access (x1)
 * Compatible antennas like the [Arduino Pro 4G Module Antennas Kit](https://store.arduino.cc/products/4g-module-antenna) (x1)
 
@@ -216,9 +216,9 @@ The Portenta Max Carrier incorporates two DIP switches, giving users the ability
 
 For configurations when the Portenta Max Carrier is combined with the Portenta boards, the DIP switch governs these settings:
 
-| **Ethernet DIP Switch Designation** | **Position: ON**  | **Position: OFF** |
-|:-----------------------------------:|:-----------------:|:-----------------:|
-|                1 - 2                | Ethernet Disabled for X8 / Enabled for H7/C33 | Ethernet Enabled for X8 / Disabled for H7/C33  |
+| **Ethernet DIP Switch Designation** |               **Position: ON**                |               **Position: OFF**               |
+|:-----------------------------------:|:---------------------------------------------:|:---------------------------------------------:|
+|                1 - 2                | Ethernet Disabled for X8 / Enabled for H7/C33 | Ethernet Enabled for X8 / Disabled for H7/C33 |
 
 For an in-depth understanding of the DIP switch, kindly refer to [this section](#dip-switch-configuration).
 

--- a/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/x8-getting-started/content.md
+++ b/content/hardware/04.pro/carriers/portenta-max-carrier/tutorials/x8-getting-started/content.md
@@ -30,6 +30,7 @@ The goals of this project are:
 
 - [Arduino® Portenta X8](https://store.arduino.cc/products/portenta-x8)
 - [Arduino® Portenta Max Carrier](https://store.arduino.cc/products/portenta-max-carrier)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c)
 
 ## The Portenta Max Carrier
 

--- a/content/hardware/04.pro/carriers/portenta-mid-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-mid-carrier/tutorials/user-manual/content.md
@@ -44,8 +44,9 @@ The **Portenta Mid Carrier** requires one of the SOM boards from the Portenta Fa
 
 The following accessories are needed:
 
-- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 - Wi-Fi® Access Point or Ethernet with Internet access (x1)
+- Pro 4G Module ([GNSS Module Global](https://store.arduino.cc/products/4g-module-global?queryID=undefined) / [EMEA](https://store.arduino.cc/products/4g-module-emea?queryID=undefined)) (x1)
 - Compatible antennas like the [Arduino Pro 4G Module Antennas Kit](https://store.arduino.cc/products/4g-module-antenna) (x1)
 - Power cables: Wires with a cross-sectional area ranging from 0.82 mm² to 1.3 mm², corresponding to AWG sizes 18 to 16
 

--- a/content/hardware/04.pro/carriers/portenta-mid-carrier/tutorials/user-manual/content.md
+++ b/content/hardware/04.pro/carriers/portenta-mid-carrier/tutorials/user-manual/content.md
@@ -44,7 +44,7 @@ The **Portenta Mid Carrier** requires one of the SOM boards from the Portenta Fa
 
 The following accessories are needed:
 
-- USB-C® cable (either USB-C® to USB-A or USB-C® to USB-C®) (x1)
+- [USB-C® cable (USB-C® to USB-A cable)](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 - Wi-Fi® Access Point or Ethernet with Internet access (x1)
 - Compatible antennas like the [Arduino Pro 4G Module Antennas Kit](https://store.arduino.cc/products/4g-module-antenna) (x1)
 - Power cables: Wires with a cross-sectional area ranging from 0.82 mm² to 1.3 mm², corresponding to AWG sizes 18 to 16

--- a/content/hardware/04.pro/shields/portenta-cat-m1-nb-iot-gnss-shield/tutorials/getting-started/getting-started.md
+++ b/content/hardware/04.pro/shields/portenta-cat-m1-nb-iot-gnss-shield/tutorials/getting-started/getting-started.md
@@ -35,10 +35,11 @@ The goals of this project are:
 
 ## Hardware & Software Needed
 
-- Arduino IDE ([online](https://create.arduino.cc/) or [offline](https://www.arduino.cc/en/main/software)).
 - [Portenta H7](https://store.arduino.cc/products/portenta-h7)
 - [Portenta Cat. M1/NB IoT GNSS Shield](https://store.arduino.cc/products/portenta-catm1)
-- [Dipole Antenna](https://store.arduino.cc/antenna) (or equivalent product with the same frequency range).
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
+- [Dipole Antenna](https://store.arduino.cc/antenna) (or equivalent product with the same frequency range)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software) or [Arduino IDE 2.0+](https://www.arduino.cc/en/software)
 
 ## Instructions
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/blob-detection/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/blob-detection/content.md
@@ -25,8 +25,8 @@ In this tutorial you will use the Portenta Vision Shield to detect the presence 
 
 - [Portenta H7 board](https://store.arduino.cc/portenta-h7)
 - [Arduino Portenta Vision Shield - Ethernet](https://store.arduino.cc/products/arduino-portenta-vision-shield-ethernet)
-- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
-- Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4+
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software) or [Arduino IDE 2.0+](https://www.arduino.cc/en/software)
 - Portenta Bootloader Version 20+
 - OpenMV IDE 2.6.4+
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/camera-to-bitmap-sd-card/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/camera-to-bitmap-sd-card/content.md
@@ -31,9 +31,9 @@ This tutorial shows you how to capture a frame from the Portenta Vision Shield C
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - Portenta Vision Shield ([LoRa](https://store.arduino.cc/portenta-vision-shield-lora) or [Ethernet](https://store.arduino.cc/portenta-vision-shield))
-- 1x USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - Micro SD card
-- Arduino IDE or Arduino-cli
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2.0+](https://www.arduino.cc/en/software) or [Arduino-cli](https://arduino.github.io/arduino-cli)
 
 ## Instructions
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/connecting-to-ttn/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/connecting-to-ttn/content.md
@@ -26,9 +26,9 @@ This tutorial explains how to connect your Portenta H7 to The Things Network (TT
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield - LoRa](https://store.arduino.cc/portenta-vision-shield-lora)
-- [1x Dipole Pentaband antenna](https://store.arduino.cc/antenna) or a UFL Antenna of the H7 
-- Arduino [offline](https://www.arduino.cc/en/main/software) IDE or Arduino [Cloud Editor](https://create.arduino.cc/)
-- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- [Dipole Pentaband antenna](https://store.arduino.cc/antenna) or a UFL Antenna of the H7 (x1)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2.0+](https://www.arduino.cc/en/software), or the [Arduino Cloud Editor](https://create.arduino.cc/editor)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - An [account](https://console.cloud.thethings.network/) with The Things Network
 
 ### Updating the LoRa® Module Firmware

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/creating-basic-face-filter/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/creating-basic-face-filter/content.md
@@ -26,8 +26,8 @@ In this tutorial you will build a MicroPython application with OpenMV, to use th
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield](https://store.arduino.cc/portenta-vision-shield)
-- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
-- Arduino IDE 1.8.10+  or Arduino Pro IDE 0.0.4+ 
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software) or [Arduino IDE 2.0+](https://www.arduino.cc/en/software)
 - Portenta Bootloader Version 20+
 - OpenMV IDE 2.6.4+
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/custom-machine-learning-model/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/custom-machine-learning-model/content.md
@@ -26,7 +26,7 @@ This tutorial teaches you how to train a custom machine learning model with Edge
 
 - [Portenta H7 board](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield - LoRa](https://store.arduino.cc/portenta-vision-shield-lora) or [Portenta Vision Shield - Ethernet](https://store.arduino.cc/products/arduino-portenta-vision-shield-ethernet)
-- USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - An [Edge Impulse®](https://studio.edgeimpulse.com/) account for training the ML model
 - Fruits (or other objects) to create the classification model 🍏🍌🍐
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-ide/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-ide/content.md
@@ -34,7 +34,8 @@ The goals of this project are:
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield - Ethernet](https://store.arduino.cc/products/arduino-portenta-vision-shield-ethernet)
-- Arduino [offline IDE](https://www.arduino.cc/en/main/software) or Arduino [Cloud Editor](https://create.arduino.cc/)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2.0+](https://www.arduino.cc/en/software), or the [Arduino Cloud Editor](https://create.arduino.cc/editor)
 - Ethernet cable
 - USB-C® cable
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-openmv/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/ethernet-with-openmv/content.md
@@ -30,9 +30,9 @@ With the Ethernet version of the Arduino Portenta Vision Shield it is possible t
 
 - [Portenta H7 board](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield - Ethernet](https://store.arduino.cc/products/arduino-portenta-vision-shield-lora®)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c)
 - [OpenMV](https://openmv.io/pages/download)
 - Ethernet cable
-- USB-C® cable
 
 ***If you want to know more about the ethernet connection please go to the [Arduino IDE ethernet tutorial](https://docs.arduino.cc/tutorials/portenta-vision-shield/ethernet-with-ide#ethernet-connection)***
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/getting-started-camera/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/getting-started-camera/content.md
@@ -23,8 +23,8 @@ This tutorial shows you how to capture frames from the Arduino Portenta Vision S
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - Portenta Vision Shield ([LoRa](https://store.arduino.cc/portenta-vision-shield-lora) or [Ethernet](https://store.arduino.cc/portenta-vision-shield))
-- 1x USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
-- Arduino IDE 1.8.10+
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c) (X1)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software) or [Arduino IDE 2.0+](https://www.arduino.cc/en/software)
 - Processing 3.5.4+
 
 ## Instructions

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/speech-recognition-engine/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/speech-recognition-engine/content.md
@@ -65,8 +65,8 @@ To use the Arduino Speech Recognition Engine, you will need one of the following
 In the case of the Portenta H7, remember that is always possible to add an external microphone as additional hardware, instead of using the Portenta Vision Shield.
 
 Additionally, you will need the following hardware and software:
-- 1x USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
-- [Arduino IDE 2](https://www.arduino.cc/en/software), [Arduino Cloud](https://cloud.arduino.cc), or [Arduino-cli](https://arduino.github.io/arduino-cli)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2.0+](https://www.arduino.cc/en/software), [Arduino Cloud Editor](https://create.arduino.cc/editor), or [Arduino-cli](https://arduino.github.io/arduino-cli)
 
 ## Instructions
 

--- a/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/things-network-openmv/content.md
+++ b/content/hardware/04.pro/shields/portenta-vision-shield/tutorials/things-network-openmv/content.md
@@ -28,10 +28,10 @@ This tutorial explains how to connect your Portenta H7 to The Things Network (TT
 
 - [Portenta H7](https://store.arduino.cc/portenta-h7)
 - [Portenta Vision Shield - LoRa](https://store.arduino.cc/portenta-vision-shield-lora)
-- 1x [Dipole Pentaband antenna](https://store.arduino.cc/antenna) or a UFL Antenna of the H7 
+- [Dipole Pentaband antenna](https://store.arduino.cc/antenna) or a UFL Antenna of the H7 (x1)
 - [OpenMV IDE](https://openmv.io/pages/download)
-- Arduino IDE 1.8.10+ or Arduino Pro IDE 0.0.4+ or Arduino CLI 0.13.0+
-- 1x USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
+- [Arduino IDE 1.8.10+](https://www.arduino.cc/en/software), [Arduino IDE 2.0+](https://www.arduino.cc/en/software) or [Arduino CLI 0.13.0+](https://arduino.github.io/arduino-cli)
+- [USB-C® cable](https://store.arduino.cc/products/usb-cable2in1-type-c) (x1)
 - An account on [The Things Network](https://console.cloud.thethings.network/)
 
 ## Instructions


### PR DESCRIPTION
## What This PR Changes
Updates Portenta X8 involved documentation regarding USB-C® to USB-A cable requirement

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
