### PR TITLE
[PXCT-1605] Portenta C33: Compatibility Update

### DIFF
--- a/content/hardware/04.pro/boards/portenta-c33/compatibility.yml
+++ b/content/hardware/04.pro/boards/portenta-c33/compatibility.yml
@@ -10,7 +10,7 @@ hardware:
     - nicla-vision
   shields:
     - portenta-vision-shield
-    - portenta-cat-m1-nb-iot-gnss-shield
+    #- portenta-cat-m1-nb-iot-gnss-shield
   carriers:
     - portenta-breakout
     - portenta-max-carrier


### PR DESCRIPTION
## What This PR Changes
- Updates compatibility list of the Portenta C33 regarding  Cat. M1/NB IoT GNSS shield

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
