### PR TITLE
Fix SD.open() for append

### DIFF
--- a/content/hardware/03.nano/carriers/nano-connector-carrier/tutorials/getting-started-nano-connector-carrier/content.md
+++ b/content/hardware/03.nano/carriers/nano-connector-carrier/tutorials/getting-started-nano-connector-carrier/content.md
@@ -471,7 +471,7 @@ void loop() {
     unsigned long currentTime = millis();
     if (currentTime - lastRecordTime >= RECORD_INTERVAL) {
       // Open the file for writing
-      dataFile = SD.open(fileName, FILE_APPEND);
+      dataFile = SD.open(fileName, FILE_WRITE);
       
       if (dataFile) {
         // Write timestamp and movement data to CSV file


### PR DESCRIPTION
## What This PR Changes
The SD.open() method only accepts FILE_READ and FILE_WRITE -- FILE_APPEND is not defined.  FILE_WRITE defaults to seeking to the end of the file and will facilitate an append operation.  Fixes motion logger example.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
