### PR TITLE
Fixed grammatical error in led-matrix.md

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/led-matrix/led-matrix.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/led-matrix/led-matrix.md
@@ -426,7 +426,7 @@ The available animations are:
 ## Animation Generation
 We have developed a tool that is used to generate frames and animations to be rendered on the LED Matrix in your browser. This tool is part of [Arduino labs](https://labs.arduino.cc), and is therefore considered experimental software. 
 
-To use the tool you need to upload the following sketch, allowing the board to read serial inputs send by the browser. 
+To use the tool you need to upload the following sketch, allowing the board to read serial inputs sent by the browser. 
 
 You can also find the sketch in **File > Examples > LED_Matrix > LivePreview**
 
@@ -459,7 +459,7 @@ void loop() {
 
 ![LED Matrix Editor](assets/led-matrix-tool.png)
 
-Once you've made your animations, you can export them from the tool in the format that lets you use them like [previously discussed](#how-to-write-a-frame).
+Once you've made your animations, you can export them from the tool in the format that lets you use them as [previously discussed](#how-to-write-a-frame).
 
 You can find more tips on how to use this tool on [its site](https://ledmatrix-editor.arduino.cc).
 


### PR DESCRIPTION


## What This PR Changes
- Grammatical error.
- Replaced "like" with "as" - too informal

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
