### PR TITLE
Update reference.md

### DIFF
--- a/content/learn/03.programming/00.reference/reference.md
+++ b/content/learn/03.programming/00.reference/reference.md
@@ -352,7 +352,7 @@ Compact version of the [Arduino Language Reference](https://www.arduino.cc/refer
 | ------------------ | ------------------------------------------------------------------ |
 | `! (logical not)`  | Inverts the logical value, true becomes false and vice versa.      |
 | `&& (logical and)` | Logical AND operator, returns true if both operands are true.      |
-| `(logical or)`     | Logical OR operator, returns true if at least one operand is true. |
+| `|| (logical or)`  | Logical OR operator, returns true if at least one operand is true. |
 
 
 ### Pointer Access Operators


### PR DESCRIPTION
Added the local or operator symbol to the table, it wasn't there for some reason.

## What This PR Changes
- Added `||` to the logical or operator reference.

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
