### PR TITLE
[PXCT-1707] Nesso N1: Fix captions in user manual display section

### DIFF
--- a/content/hardware/09.kits/maker/nesso-n1/tutorials/user-manual/content.md
+++ b/content/hardware/09.kits/maker/nesso-n1/tutorials/user-manual/content.md
@@ -652,7 +652,7 @@ The display and touch features are easily accessed using the `Arduino_Nesso_N1` 
 
 The following example initializes the display using the `NessoDisplay` class and prints a simple text string.
 
-![Display Touch Coordinates](assets/display-example-1.png)
+![Display Text](assets/display-example-1.png)
 
 ```arduino
 #include <Arduino_Nesso_N1.h>
@@ -682,7 +682,7 @@ void loop() {
 
 NessoDisplay inherits from 'M5GFX', you can therefore draw shapes using established methods.
 
-![Display Touch Coordinates](assets/display-example-2.png)
+![Display Shapes](assets/display-example-2.png)
 
 ```arduino
 #include <Arduino_Nesso_N1.h>


### PR DESCRIPTION
## What This PR Changes
Fix 2 wrong images' caption in Nesso N1 user manual's display section.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
