### PR TITLE
[PXCT-1703]  Nesso N1: fix incorrect I2C addresses in datasheet

### DIFF
--- a/content/hardware/09.kits/maker/nesso-n1/datasheet/datasheet.md
+++ b/content/hardware/09.kits/maker/nesso-n1/datasheet/datasheet.md
@@ -301,7 +301,7 @@ Use the limits below to define the operating environment, thermal margins, and p
 <p style="text-align: justify;">The Qwiic connector shares the main I²C bus with internal peripherals (BMI270 IMU, BQ27220 fuel gauge, touch controller, I/O expander). I²C pull-up resistors are provided on the SDA and SCL lines. Maximum I²C bus speed is 400 kHz (Fast Mode).</p>
 
 <div style="background-color: rgba(0, 170, 228, 0.2); border-left: 6px solid rgba(0, 120, 180, 1); margin: 20px 0; padding: 15px;">
-  <strong>I²C Bus Considerations:</strong> Multiple devices share the same I²C bus. Ensure connected modules use unique I²C addresses to avoid conflicts. The system I²C addresses include: BMI270 (0x68/0x69), BQ27220 (0x55), FT6336U (0x38), PI4IOE5V6408 (0x20/0x21 selectable).
+  <strong>I²C Bus Considerations:</strong> Multiple devices share the same I²C bus. Ensure connected modules use unique I²C addresses to avoid conflicts. The system I²C addresses include: BMI270 (0x68/0x69), BQ27220 (0x55), AW32001A (0x49), FT6336U (0x38), and PI4IOE5V6408 (0x43, 0x44).
 </div>
 
 ### HAT Connector (J4)


### PR DESCRIPTION
## Summary
This PR corrects the listed I2C addresses for the internal components of the Nesso N1 in the datasheet.

## What This PR Changes
- **Corrected PI4IOE5V6408 Addresses:** The datasheet previously listed the I/O expanders as `0x20/0x21`. The actual hardware addresses are `0x43` and `0x44`.
-  **Added AW32001A:** Added the Awinic battery charger IC (`0x49`) to the list of reserved addresses. This device is present on the bus but was missing from the documentation, causing confusion for users performing I2C scans.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
