### PR TITLE
doc: update giga-r1-wifi sdram tutorial

### DIFF
--- a/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/cheat-sheet/cheat-sheet.md
+++ b/content/hardware/10.mega/boards/giga-r1-wifi/tutorials/cheat-sheet/cheat-sheet.md
@@ -114,10 +114,14 @@ The microcontroller operates on a voltage of 3.3V, applying a higher voltage tha
 
 The **GIGA R1** has 1 MB of SRAM that is internal to the processor, and 8MB of SDRAM which you can access and write to. 
 
-To access the SDRAM you need to use the SDRAM library, include it in your sketch with:
+To access the SDRAM you need to use the SDRAM library, include it in your sketch and initialize with:
 
 ```arduino
 #include "SDRAM.h"
+
+void setup(){
+  SDRAM.begin();
+}
 ```
 
 Before writing to the SDRAM, you need to allocate it, the following code will create an array that reserves 7MB of the SDRAM for you to write to.


### PR DESCRIPTION


## What This PR Changes
- Tutorial was missing the initialization step of SDRAM. It should to be initialized with `SDRAM.begin()` before using it.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
