### PR TITLE
[PXCT-1423] Nano Connector Carrier - incorrect Qwiic VCC information in User Manual

### DIFF
--- a/content/hardware/03.nano/carriers/nano-connector-carrier/tutorials/getting-started-nano-connector-carrier/content.md
+++ b/content/hardware/03.nano/carriers/nano-connector-carrier/tutorials/getting-started-nano-connector-carrier/content.md
@@ -65,7 +65,7 @@ The Grove connector uses a 4-pin DIP-2.0 mm connector (P/N: 114020164) with four
 | Pin | Connection                           |
 |-----|--------------------------------------|
 | GND | Ground                               |
-| VCC | VCC |
+| VCC | +3.3 VDC/ +5 VDC (selected by the input selector switch) |
 | A3  | Analog pin A3 on the Nano board|
 | A2  | Analog pin A2 on the Nano board|
 
@@ -74,7 +74,7 @@ The Grove connector uses a 4-pin DIP-2.0 mm connector (P/N: 114020164) with four
 | Pin | Connection                           |
 |-----|--------------------------------------|
 | GND | Ground                               |
-| VCC | VCC |
+| VCC | +3.3 VDC/ +5 VDC (selected by the input selector switch) |
 | A1  | Analog pin A1 on the Nano board|
 | A0  | Analog pin A0 on the Nano board|
 
@@ -83,7 +83,7 @@ The Grove connector uses a 4-pin DIP-2.0 mm connector (P/N: 114020164) with four
 | Pin  | Connection                           |
 |------|--------------------------------------|
 | GND  | Ground                               |
-| VCC | VCC |
+| VCC | +3.3 VDC/ +5 VDC (selected by the input selector switch) |
 | MOSI | SPI MOSI (D11 pin on the Nano board)|
 | MISO | SPI MISO (D12 pin on the Nano board)|
 
@@ -92,7 +92,7 @@ The Grove connector uses a 4-pin DIP-2.0 mm connector (P/N: 114020164) with four
 | Pin | Connection                           |
 |-----|--------------------------------------|
 | GND | Ground                               |
-| VCC | +3.3 VDC |
+| VCC | +3.3 VDC/ +5 VDC (selected by the input selector switch) |
 | SDA | I²C Data (A4 pin on the Nano board, shared with the Qwiic connector) |
 | SCL | I²C Clock (A5 pin on the Nano board, shared with the Qwiic connector)|
 


### PR DESCRIPTION
## What This PR Changes
- Fixed incorrect Qwiic VCC information in User Manual

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
