### PR TITLE
[PXCT-1579] Nesso N1 - cloud updates

### DIFF
--- a/content/hardware/09.kits/maker/nesso-n1/tutorials/user-manual/content.md
+++ b/content/hardware/09.kits/maker/nesso-n1/tutorials/user-manual/content.md
@@ -153,7 +153,7 @@ Because "Manual Devices" do not automatically generate a downloadable sketch, yo
     WiFiConnectionHandler ArduinoIoTPreferredConnection(SECRET_WIFI_SSID, SECRET_WIFI_PASS);
 
     void initProperties(){
-      ArduinoCloud.addProperty(led, READWRITE, ON_CHANGE, onLedChange);
+      ArduinoCloud.addProperty(led, Permission::ReadWrite).onUpdate(onLedChange);
       
       ArduinoCloud.setBoardId(SECRET_DEVICE_ID);
       ArduinoCloud.setSecretDeviceKey(SECRET_DEVICE_KEY);


### PR DESCRIPTION
## Summary
This PR updates the Nesso N1 user manual to clarify that currently the board can be programmed with the desktop Arduino IDE, is compatible with Arduino IoT Cloud as a Manual Device, and is not yet supported by the Arduino Cloud Editor.

## What changed
* Software requirements
  * Removed Arduino Cloud Editor as a supported environment.
  * Clarified that Arduino IDE is required, version 2.0 or higher recommended.
  * Specified that the ESP32 boards core by Espressif must be version 3.3.3 or newer.

* Installation section
  * Updated wording to state that Nesso N1 is programmed through the desktop Arduino IDE.
  * Clarified that support for Nesso N1 requires ESP32 core version 3.3.3 or newer.
  * Adjusted Boards Manager steps to mention Install or Update and selecting Arduino Nesso N1 from the esp32 menu.

* Cloud Editor section
  * Replaced the previous description with a clear note that Nesso N1 is not yet supported in the Arduino Cloud Editor.
  * Instructed users to use the desktop Arduino IDE to compile and upload sketches.

* Arduino IoT Cloud section
  * Added a guide for using Nesso N1 with Arduino IoT Cloud as a Manual Device.
  * Described the flow to create a Manual Device, set up a Thing and Cloud variables, copy the generated sketch into the Arduino IDE, configure credentials in thingProperties.h, and upload using the Arduino Nesso N1 board.