### PR TITLE
[PXCT-1529] UNO Q documentation to include Arduino Router details

### DIFF
--- a/content/hardware/02.uno/boards/uno-q/tutorials/01.user-manual/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/01.user-manual/content.md
@@ -799,7 +799,7 @@ While the `Bridge` library is what you use in your code, the Router is the traff
 
   **Linux ↔ Linux:** You can use the Router to bridge different applications running on the MPU. For example, a Python script can expose an RPC function that another Python® or C++ application calls directly, allowing services to exchange data without involving the MCU at all.
 
-- **Service Discovery:** Clients (like your Python script or the MCU Sketch) "register" functions they want to expose. The Router keeps a directory of these functions and routes calls to the correct destination.
+- **Service Discovery:** Clients (like your Python® script or the MCU Sketch) "register" functions they want to expose. The Router keeps a directory of these functions and routes calls to the correct destination.
 
 **Managing the Router Service**
 


### PR DESCRIPTION
## What This PR Changes
- UNO Q documentation to include Arduino Router details

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
