### PR TITLE
Update stepper-library-examples.md

### DIFF
--- a/content/learn/04.electronics/04.stepper-motors/stepper-library-examples.md
+++ b/content/learn/04.electronics/04.stepper-motors/stepper-library-examples.md
@@ -54,7 +54,7 @@ A stepper motor follows the turns of a potentiometer (or other sensor) on analog
 // create an instance of the stepper class, specifying
 // the number of steps of the motor and the pins it's
 // attached to
-Stepper stepper(STEPS, 8, 9, 10, 11);
+Stepper stepper(STEPS, 8, 10, 9, 11);
 
 // the previous reading from the analog input
 int previous = 0;


### PR DESCRIPTION


## What This PR Changes
Description:
The default Stepper library examples often use the sequence (8, 9, 10, 11). However, for the widely used 28BYJ-48 stepper motor paired with the ULN2003 driver board, this sequence causes vibration without rotation.

Updating the pin definition to (8, 10, 9, 11) correctly sequences the internal coils, ensuring smooth rotation as intended by the tutorial.
## Contribution Guidelines
- [v ] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
