### PR TITLE
[PXCT-1596] Portenta H7: udev Rules Update

### DIFF
--- a/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
+++ b/content/hardware/04.pro/boards/portenta-h7/tutorials/setting-up-portenta/content.md
@@ -21,6 +21,7 @@ software:
 ---
 
 ## Overview
+
 Congratulations on your purchase of one of our most powerful microcontroller boards to date! We know you are eager to try out your new board but before you can start using the Portenta H7 to run Arduino sketches you need to configure your computer and the Arduino IDE. This tutorial teaches you how to set up the board, how to configure your computer and how to run the classic Arduino blink example to verify if the configuration was successful.
 
 One of the benefits of the Portenta H7 is that it supports different types of software cores. A core is the software API for a particular set of processors. It is the API that provides functions such as digitalRead(), analogWrite(), millis() etc. which directly operate on the hardware.
@@ -41,6 +42,7 @@ This tutorial focuses on the Arduino core which allows you to benefit from the t
 - USB-C® cable (either USB-A to USB-C® or USB-C® to USB-C®)
 
 ## Portenta and The Arduino Core
+
 The Portenta H7 is equipped with two Arm Cortex ST processors (Cortex-M4 and Cortex-M7) which run the Mbed OS. Mbed OS is an embedded real time operating system (RTOS) designed specifically for microcontrollers to run IoT applications on low power. A real-time operating system is an operating system designed to run real-time applications that process data as it comes in, typically without buffer delays. [Here you can read more about real time operating systems](https://www.ni.com/en-us/innovations/white-papers/07/what-is-a-real-time-operating-system--rtos--.html).
 
 The Arduino core for the Portenta H7 sits on top of the Mbed OS and allows to develop applications using Mbed OS APIs which handle for example storage, connectivity, security and other hardware interfacing. [Here you can read more about the Mbed OS APIs](https://os.mbed.com/docs/mbed-os/latest/apis/index.html). However, taking advantage of the Arm® Mbed™ real time operating system's powerful features can be a complicated process. Therefore we simplified that process by allowing you to run Arduino sketches on top of it.
@@ -50,23 +52,27 @@ The Arduino core for the Portenta H7 sits on top of the Mbed OS and allows to de
 ## Instructions
 
 ### Configuring the Development Environment
+
 In this section, we will guide you through a step-by-step process of setting up your Portenta board for running an Arduino Sketch that blinks the built-in RGB LED.
 
 ***IMPORTANT: Please make sure to update the bootloader to the most recent version to benefit from the latest improvements. Follow [these steps](https://docs.arduino.cc/tutorials/portenta-h7/updating-the-bootloader/) before you proceed with the next step of this tutorial.***
 
-### 1. The Basic Setup
+### The Basic Setup
+
 Let's begin by Plug-in your Portenta to your computer using the appropriate USB-C® cable. Next, open your IDE and make sure that you have the right version of the Arduino IDE downloaded on to your computer.
 
 ![The Portenta H7 can be connected to the computer using an appropriate USB-C® cable](assets/por_ard_gs_basic_setup.svg)
 
-### 2. Adding the Portenta to the List of Available Boards
+### Adding the Portenta to the List of Available Boards
+
 In your Arduino IDE, open the board manager and search for "portenta". Find the Arduino mbed-enabled Boards library and click on "Install" to install the latest version of the mbed core (1.2.3 at the time of writing this tutorial).
 
 **Note:** If you have previously installed the Nano 33 BLE core it will be updated by following this step.
 
 ![A search for "portenta" reveals the core that needs to be installed to support Portenta H7.](assets/por_ard_gs_bm_core.png)
 
-### 3. Uploading the Classic Blink Sketch
+### Uploading the Classic Blink Sketch
+
 Let's program the Portenta with the classic blink example to check if the connection to the board works. There are two ways to do that:
 
 - In the classic Arduino IDE open the blink example by clicking the menu entry **File > Examples > 01.Basics > Blink**. You need to swap LOW and HIGH pin values as the built-in LED on Portenta is turned on by pulling it LOW.
@@ -95,7 +101,8 @@ For Portenta H7 LED_BUILTIN represents the built-in RGB LED on the board in gree
 
 **Note:** The individual colors of the built-in RGB LED can be accessed and controlled separately. In the tutorial [Dual core processing](https://docs.arduino.cc/tutorials/portenta-h7/dual-core-processing/) you will learn how to control the LED to light it in different colors
 
-### 4. Upload the Blink Sketch 
+### Upload the Blink Sketch 
+
 Now it's time to upload the sketch and see if the LED will start to blink. Make sure you select Arduino Portenta H7 (M7 core) as the board and the port to which the Portenta H7 is connected. If the Portenta H7 doesn't show up in the list of ports, go back to step 1 and make sure that the drivers are installed correctly. Once selected click Upload. Once uploaded the built-in LED should start blinking with an interval of 1 second.
 
 **Note:** The Portenta H7 has an M7 and an M4 processor which run separate cores. That's why you need to select the one to which you want to upload your sketch to (check out the tutorial [Dual core processing](https://docs.arduino.cc/tutorials/portenta-h7/dual-core-processing/) to learn more about Portenta's processors).
@@ -105,22 +112,23 @@ Now it's time to upload the sketch and see if the LED will start to blink. Make 
 **Optional:** We collect all the sketches from the tutorials in a library which you can install from the Library Manager: **Tools > Manage Libraries**. Search for 'Arduino_Pro_Tutorials' or download them from the [repository](https://github.com/arduino-libraries/Arduino_Pro_Tutorials/releases).
 
 ## Conclusion
+
 You have now configured your Portenta board to run Arduino sketches. Along with that you gained an understanding of how the Arduino Core runs on top of Mbed OS.
 
-### Next Steps
--   Proceed with the next tutorial [Dual core processing](https://docs.arduino.cc/tutorials/portenta-h7/dual-core-processing/) to learn how to make use of Portenta H7's two processors to do two separate tasks simultaneously.
--   Read more about why we chose Mbed as as the foundation [here](https://blog.arduino.cc/2019/07/31/why-we-chose-to-build-the-arduino-nano-33-ble-core-on-mbed-os/).
-
 ## Troubleshooting
+
 ### Sketch Upload Troubleshooting
+
 If trying to upload a sketch but you receive an error message, saying that the upload has failed you can try to upload the sketch while the Portenta H7 is in bootloader mode. To do so you need to double click the reset button. The green LED will start fading in and out. Try to upload the sketch again. The green LED will stop fading when the upload completes.
 
 ![Double-clicking the reset button puts the board into bootloader mode.](assets/por_ard_gs_reset.png)
 
 ### USB Hub Issues Troubleshooting
+
 If you would like to use a USB hub to connect other devices to the Portenta make sure it's an active USB hub that can provide power to these devices. Passive hubs won't work. If you're using an active USB hub but still don't get it to work it may be a model that is not supported.
 
 ### Ubuntu Issues Troubleshooting
+
 If you're having troubles getting your Portenta to work on Ubuntu you can try the following:
 
 - Make sure **modemmanager** is not installed. Otherwise remove it with `sudo apt-get remove modemmanager`
@@ -142,3 +150,8 @@ echo 'SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", MODE:="0666"' > 20-portenta.ru
 ```bash
 sudo mv 20-portenta.rules /etc/udev/rules.d/
 ```
+
+## Next Steps
+
+-   Proceed with the next tutorial [Dual core processing](https://docs.arduino.cc/tutorials/portenta-h7/dual-core-processing/) to learn how to make use of Portenta H7's two processors to do two separate tasks simultaneously.
+-   Read more about why we chose Mbed as as the foundation [here](https://blog.arduino.cc/2019/07/31/why-we-chose-to-build-the-arduino-nano-33-ble-core-on-mbed-os/).


### PR DESCRIPTION
## What This PR Changes
- Updates udev rules in the chapter Ubuntu Issues Troubleshooting within Portenta H7
- Original Author & PR: https://github.com/arduino/docs-content/pull/807
- Details from original PR: I have troubled with this problem for 3 month. But after a step by step debug I have found a solution. The two steps with the text for the udev rule were both incorrect and the rule was not applied. You can debug the udev tree with this command: sudo udevadm info -a -p $(udevadm info -q path -n /dev/ttyACM0) (asuming that your device is mounted as /dev/ttyACM0). I am not shure if it is the only page were this suggestion is present. By frigi83
- Present PR brings the [original PR changes from the original Author ](https://github.com/arduino/docs-content/pull/807) on top of the latest version of the branch

## Contribution Guidelines
- [ ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
