### PR TITLE
Update digital-pins.md

### DIFF
--- a/content/learn/02.microcontrollers/01.digital-pins/digital-pins.md
+++ b/content/learn/02.microcontrollers/01.digital-pins/digital-pins.md
@@ -46,6 +46,6 @@ Short circuits on Arduino pins, or attempting to run high current devices from t
 
 ### See Also
 
-- [pinMode](https://www.arduino.cc/reference/en/language/functions/digital-io/pinmode/)
+- [pinMode](https://www.arduino.cc/reference/en/language/functions/digital-io/pinMode/)
 - [digitalWrite](https://www.arduino.cc/reference/en/language/functions/digital-io/digitalwrite/)
 - [digitalRead](https://www.arduino.cc/reference/en/language/functions/digital-io/digitalread/)


### PR DESCRIPTION
Fixed broken pinMode() link in 'See Also' section.

## What This PR Changes
- The pinMode() Link in the See Also section linked to 'pinmode' instead of 'pinMode' leading to a 404 page.

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
