### PR TITLE
[HWU4M-96[PXCT-929] add link to udev helpcenter article

### DIFF
--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -82,3 +82,5 @@ To enable the Arduino IDE to access the serial port and upload code to your boar
 ```
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", GROUP="plugdev", MODE="0666"
 ```
+
+Make sure you've run the `post_install.sh` script to set the correct udev rules. You can find full instructions and download links in our [Help Center article](https://support.arduino.cc/hc/en-us/articles/9005041052444-Fix-udev-rules-on-Linux) on fixing udev rules.

--- a/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
+++ b/content/software/ide-v2/tutorials/getting-started/01.ide-v2-downloading-and-installing/ide-v2-downloading-and-installing.md
@@ -83,4 +83,4 @@ To enable the Arduino IDE to access the serial port and upload code to your boar
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", GROUP="plugdev", MODE="0666"
 ```
 
-Make sure you've run the `post_install.sh` script to set the correct udev rules. You can find full instructions and download links in our [Help Center article](https://support.arduino.cc/hc/en-us/articles/9005041052444-Fix-udev-rules-on-Linux) on fixing udev rules.
+***Make sure you've run the `post_install.sh` script to set the correct udev rules. You can find full instructions and download links in our [Help Center article](https://support.arduino.cc/hc/en-us/articles/9005041052444-Fix-udev-rules-on-Linux) on fixing udev rules.***


### PR DESCRIPTION
## What This PR Changes
This PR adds a link to the IDE 2 installation article on where to find more information about udev rules in the helpcenter.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
