### PR TITLE
Add the 2 steps migration

### DIFF
--- a/content/arduino-cloud/02.hardware/06.device-provisioning/content.md
+++ b/content/arduino-cloud/02.hardware/06.device-provisioning/content.md
@@ -143,7 +143,7 @@ Once the steps are completed, the board can be registered on the Arduino IoT Clo
 1. Download the Arduino IoT Cloud CLI (version >= 0.5.0) [here](https://github.com/arduino/arduino-cloud-cli/releases)
 2. Follow the instructions in the “Installation” and “Credentials” section of this [guide](https://docs.arduino.cc/arduino-cloud/arduino-cloud-cli/getting-started/)
 3. Plug-in the board to be migrated
-4. Run the command `arduino-cloud-cli device provisioning --migrate`
+4. Run the command `arduino-cloud-cli device provisioning migrate`
 
 It will take around a minute to complete the procedure and after that the board is ready for the BLE provisioning and it will start pulsing the LED.
 


### PR DESCRIPTION
## What This PR Changes
This PR adds a new method for board migration from Provisioning 1.0 to Provisioning 2.0. The new procedure, only, prepares the board for BLE provisioning, so the user can complete the provisioning in a second step after some time in the future.

## Contribution Guidelines
- [X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
