### PR TITLE
Update quick access link for library

### DIFF
--- a/content/programming/02.libraries/libraries.md
+++ b/content/programming/02.libraries/libraries.md
@@ -15,7 +15,7 @@ links:
     },
     {
       title: "LiquidCrystal I2C",
-      url: https://docs.arduino.cc/libraries/liquidcrystal-i2c//
+      url: https://docs.arduino.cc/libraries/liquidcrystal-i2c/
     },
     { title: "WiFi", url: https://docs.arduino.cc/libraries/wifi/ },
     { title: "SD", url: https://docs.arduino.cc/libraries/sd/ },

--- a/content/programming/02.libraries/libraries.md
+++ b/content/programming/02.libraries/libraries.md
@@ -7,21 +7,21 @@ links:
   [
     {
       title: "LiquidCrystal",
-      url: https://docs.arduino.cc/libraries/LiquidCrystal/
+      url: https://docs.arduino.cc/libraries/liquidcrystal/
     },
     {
       title: "Servo",
-      url: https://docs.arduino.cc/libraries/Servo/,
+      url: https://docs.arduino.cc/libraries/servo/,
     },
     {
       title: "LiquidCrystal I2C",
-      url: https://docs.arduino.cc/libraries/LiquidCrystal%20I2C/
+      url: https://docs.arduino.cc/libraries/liquidcrystal-i2c//
     },
-    { title: "WiFi", url: https://docs.arduino.cc/libraries/WiFi/ },
-    { title: "SD", url: https://docs.arduino.cc/libraries/SD/ },
+    { title: "WiFi", url: https://docs.arduino.cc/libraries/wifi/ },
+    { title: "SD", url: https://docs.arduino.cc/libraries/sd/ },
     {
       title: "Stepper",
-      url: https://docs.arduino.cc/libraries/Stepper/,
+      url: https://docs.arduino.cc/libraries/stepper/,
     },
   ]
 ---


### PR DESCRIPTION
## What This PR Changes
Quick access link on programming page was broken. Now they are using the correct slug