### PR TITLE
[PXCT-864] Replaced suggested library for Portenta C33

### DIFF
--- a/content/hardware/04.pro/boards/portenta-c33/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-c33/essentials.md
@@ -1,7 +1,7 @@
 ---
 productsLibrariesMap:
-  - wifi
   - arduinoble
+  - se05x
 ---
 
 <EssentialsColumn title="First Steps">

--- a/content/hardware/04.pro/boards/portenta-c33/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-c33/essentials.md
@@ -1,7 +1,7 @@
 ---
 productsLibrariesMap:
   - arduinoble
-  - se05x
+  - arduino_secureelement
 ---
 
 <EssentialsColumn title="First Steps">


### PR DESCRIPTION
## What This PR Changes
- Replaced the suggested library for Portenta C33, since the wifi library is not listed on the library page, since it is built in to the core, I replaced it with another library that works with the C33

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
