### PR TITLE
[PXCT-1708] Nesso N1: Fix modulino lib name

### DIFF
--- a/content/hardware/09.kits/maker/nesso-n1/essentials.md
+++ b/content/hardware/09.kits/maker/nesso-n1/essentials.md
@@ -2,7 +2,7 @@
 productsLibrariesMap:
   - arduino_nesso_n1
   - nimble-arduino
-  - arduino-modulino
+  - arduino_modulino
   - radiolib
   - wire
   - irremote
@@ -10,12 +10,8 @@ productsLibrariesMap:
 
 <EssentialsColumn title="Suggested Libraries">
 
-  <EssentialElement title="Arduino_Nesso_N1" type="library" link="https://docs.arduino.cc/libraries/arduino-nesso-n1">
+  <EssentialElement title="Arduino_Nesso_N1" type="library" link="https://docs.arduino.cc/libraries/arduino_nesso_n1">
     The official library for the Nesso N1, providing a simple interface for battery management, display control, and onboard sensors.
-  </EssentialElement>
-
-  <EssentialElement title="Arduino-Modulino" type="library" link="https://docs.arduino.cc/libraries/arduino-modulino">
-    A simple interface to control the Arduino Modulino family of products via the Qwiic connector.
   </EssentialElement>
 
   <EssentialElement title="Wire" type="library" link="https://www.arduino.cc/reference/en/language/functions/communication/wire/">


### PR DESCRIPTION
## What This PR Changes
- Fix Arduino Modulino Library name in order to be listed correctly within suggested libraries (arduino-modulino -> arduino_modulino).
- Remove arduino modulino library paragraph from external resources section.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
