### PR TITLE
[PXCT-536] Nano Matter - Remove custom board url

### DIFF
--- a/content/hardware/03.nano/boards/nano-matter/tutorials/01.user-manual/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/01.user-manual/content.md
@@ -36,11 +36,7 @@ This user manual will guide you through a practical journey covering the most in
 
 ### Board Core and Libraries
 
-The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **File > Preferences** and in the **Additional boards manager URLs**, add the following:
-
-`https://siliconlabs.github.io/arduino/package_arduinosilabs_index.json`
-
-Now navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
+The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
 
 ![Installing the Silicon Labs core in the Arduino IDE](assets/bsp-install-2.png)
 

--- a/content/hardware/03.nano/boards/nano-matter/tutorials/01.user-manual/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/01.user-manual/content.md
@@ -121,11 +121,7 @@ For low-power consumption applications, the following hacks are recommended:
 
 ### Install Board Core and Libraries
 
-The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **File > Preferences** and in the **Additional boards manager URLs**, add the following:
-
-`https://siliconlabs.github.io/arduino/package_arduinosilabs_index.json`
-
-Now navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
+The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
 
 ![Installing the Silicon Labs core in the Arduino IDE](assets/bsp-install-2.png)
 

--- a/content/hardware/03.nano/boards/nano-matter/tutorials/02.getting-started-matter-display/getting-started-matter-display.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/02.getting-started-matter-display/getting-started-matter-display.md
@@ -86,11 +86,7 @@ We are going to use the Arduino IDE to develop around the Nano Matter Display. F
 
 ### Board Core and Library Installation
 
-The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **File > Preferences** and in the **Additional boards manager URLs**, add the following:
-
-`https://siliconlabs.github.io/arduino/package_arduinosilabs_index.json`
-
-Now navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
+The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
 
 ![Installing the Silicon Labs core in the Arduino IDE](assets/bsp-install-2.png)
 

--- a/content/hardware/03.nano/boards/nano-matter/tutorials/03.matter-fan/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/03.matter-fan/content.md
@@ -55,11 +55,7 @@ Download the complete project code [here](assets/matter_fan.zip).
 
 ### Board Core and Libraries
 
-The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **File > Preferences** and in the **Additional boards manager URLs**, add the following:
-
-`https://siliconlabs.github.io/arduino/package_arduinosilabs_index.json`
-
-Now navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
+The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
 
 ![Installing the Silicon Labs core in the Arduino IDE](assets/bsp-install-2.png)
 

--- a/content/hardware/03.nano/boards/nano-matter/tutorials/04.matter-relay-lightbulb/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/04.matter-relay-lightbulb/content.md
@@ -57,11 +57,7 @@ Download the complete project code [here](assets/matter_smart_relay.zip).
 
 ### Board Core and Libraries
 
-The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **File > Preferences** and in the **Additional boards manager URLs**, add the following:
-
-`https://siliconlabs.github.io/arduino/package_arduinosilabs_index.json`
-
-Now navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
+The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
 
 ![Installing the Silicon Labs core in the Arduino IDE](assets/bsp-install-2.png)
 

--- a/content/hardware/03.nano/boards/nano-matter/tutorials/05.matter-rgb-light/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/05.matter-rgb-light/content.md
@@ -55,11 +55,7 @@ Download the complete project code [here](assets/matter_rgb_light.zip).
 
 ### Board Core and Libraries
 
-The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **File > Preferences** and in the **Additional boards manager URLs**, add the following:
-
-`https://siliconlabs.github.io/arduino/package_arduinosilabs_index.json`
-
-Now navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
+The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
 
 ![Installing the Silicon Labs core in the Arduino IDE](assets/bsp-install-2.png)
 

--- a/content/hardware/03.nano/boards/nano-matter/tutorials/06.matter-temp-sensor/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/06.matter-temp-sensor/content.md
@@ -55,11 +55,7 @@ Download the complete project code [here](assets/matter_temperature_sensor.zip).
 
 ### Board Core and Libraries
 
-The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **File > Preferences** and in the **Additional boards manager URLs**, add the following:
-
-`https://siliconlabs.github.io/arduino/package_arduinosilabs_index.json`
-
-Now navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
+The **Silicon Labs** core contains the libraries and examples you need to work with the board's components, such as its Matter, Bluetooth® Low Energy, and I/Os. To install the Nano Matter core, navigate to **Tools > Board > Boards Manager** or click the Boards Manager icon in the left tab of the IDE. In the Boards Manager tab, search for `Nano Matter` and install the latest `Silicon Labs` core version.
 
 ![Installing the Silicon Labs core in the Arduino IDE](assets/bsp-install-2.png)
 


### PR DESCRIPTION
## What This PR Changes
This PR removes any mentions of the custom board url since the Nano Matter core is now available by default in the Arduino IDE.

Suggestion: Add a getting started guide to maintain all information regarding board installations and first time use in one single place. This way updates don't need to be done to all articles but only to one instead. cc @mcmchris @jcarolinares 

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
