### PR TITLE
content.md: disable RCP auto-update from sdkconfig.defaults

### DIFF
--- a/content/hardware/03.nano/boards/nano-matter/tutorials/07.open-thread-border-router/content.md
+++ b/content/hardware/03.nano/boards/nano-matter/tutorials/07.open-thread-border-router/content.md
@@ -242,6 +242,14 @@ CONFIG_OPENTHREAD_COMMISSIONER=y
 CONFIG_OPENTHREAD_JOINER=y
 ```
 
+With the same editor, open the 'sdkconfig.defaults' file located in `esp-thread-br/examples/basic_thread_border_router/sdkconfig.defaults` and do the following modifications:
+
+- Disable the default setting for the RCP firmware auto-update verifying this parameter is not set. This setting will otherwise overwrite the line on sdkconfig file during build.
+
+```bash
+# CONFIG_OPENTHREAD_BR_AUTO_UPDATE_RCP=y
+```
+
 - Navigate to `esp-thread-br/examples/basic_thread_border_router/main/esp_ot_config.h`
 
 - Modify the Serial port baud rate to `115200`, the result should look like this:


### PR DESCRIPTION
While following this documentation today, I noticed that it didn't work. ESP32 board complained that it's trying to update RCP and failing to do so.

I noticed that the sdkconfig line for ```CONFIG_OPENTHREAD_BR_AUTO_UPDATE_RCP``` is automatically uncommented / overwritten when running ```idf.py build```. That config is enabled inside sdconfig.defaults file and it seems that build step writes atleast some defaults to sdkconfig.

This commit adds additional step for commenting out that RCP auto update setting from sdkconfig.defaults file as well, which fixed this issue for me.

For context I was following this guide on 9th of August 2025 with POP!_OS 22.04 LTS 64-bit. Fresh git pulls for every step, just as mentioned in the guide.

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
