### PR TITLE
Update UNO Q buy now link

### DIFF
--- a/content/hardware/02.uno/boards/uno-q/product.md
+++ b/content/hardware/02.uno/boards/uno-q/product.md
@@ -1,6 +1,6 @@
 ---
 title: UNO Q
-url_shop: https://store.arduino.cc/products/uno-q
+url_shop: https://www.arduino.cc/product-uno-q/#arduino-uno-q-comes-in-two-versions
 primary_button_url: /tutorials/uno-q/user-manual
 primary_button_title: User Manual
 secondary_button_url: /software/app-lab/tutorials/getting-started/


### PR DESCRIPTION
## What This PR Changes
Updates the link for the buy now button to reflect both 2GB and 4GB versions.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
