### PR TITLE
[MNE-45] Add Nano ESP32 Version Info

### DIFF
--- a/content/hardware/03.nano/boards/nano-esp32/features.md
+++ b/content/hardware/03.nano/boards/nano-esp32/features.md
@@ -24,10 +24,10 @@ This board is Bluetooth® enabled allowing you to control peripheral devices and
 </Feature>
 
 <Feature title="ESP32 Platform" image="mcu">
-The Nano ESP32's Board Package is based on the well maintained & documented <a href="https://github.com/espressif/arduino-esp32">ESP32 core</a> from Espressif.
-<FeatureWrapper>
-  <FeatureLink variant="secondary" title="ESP32 Documentation" url="https://docs.espressif.com/projects/arduino-esp32/en/latest/"/>
-</FeatureWrapper>
+  The Nano ESP32's Board Package is based on the well-maintained & documented <a href="https://github.com/espressif/arduino-esp32">ESP32 core</a> from Espressif, specifically using the 2.x branch with ESP-IDF version v5.1.4.
+  <FeatureWrapper>
+    <FeatureLink variant="secondary" title="ESP32 Documentation" url="https://docs.espressif.com/projects/arduino-esp32/en/latest/"/>
+  </FeatureWrapper>
 </Feature>
 
 <Feature title="USB-C®" image="usb">

--- a/content/hardware/03.nano/boards/nano-esp32/tutorials/esp-now/esp-now.md
+++ b/content/hardware/03.nano/boards/nano-esp32/tutorials/esp-now/esp-now.md
@@ -11,6 +11,8 @@ tags: [ESP32, Debugging, IDE]
 
 ESP-NOW is a wireless communication protocol developed by Espressif, the company behind the ESP32 microcontroller (MCU). Since the Arduino Nano ESP32 is equipped with that MCU it also supports the ESP-NOW protocol out of the box. It's designed for efficient and low-latency communication between devices, capable of sending up to 250 bytes.
 
+***Note: The Nano ESP32 utilizes the Arduino ESP32 Boards core based on the 2.x branch of the arduino-esp32 core, leveraging ESP-IDF version [v5.1.4](https://docs.espressif.com/projects/esp-idf/en/v5.1.4/esp32/api-reference/network/esp_now.html). Please be aware that functions and features may differ between versions, so ensure you reference the correct documentation for this setup.***
+
 ## Hardware Requirements
 
 ESP-NOW is supported on the following microcontrollers: 

--- a/content/hardware/03.nano/boards/nano-esp32/tutorials/getting-started-nano-esp32/getting-started-nano-esp32.md
+++ b/content/hardware/03.nano/boards/nano-esp32/tutorials/getting-started-nano-esp32/getting-started-nano-esp32.md
@@ -11,6 +11,8 @@ To use the [Arduino Nano ESP32](/hardware/nano-esp32) board, you will need to in
 
 To install it, you will need the Arduino IDE, which you can download from the [Arduino Software page](https://www.arduino.cc/en/software). In this guide, we will use the latest version of the IDE 2.
 
+***Note: The Nano ESP32 utilizes the Arduino ESP32 Boards core based on the 2.x branch of the arduino-esp32 core, leveraging ESP-IDF version v5.1.4. Please be aware that functions and features may differ between versions, so ensure you reference the correct documentation for this setup.***
+
 ## Software & Hardware Needed
 
 - [Arduino Nano ESP32](https://store.arduino.cc/nano-esp32)


### PR DESCRIPTION
## What This PR Changes
This PR adds notes informing users about the version the Arduino Nano ESP32 core is based on, and highlights the fact that users need to make sure to use the correct version when referencing espressifs documentation.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
