### PR TITLE
[PXCT-1238] Modulino nodes (all) - Remove Nano classic and Nano Every

### DIFF
--- a/content/hardware/11.accessories/modulino-nodes/modulino-buttons/compatibility.yml
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-buttons/compatibility.yml
@@ -7,11 +7,9 @@ hardware:
   carriers: 
     - nano-connector-carrier
   boards: 
-    - nano
     - nano-33-iot
     - nano-33-ble
     - nano-33-ble-sense
-    - nano-every
     - nano-rp2040-connect
     - nano-esp32
     - nano-matter

--- a/content/hardware/11.accessories/modulino-nodes/modulino-buzzer/compatibility.yml
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-buzzer/compatibility.yml
@@ -7,11 +7,9 @@ hardware:
   carriers: 
     - nano-connector-carrier
   boards: 
-    - nano
     - nano-33-iot
     - nano-33-ble
     - nano-33-ble-sense
-    - nano-every
     - nano-rp2040-connect
     - nano-esp32
     - nano-matter

--- a/content/hardware/11.accessories/modulino-nodes/modulino-distance/compatibility.yml
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-distance/compatibility.yml
@@ -7,11 +7,9 @@ hardware:
   carriers: 
     - nano-connector-carrier
   boards: 
-    - nano
     - nano-33-iot
     - nano-33-ble
     - nano-33-ble-sense
-    - nano-every
     - nano-rp2040-connect
     - nano-esp32
     - nano-matter

--- a/content/hardware/11.accessories/modulino-nodes/modulino-knob/compatibility.yml
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-knob/compatibility.yml
@@ -7,11 +7,9 @@ hardware:
   carriers: 
     - nano-connector-carrier
   boards: 
-    - nano
     - nano-33-iot
     - nano-33-ble
     - nano-33-ble-sense
-    - nano-every
     - nano-rp2040-connect
     - nano-esp32
     - nano-matter

--- a/content/hardware/11.accessories/modulino-nodes/modulino-movement/compatibility.yml
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-movement/compatibility.yml
@@ -7,11 +7,9 @@ hardware:
   carriers: 
     - nano-connector-carrier
   boards: 
-    - nano
     - nano-33-iot
     - nano-33-ble
     - nano-33-ble-sense
-    - nano-every
     - nano-rp2040-connect
     - nano-esp32
     - nano-matter

--- a/content/hardware/11.accessories/modulino-nodes/modulino-pixels/compatibility.yml
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-pixels/compatibility.yml
@@ -7,11 +7,9 @@ hardware:
   carriers: 
     - nano-connector-carrier
   boards: 
-    - nano
     - nano-33-iot
     - nano-33-ble
     - nano-33-ble-sense
-    - nano-every
     - nano-rp2040-connect
     - nano-esp32
     - nano-matter

--- a/content/hardware/11.accessories/modulino-nodes/modulino-thermo/compatibility.yml
+++ b/content/hardware/11.accessories/modulino-nodes/modulino-thermo/compatibility.yml
@@ -7,11 +7,9 @@ hardware:
   carriers: 
     - nano-connector-carrier
   boards: 
-    - nano
     - nano-33-iot
     - nano-33-ble
     - nano-33-ble-sense
-    - nano-every
     - nano-rp2040-connect
     - nano-esp32
     - nano-matter


### PR DESCRIPTION
Updated compatibility.yml files for all modulino accessories to remove 'nano' and 'nano-every' from the supported boards list. This reflects updated hardware compatibility for these modules.

## What This PR Changes
- Nano Classic and Nano Every removed from compatibility on Modulino Nodes
## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
