### PR TITLE
Update introduction-to-the-serial-peripheral-interface.md

### DIFF
--- a/content/tutorials/generic/introduction-to-the-serial-peripheral-interface/introduction-to-the-serial-peripheral-interface.md
+++ b/content/tutorials/generic/introduction-to-the-serial-peripheral-interface/introduction-to-the-serial-peripheral-interface.md
@@ -241,11 +241,11 @@ delay(10);
 We end the setup function by sending the word "hi" plus a line feed out the built in serial port for debugging purposes. This way if our data comes out looking funny later on we can tell it isn't just the serial port acting up:
 
 ```arduino
-Serial.print('h',BYTE);
+Serial.print('h');
 
-  Serial.print('i',BYTE);
+  Serial.print('i');
 
-  Serial.print('\n',BYTE);//debug
+  Serial.print('\n');//debug
 
   delay(1000);
 }
@@ -431,11 +431,11 @@ void setup()
 
   delay(3000);
 
-  Serial.print('h',BYTE);
+  Serial.print('h');
 
-  Serial.print('i',BYTE);
+  Serial.print('i');
 
-  Serial.print('\n',BYTE);//debug
+  Serial.print('\n');//debug
 
   delay(1000);
 }
@@ -469,7 +469,7 @@ void loop()
 
   Serial.print(eeprom_output_data,DEC);
 
-  Serial.print('\n',BYTE);
+  Serial.print('\n');
 
   address++;
 


### PR DESCRIPTION
Changed the `Serial.print(char,BYTE)` lines in the code to remove the unnecessary "`,BYTE`" error.   "BYTE" causes errors as it is undefined.

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
