### PR TITLE
docs: Add missing read() method documentation to I2S library

### DIFF
--- a/content/learn/07.built-in-libraries/02.i2s/i2s.md
+++ b/content/learn/07.built-in-libraries/02.i2s/i2s.md
@@ -110,6 +110,36 @@ None
 #### Returns
 The next sample of incoming I2S data available (or 0 if no data is available)
 
+
+### `read()`
+
+#### Description
+
+Reads incoming I2S data from the I2S interface. This method reads and removes the next sample of incoming I2S data available from the internal I2S buffer. read() inherits from the Stream utility class.
+
+#### Syntax
+
+```
+I2S.read()
+```
+
+```
+I2S.read(buffer, length)
+```
+
+#### Parameters
+
+None (for single sample read)
+
+buffer: an array to read data into
+
+length: the number of samples to read
+
+#### Returns
+
+The first sample of incoming I2S data available (or -1 if no data is available) - int
+
+For buffer read: the number of samples read into the buffer
 ### `write()`
 
 #### Description


### PR DESCRIPTION
Fixes #2583

Added comprehensive documentation for the read() method in the I2S library.

The read() method was being used in examples but was not documented in the API reference. This commit adds:
- Method description
- Two syntax variants (single sample and buffer read)
- Parameter documentation
- Return value documentation

This resolves the issue where users could not find documentation for the read() method despite it being used in code examples.

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
