### PR TITLE
[PXCT-892] Fixed cad file location for GIGA R1 WiFI

### DIFF
--- a/content/hardware/10.mega/boards/giga-r1-wifi/product.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/product.md
@@ -11,5 +11,3 @@ sku: [ABX00063]
 ---
 
 The **GIGA R1 WiFi** is a powerful, feature-packed board with a large amount of GPIOs and dedicated connectors. Based on the [STM32H747XI](/resources/datasheets/stm32h747xi.pdf) micro based on the [Mbed OS](https://os.mbed.com/), the GIGA R1 WiFi features 76 GPIOs, a [dual core processor](/tutorials/giga-r1-wifi/giga-dual-core), [advanced ADC/DAC](/tutorials/giga-r1-wifi/giga-audio) features as well as camera & display connectors. It also has a rich [USB interface](/tutorials/giga-r1-wifi/giga-usb) with support for HID via USB-C® and USBHost (keyboard, mass storage) via a dedicated USB-A connector.
-
-To download the source file for this board, click [this link](https://content.arduino.cc/assets/ABX00063-cad-files.zip).


### PR DESCRIPTION
## What This PR Changes
- Fixed the location of the cad files

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
