### PR TITLE
[PC-1952] - Opta Analog and Digital Expansions Product and Store Pages Name Alignment

### DIFF
--- a/content/hardware/07.opta/opta-family/opta-analog-exp/features.md
+++ b/content/hardware/07.opta/opta-family/opta-analog-exp/features.md
@@ -1,8 +1,8 @@
 <FeatureDescription>
 
-**Arduino Opta® Analog Expansions** are designed to multiply your Opta® micro PLC capabilities with the addition of eight programmable analog inputs for connecting your digital or analog sensors, allowing you to interface with voltage, current or resistive sensors, eight analog outputs for voltage or current and four PWM outputs.
+The **Arduino Opta® Analog Expansion A0602** is designed to multiply your Opta® micro PLC capabilities with the addition of eight programmable analog inputs for connecting your digital or analog sensors, allowing you to interface with voltage, current or resistive sensors, eight analog outputs for voltage or current and four PWM outputs.
 
-Opta Analog Expansion allows professionals to scale up industrial and building automation projects while taking advantage of the Arduino ecosystem.
+The Opta® Analog Expansion A0602 allows professionals to scale up industrial and building automation projects while taking advantage of the Arduino ecosystem.
 
 </FeatureDescription>
 

--- a/content/hardware/07.opta/opta-family/opta-analog-exp/product.md
+++ b/content/hardware/07.opta/opta-family/opta-analog-exp/product.md
@@ -1,5 +1,5 @@
 ---
-title: Opta Analog Expansion
+title: Opta Analog Expansion A0602
 url_shop: https://store.arduino.cc/products/opta-ext-a0602
 url_guide: /tutorials/opta-analog-exp/user-manual
 primary_button_url: /tutorials/opta/user-manual#opta-analog-expansions
@@ -10,4 +10,4 @@ core: arduino:mbed_opta
 certifications: [FCC, CE, UKCA, cULus, ENEC]
 ---
 
-The **Arduino Opta® Analog Expansion** is a plug-and-play extension to the **Opta® PLC Controller** that expands its capabilities with more **inputs** with multiple functions such as digital, analog voltage, analog current or temperature and more **outputs** with analog voltage, analog current and PWM functionalities. Fully compatible with the Arduino Ecosystem.
+The **Arduino Opta® Analog Expansion A0602** is a plug-and-play extension to the **Opta® PLC Controller** that expands its capabilities with more **inputs** with multiple functions such as digital, analog voltage, analog current or temperature and more **outputs** with analog voltage, analog current and PWM functionalities. It is fully compatible with the Arduino ecosystem.

--- a/content/hardware/07.opta/opta-family/opta-digital-exp/features.md
+++ b/content/hardware/07.opta/opta-family/opta-digital-exp/features.md
@@ -1,12 +1,13 @@
 <FeatureDescription>
 
-**Arduino Opta® Digital Expansions** are designed to multiply your Opta® micro PLC capabilities with the addition of 16 programmable inputs for connecting your digital sensors and 8 more relays to operate your machines.
+The **Arduino Opta® Digital Expansion D1608E** and the **Arduino Opta® Digital Expansion D1608S** are designed to multiply your Opta® micro PLC capabilities with the addition of 16 programmable inputs for connecting your digital sensors and 8 more relays to operate your machines.
 
 Designed in partnership with leading relay manufacturer Finder®, it allows professionals to scale up industrial and building automation projects while taking advantage of the Arduino ecosystem.
 
-Arduino Opta® Digital Expansion is available in two variants:
-* AFX00005 - Arduino Opta® Ext D1608E: Electromechanical Relay outputs
-* AFX00006 - Arduino Opta® Ext D1608S: Solid State Relay outputs
+Arduino Opta® Digital Expansions are available in two variants:
+
+* AFX00005 - Arduino Opta® Ext D1608E: Electromechanical relay outputs
+* AFX00006 - Arduino Opta® Ext D1608S: Solid State relay outputs
 
 </FeatureDescription>
 

--- a/content/hardware/07.opta/opta-family/opta-digital-exp/product.md
+++ b/content/hardware/07.opta/opta-family/opta-digital-exp/product.md
@@ -1,5 +1,5 @@
 ---
-title: Opta Digital Expansion
+title: Opta Digital Expansion D1608E and D1608S
 url_shop: https://store.arduino.cc/collections/pro-family
 url_guide: /tutorials/opta-digital-exp/user-manual
 primary_button_url: /tutorials/opta/user-manual#opta-digital-expansions
@@ -10,4 +10,4 @@ core: arduino:mbed_opta
 certifications: [FCC, CE, UKCA]
 ---
 
-The **Arduino Opta® Digital Expansion** is a plug-and-play extension to the **Opta® PLC Controller** that expands its capabilities with more inputs and outputs. Two variants are available: the AFX00005 - Opta Ext D1608E (with Electromechanical Relays) and the AFX00006 - Opta Ext D1608S (with Solid State Relays), both of them fully compatible with the Arduino Ecosystem.
+The **Arduino Opta® Digital Expansion D1608E** and the **Arduino Opta® Digital Expansion D1608S** are plug-and-play extensions for the Opta® PLC controller, designed to enhance its functionality with additional inputs and outputs. These expansions come in two variants: the AFX00005 - Opta Ext D1608E (with electromechanical relays) and the AFX00006 - Opta Ext D1608S (with solid state relays), both fully compatible with the Arduino ecosystem.

--- a/content/hardware/07.opta/opta-family/opta-digital-exp/product.md
+++ b/content/hardware/07.opta/opta-family/opta-digital-exp/product.md
@@ -1,5 +1,5 @@
 ---
-title: Opta Digital Expansion D1608E and D1608S
+title: Opta Digital Expansion D1608E - D1608S
 url_shop: https://store.arduino.cc/collections/pro-family
 url_guide: /tutorials/opta-digital-exp/user-manual
 primary_button_url: /tutorials/opta/user-manual#opta-digital-expansions


### PR DESCRIPTION
## What This PR Changes
- This PR aligns the Opta Analog and Digital Expansions name in the Arduino Store and Docs.

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
