### PR TITLE
[PXCT-899] Arduino UNO R4 - Update led-matrix.md

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/led-matrix/led-matrix.md
+++ b/content/hardware/02.hero/boards/uno-r4-wifi/tutorials/led-matrix/led-matrix.md
@@ -83,7 +83,7 @@ byte frame[8][12] = {
 
 This option is simple to understand, because you can see the image in the pattern of the array, and it is easy to edit in runtime. The ones in the array above form a heart, and that's the image you'd see on the screen.
 
-To target an individual pixel you select its address and change the value, remember that you'll need to start counting at 0. So, the following line will target the third pixel from the left and the second from the top, then turn it on:
+To target an individual pixel you select its address and change the value, remember that you'll need to start counting at 0. So, the following line will target the third pixel from the top and the second from the left, then turn it on:
 
 ```arduino
 frame[2][1] = 1;


### PR DESCRIPTION
we are setting the pixel value from the third row and second column in this case frame[2][1] , and not how was writted before

## What This PR Changes
- changes the text explaining the example of the function renderBitmap(frame, 8, 12);

## Contribution Guidelines
- [ x ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
