### PR TITLE
Fixed broken link to LVGL guide

### DIFF
--- a/content/hardware/10.mega/shields/giga-display-shield/tutorials/06.image-orientation/content.md
+++ b/content/hardware/10.mega/shields/giga-display-shield/tutorials/06.image-orientation/content.md
@@ -33,7 +33,7 @@ BoschSensorClass imu(Wire1);
 
 Start receiving IMU readings with `imu.begin();` and start the display with `Display.begin();`.
 
-Then we can assign attributes to the images such as its source, alignment and how the rotation should behave. For more information on image attributes with LVGL, check out our [LVGL tutorial](lvgl-guide#image).
+Then we can assign attributes to the images such as its source, alignment and how the rotation should behave. For more information on image attributes with LVGL, check out our [LVGL tutorial](/tutorials/giga-display-shield/lvgl-guide).
 
 ```arduino
 LV_IMG_DECLARE(img_arduinologo);


### PR DESCRIPTION
## What This PR Changes
- Link to lvgl guide producing 404, updated this link https://docs.arduino.cc/tutorials/giga-display-shield/image-orientation/lvgl-guide to this link https://docs.arduino.cc/tutorials/giga-display-shield/lvgl-guide/

## Contribution Guidelines
- [X ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
