### PR TITLE
[PC-1976] Edge Control datasheet visibility issue fix try

### DIFF
--- a/content/hardware/05.pro-solutions/solutions-and-kits/edge-control/datasheet/datasheet.md
+++ b/content/hardware/05.pro-solutions/solutions-and-kits/edge-control/datasheet/datasheet.md
@@ -2,7 +2,6 @@
 identifier: AKX00034
 title: Arduino® Edge Control
 hardwareRevision: Rev 2
-isDraft: true
 type: pro
 ---
 


### PR DESCRIPTION
## What This PR Changes
- The datasheet was set as a draft, eliminating this setting to check if it appears.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
