### PR TITLE
Fix incorrect VCC voltage for nano connector carrier

### DIFF
--- a/content/hardware/03.nano/carriers/nano-connector-carrier/tutorials/getting-started-nano-connector-carrier/content.md
+++ b/content/hardware/03.nano/carriers/nano-connector-carrier/tutorials/getting-started-nano-connector-carrier/content.md
@@ -46,7 +46,7 @@ The Qwiic connector uses a 4-pin JST SH connector (P/N: SM04B-SRSS-TB(LF)(SN)) w
 | Pin | Connection                               |
 |-----|------------------------------------------|
 | GND | Ground                                   |
-| VCC | +3.3 VDC/ +5 VDC (selected by the input selector switch) |
+| VCC | +3.3 VDC |
 | SDA | I²C Data (connected to the A4 pin of the Nano board)   |
 | SCL | I²C Clock (connected to the A5 pin of the Nano board) |
 


### PR DESCRIPTION
Updated VCC voltage specification in the connection table.

## What This PR Changes
- Changes the voltage on the power pin of the Qwiic connector to fixed 3V3. It's always translated to 3V3.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
