### PR TITLE
Remove outdated license text in cores.md

### DIFF
--- a/content/learn/01.starting-guide/07.cores/cores.md
+++ b/content/learn/01.starting-guide/07.cores/cores.md
@@ -41,6 +41,3 @@ If you have more JSON files to add, click on the little icon on the right of the
 ![](./assets/Core_MoreJsons.png)
 
 After this procedure, the new cores will be available for install in the Boards Manager. Please refer to the information provided by the third party core author to get more specific instructions.
-
-The text of the Arduino getting started guide is licensed under a
-[Creative Commons Attribution-ShareAlike 3.0 License](http://creativecommons.org/licenses/by-sa/3.0/). Code samples in the guide are released into the public domain.


### PR DESCRIPTION
## What This PR Changes
- License information is part of the webpage footer:
![image](https://github.com/user-attachments/assets/bc7982a4-947a-4256-a9ce-8240f37898a4)
- This text is redundant.
- Having this as a part of the md has also led to it becoming outdated.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
