### PR TITLE
[PXCT-865] Changed suggested libraries for Portanta H7 and H7 Lite Connected

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/essentials.md
@@ -1,6 +1,5 @@
 ---
 productsLibrariesMap:
-  - wifi
   - arduinoble
 ---
 

--- a/content/hardware/04.pro/boards/portenta-h7-lite-connected/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-h7-lite-connected/essentials.md
@@ -1,5 +1,6 @@
 ---
 productsLibrariesMap:
+  - arduino_portenta_ota
   - arduinoble
 ---
 

--- a/content/hardware/04.pro/boards/portenta-h7/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-h7/essentials.md
@@ -1,6 +1,6 @@
 ---
 productsLibrariesMap:
-  - wifi
+  - lvgl
   - arduinoble
 ---
 

--- a/content/hardware/04.pro/boards/portenta-h7/essentials.md
+++ b/content/hardware/04.pro/boards/portenta-h7/essentials.md
@@ -1,6 +1,7 @@
 ---
 productsLibrariesMap:
   - lvgl
+  - arduino_portenta_ota
   - arduinoble
 ---
 


### PR DESCRIPTION
## What This PR Changes
- Changed suggested libraries on product pages so it points to libraries that work with the boards

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
