### PR TITLE
Update datasheet link in Getting Started [PXCT-1094]

### DIFF
--- a/content/hardware/02.hero/shields/spe-shield/tutorials/getting-started/spe-getting-started.md
+++ b/content/hardware/02.hero/shields/spe-shield/tutorials/getting-started/spe-getting-started.md
@@ -55,7 +55,7 @@ The full pinout is available below:
 ### Datasheet
 
 The complete datasheet is available and downloadable as PDF from the link below:
-- [Arduino UNO SPE Shield datasheet](../../downloads/ASX00073-datasheet.pdf)
+- [Arduino UNO SPE Shield datasheet](/resources/datasheets/ASX00073-datasheet.pdf)
 
 ### Schematics
 


### PR DESCRIPTION
## What This PR Changes
There was a link in the Getting Started for the UNO SPE Shield to the datasheet that wasn't working. The link was updated to fit the same manner of linking in the GIGA R1 WiFi User Manual.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
