### PR TITLE
[PXCT-368] Fixed nano every clock speed info

### DIFF
--- a/content/hardware/03.nano/boards/nano-every/tech-specs.yml
+++ b/content/hardware/03.nano/boards/nano-every/tech-specs.yml
@@ -17,7 +17,7 @@ Power:
   Input voltage (nominal): 7-21V
   DC Current per I/O Pin: 15 mA
 Clock speed:
-  Processor: ATMega4809 16 MHz
+  Processor: ATMega4809 20 MHz
 Memory:
   ATmega328P: 6KB SRAM, 48KB flash 256 byte EEPROM
 Dimensions:


### PR DESCRIPTION
## What This PR Changes
- Fixed incorrect information about the nano every's clock speed

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
