### PR TITLE
[PXCT-1052] Add Modulino MicroPython library to essentials lists 

### DIFF
--- a/content/hardware/11.accessories/modulino-nodes/modulino-buttons/essentials.md
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-buttons/essentials.md
@@ -1,8 +1,11 @@
-
 <EssentialsColumn title="Suggested Libraries">
 
-<EssentialElement title="Arduino Modulino" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
+<EssentialElement title="Arduino Modulino® Library" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
 This library allows you to communicate with the Arduino Modulino® nodes.
+  </EssentialElement>
+
+<EssentialElement title="Modulino MicroPython Package" type="library" link="https://github.com/arduino/arduino-modulino-mpy">
+This library allows you to communicate with the Arduino Modulino® nodes in MicroPython.
   </EssentialElement>
 
 </EssentialsColumn>

--- a/content/hardware/11.accessories/modulino-nodes/modulino-buzzer/essentials.md
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-buzzer/essentials.md
@@ -1,8 +1,11 @@
-
 <EssentialsColumn title="Suggested Libraries">
 
-<EssentialElement title="Arduino Modulino" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
+<EssentialElement title="Arduino Modulino® Library" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
 This library allows you to communicate with the Arduino Modulino® nodes.
+  </EssentialElement>
+
+<EssentialElement title="Modulino MicroPython Package" type="library" link="https://github.com/arduino/arduino-modulino-mpy">
+This library allows you to communicate with the Arduino Modulino® nodes in MicroPython.
   </EssentialElement>
 
 </EssentialsColumn>

--- a/content/hardware/11.accessories/modulino-nodes/modulino-distance/essentials.md
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-distance/essentials.md
@@ -1,8 +1,11 @@
-
 <EssentialsColumn title="Suggested Libraries">
 
-<EssentialElement title="Arduino Modulino" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
+<EssentialElement title="Arduino Modulino® Library" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
 This library allows you to communicate with the Arduino Modulino® nodes.
+  </EssentialElement>
+
+<EssentialElement title="Modulino MicroPython Package" type="library" link="https://github.com/arduino/arduino-modulino-mpy">
+This library allows you to communicate with the Arduino Modulino® nodes in MicroPython.
   </EssentialElement>
 
 </EssentialsColumn>

--- a/content/hardware/11.accessories/modulino-nodes/modulino-knob/essentials.md
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-knob/essentials.md
@@ -1,8 +1,11 @@
-
 <EssentialsColumn title="Suggested Libraries">
 
-<EssentialElement title="Arduino Modulino" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
+<EssentialElement title="Arduino Modulino® Library" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
 This library allows you to communicate with the Arduino Modulino® nodes.
+  </EssentialElement>
+
+<EssentialElement title="Modulino MicroPython Package" type="library" link="https://github.com/arduino/arduino-modulino-mpy">
+This library allows you to communicate with the Arduino Modulino® nodes in MicroPython.
   </EssentialElement>
 
 </EssentialsColumn>

--- a/content/hardware/11.accessories/modulino-nodes/modulino-movement/essentials.md
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-movement/essentials.md
@@ -1,8 +1,11 @@
-
 <EssentialsColumn title="Suggested Libraries">
 
-<EssentialElement title="Arduino Modulino" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
+<EssentialElement title="Arduino Modulino® Library" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
 This library allows you to communicate with the Arduino Modulino® nodes.
+  </EssentialElement>
+
+<EssentialElement title="Modulino MicroPython Package" type="library" link="https://github.com/arduino/arduino-modulino-mpy">
+This library allows you to communicate with the Arduino Modulino® nodes in MicroPython.
   </EssentialElement>
 
 </EssentialsColumn>

--- a/content/hardware/11.accessories/modulino-nodes/modulino-pixels/essentials.md
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-pixels/essentials.md
@@ -1,8 +1,11 @@
-
 <EssentialsColumn title="Suggested Libraries">
 
-<EssentialElement title="Arduino Modulino" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
+<EssentialElement title="Arduino Modulino® Library" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
 This library allows you to communicate with the Arduino Modulino® nodes.
+  </EssentialElement>
+
+<EssentialElement title="Modulino MicroPython Package" type="library" link="https://github.com/arduino/arduino-modulino-mpy">
+This library allows you to communicate with the Arduino Modulino® nodes in MicroPython.
   </EssentialElement>
 
 </EssentialsColumn>

--- a/content/hardware/11.accessories/modulino-nodes/modulino-thermo/essentials.md
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-thermo/essentials.md
@@ -1,8 +1,11 @@
-
 <EssentialsColumn title="Suggested Libraries">
 
-<EssentialElement title="Arduino Modulino" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
+<EssentialElement title="Arduino Modulino® Library" type="library" link="https://www.arduino.cc/reference/en/libraries/modulino/">
 This library allows you to communicate with the Arduino Modulino® nodes.
+  </EssentialElement>
+
+<EssentialElement title="Modulino MicroPython Package" type="library" link="https://github.com/arduino/arduino-modulino-mpy">
+This library allows you to communicate with the Arduino Modulino® nodes in MicroPython.
   </EssentialElement>
 
 </EssentialsColumn>


### PR DESCRIPTION
Added the Modulino MicroPython Package as a suggested library for all Modulino node essentials pages. Also updated the Arduino Modulino library name for consistency.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
