### PR TITLE
Fix board reference in USB HID tutorial

### DIFF
--- a/content/hardware/02.hero/boards/uno-r4-minima/tutorials/usb-hid/usb-hid.md
+++ b/content/hardware/02.hero/boards/uno-r4-minima/tutorials/usb-hid/usb-hid.md
@@ -39,7 +39,7 @@ To turn your board into an HID, you can use the **keyboard/mouse** API that is b
 
 ## Sketch Upload Interference
 
-As a consequence of the multi-processor design of the UNO R4 WiFi board, uploads may fail with a "`No device found on ...`" error when the board is running a sketch that uses the HID capabilities.
+As a consequence of the multi-processor design of the UNO R4 Minima board, uploads may fail with a "`No device found on ...`" error when the board is running a sketch that uses the HID capabilities.
 
 For this reason, you should use the following procedure to upload under these conditions:
 


### PR DESCRIPTION


## What This PR Changes
- Even though the tutorial is for the Minima board, it said Wifi board, which might lead to confusion, so i fixed it to make it consistent.

## Contribution Guidelines
- [ X ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
