### PR TITLE
Restore schematics path

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Copy Static Files
         run: |
           mkdir -p static/resources/schematics static/resources/pinouts static/resources/models
+          find ./content/hardware -type f -name "*-schematics.pdf" -exec cp {} ./static/resources/schematics/ \;
           find ./content/hardware -type f -name "*-full-pinout.pdf" -exec cp {} ./static/resources/pinouts/ \;
           find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
           find ./content/hardware -type f -name "*-step.zip" -exec cp {} ./static/resources/models/ \;

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Copy Static Files
         run: |
           mkdir -p static/resources/schematics static/resources/pinouts static/resources/models
+          find ./content/hardware -type f -name "*-schematics.pdf" -exec cp {} ./static/resources/schematics/ \;
           find ./content/hardware -type f -name "*-full-pinout.pdf" -exec cp {} ./static/resources/pinouts/ \;
           find ./content/hardware -type f -name "*-pinout.png" -exec cp {} ./static/resources/pinouts/ \;
           find ./content/hardware -type f -name "*-step.zip" -exec cp {} ./static/resources/models/ \;


### PR DESCRIPTION
Somewhen we lost the line moving schematics PDFs to a well-known path, this PR is restoring it

Existing schematics were unaffected by deployments since their URL is static