### PR TITLE
Fix dead link in "See Also" section

### DIFF
--- a/content/learn/02.microcontrollers/01.digital-pins/digital-pins.md
+++ b/content/learn/02.microcontrollers/01.digital-pins/digital-pins.md
@@ -46,6 +46,6 @@ Short circuits on Arduino pins, or attempting to run high current devices from t
 
 ### See Also
 
-- [pinMode](https://www.arduino.cc/reference/en/language/functions/digital-io/pinmode/)
+- [pinMode](https://www.arduino.cc/reference/en/language/functions/digital-io/pinMode/)
 - [digitalWrite](https://www.arduino.cc/reference/en/language/functions/digital-io/digitalwrite/)
 - [digitalRead](https://www.arduino.cc/reference/en/language/functions/digital-io/digitalread/)


### PR DESCRIPTION
Fix link

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)
- Fix link in the https://docs.arduino.cc/learn/microcontrollers/digital-pins/ article so it actually redirects to https://docs.arduino.cc/language-reference/en/functions/digital-io/pinMode/ instead of a 404 page.

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
