### PR TITLE
Docs -Backend - Datasheet rendering-  config.json file changed to User Manual subtitle instead of Product Reference Manual

### DIFF
--- a/scripts/datasheet-rendering/config.json
+++ b/scripts/datasheet-rendering/config.json
@@ -6,7 +6,7 @@
     "datasheetsFolder" : "datasheets",
     "styleSheetsPath" : "./styles",
     "previousDocumentationFolder" : "previous-documentation",
-    "subtitle" : "Product Reference Manual",
+    "subtitle" : "User Manual",
     "datasheetSuffix": "-datasheet.pdf",
     "identifierPrefix": "SKU"
 }


### PR DESCRIPTION
## What This PR Changes
- Docs -Backend - Datasheet rendering-  config.json file changed to User Manual subtitle instead of Product Reference Manual

This is a change motivated by a request done via Docs PO, PX tasks https://arduino.atlassian.net/browse/PXCT-522 and https://arduino.atlassian.net/browse/PXCT-521 and request https://arduino.slack.com/archives/C021S4WAV2M/p1740127374494499

The change was discussed with Product Experience Responsible. More info via DM. cc @jacobhylen

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
