### PR TITLE
fix typo, it said sawtooth, it should say sine

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/dac/dac.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/dac/dac.md
@@ -46,7 +46,7 @@ For example when dimming an LED, you can freely use a PWM enabled digital pin as
 However this will not always be the case, and for many uses you will need to use a genuine analog output to get your desired results. One such case is in audio purposes, where a PWM output simply will not give the same quality of sound as a genuine analog output, and requires some fiddling to work in the first place.
 
 ## Code
-The code for this tutorial is split in two parts, one main sketch and a header file containing a pre-generated sawtooth-waveform.
+The code for this tutorial is split in two parts, one main sketch and a header file containing a pre-generated sine waveform.
 
 With this sketch, we have pre-generated a sine waveform. You could also dynamically generate it either at the beginning of your sketch or during, but doing so would be less efficient without gaining any performance. So going this route is the best practice. 
 


### PR DESCRIPTION
later in the tutorial the sawtooth wave is used.

## What This PR Changes
- it changes a mention of sawtooth wave, for sine wave, which is what it meant, it was a typo.

## Contribution Guidelines
- [ X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
