### PR TITLE
Update gps-nmea-data-101.md (serial protocol)

### DIFF
--- a/content/learn/05.communication/04.gps-nmea-data-101/gps-nmea-data-101.md
+++ b/content/learn/05.communication/04.gps-nmea-data-101/gps-nmea-data-101.md
@@ -29,7 +29,7 @@ The NMEA 0183 is a simple messaging protocol where **data in this messaging prot
 * Baud rate: 4800 bauds.
 * Data bits: 8.
 * Parity: none.
-* Stop bit: none.
+* Stop bit: 1.
 
 NMEA 0183 "talkers" can be, for example, a satellite, a depth sounder, or a compass, while the "listeners" can be a chart-plotter, a radar or a GPS receiver like the one used in the [Arduino MKR GPS Shield](https://store.arduino.cc/products/arduino-mkr-gps-shield). 
 


### PR DESCRIPTION
changed number of stop bits from 'none' to '1'. In an asynchronous data transfer (UART) a receiver always needs at least one stop bit.

## What This PR Changes
- (Please explain here why you created the pull request and specify what it changes)

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
