### PR TITLE
[PXCT-1536] Uno Q - network mode fixes

### DIFF
--- a/content/hardware/02.uno/boards/uno-q/tutorials/01.user-manual/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/01.user-manual/content.md
@@ -133,8 +133,7 @@ Network Mode relies on **local network discovery (mDNS)** to automatically find 
 
 **Troubleshooting Discovery Issues**
 
-*   **Windows Users:** When launching Arduino App Lab for the first time, you may receive a prompt from Windows Defender (or other security software) regarding `mdns-discovery.exe`. You must **allow** this access for the board to be discovered.
-    *   **Note:** The prompt may not appear on systems that have already run Arduino IDE at some point.
+*   **Windows Users:** When launching Arduino App Lab for the first time, you may receive a prompt from Windows Defender (or other security software) regarding `mdns-discovery.exe`. You must **allow** this access for the board to be discovered. *Note: The prompt may not appear on systems that have already run Arduino IDE at some point.*
 *   **Firewall Settings:** If the board does not appear, ensure that your firewall allows traffic on **UDP port 5353**, which is required for mDNS discovery.
 
 **Note**  


### PR DESCRIPTION
## Summary

This PR improves the Arduino UNO Q User Manual by clarifying how Network Mode works in Arduino App Lab and adding essential troubleshooting information.
It explains that Network Mode relies on local network discovery (mDNS) and details specific configuration requirements regarding firewalls and OS security prompts that may prevent automatic discovery.

## What This PR Changes
- Updated the **Network Mode** section to clarify that boards appear only when discoverable via mDNS on the local network
- Added specific troubleshooting steps for **Windows users** regarding the `mdns-discovery.exe` security prompt (including the note that it may not appear if Arduino IDE was previously installed)
- Added technical details regarding firewall configurations (specifically the need to allow traffic on **UDP port 5353**)
- Clarified that IP, SSH, or browser access does not guarantee visibility in Network Mode

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.