### PR TITLE
Pipe Characters added to Logical OR section in reference.md

### DIFF
--- a/content/learn/03.programming/00.reference/reference.md
+++ b/content/learn/03.programming/00.reference/reference.md
@@ -352,7 +352,7 @@ Compact version of the [Arduino Language Reference](https://www.arduino.cc/refer
 | ------------------ | ------------------------------------------------------------------ |
 | `! (logical not)`  | Inverts the logical value, true becomes false and vice versa.      |
 | `&& (logical and)` | Logical AND operator, returns true if both operands are true.      |
-| `&#124;&#124;(logical or)`     | Logical OR operator, returns true if at least one operand is true. |
+| `\|\|(logical or)`     | Logical OR operator, returns true if at least one operand is true. |
 
 
 ### Pointer Access Operators

--- a/content/learn/03.programming/00.reference/reference.md
+++ b/content/learn/03.programming/00.reference/reference.md
@@ -352,7 +352,7 @@ Compact version of the [Arduino Language Reference](https://www.arduino.cc/refer
 | ------------------ | ------------------------------------------------------------------ |
 | `! (logical not)`  | Inverts the logical value, true becomes false and vice versa.      |
 | `&& (logical and)` | Logical AND operator, returns true if both operands are true.      |
-| `\|\|(logical or)`     | Logical OR operator, returns true if at least one operand is true. |
+| `\|\| (logical or)`| Logical OR operator, returns true if at least one operand is true. |
 
 
 ### Pointer Access Operators

--- a/content/learn/03.programming/00.reference/reference.md
+++ b/content/learn/03.programming/00.reference/reference.md
@@ -352,7 +352,7 @@ Compact version of the [Arduino Language Reference](https://www.arduino.cc/refer
 | ------------------ | ------------------------------------------------------------------ |
 | `! (logical not)`  | Inverts the logical value, true becomes false and vice versa.      |
 | `&& (logical and)` | Logical AND operator, returns true if both operands are true.      |
-| `(logical or)`     | Logical OR operator, returns true if at least one operand is true. |
+| `&#124;&#124;(logical or)`     | Logical OR operator, returns true if at least one operand is true. |
 
 
 ### Pointer Access Operators


### PR DESCRIPTION
## What This PR Changes
In the file "reference.md" the section describing the Logical OR operator was missing the pair of vertical pipe characters.
This merge adds those characters.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
