### PR TITLE
[PXCT-595] Tech Specs changed from wrong A4 to A4 as CS of the SPI library related with the product

### DIFF
--- a/content/hardware/01.mkr/02.shields/mkr-therm-shield/tech-specs.yml
+++ b/content/hardware/01.mkr/02.shields/mkr-therm-shield/tech-specs.yml
@@ -3,7 +3,7 @@ Shield:
   SKU: ASX00012
   Compatibility: MKR
 Communication: SPI and 1-Wire®
-Chip Select Pin (SPI): A3
+Chip Select Pin (SPI): A4
 1-Wire® Pin: D0
 Digital converter: MAX31855
 Connectors:


### PR DESCRIPTION

## What This PR Changes
- Tech Specs changed from wrong A4 to A4 as CS of the SPI library related with the product

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
