### PR TITLE
Change spelling of Electric Potention to  Electric Potential variable…

### DIFF
--- a/content/arduino-cloud/03.cloud-interface/02.variables/variables.md
+++ b/content/arduino-cloud/03.cloud-interface/02.variables/variables.md
@@ -175,7 +175,7 @@ You can use them just like a normal variable of the wrapped type since they supp
 | Counter              | `CloudCounter variableName;`             | `int`             |
 | Data Rate            | `CloudDataRate variableName;`            | `float`           |
 | Electric Current     | `CloudElectricCurrent variableName;`     | `float`           |
-| Electric Potention   | `CloudElectricPotention variableName;`   | `float`           |
+| Electric Potential   | `CloudElectricPotential variableName;`   | `float`           |
 | Electric Resistance  | `CloudElectricResistance variableName;`  | `float`           |
 | Energy               | `CloudEnergy variableName;`              | `float`           |
 | Flow Rate            | `CloudFlowRate variableName;`            | `float`           |


### PR DESCRIPTION
… name

The specialized type listed Electric Potention, I believe should be Electric Potential?  

When selecting cloud variables in the Arduino Cloud, it is listed Electric Potential.

## What This PR Changes
- There is a difference between the spelling in the chart, and in the Arduino Cloud.  I changed Electric Potention to Electric Potential to match the wording in the Arduino Cloud when selecting the specialized data type.

## Contribution Guidelines
- [x ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
