### PR TITLE
Update DC Current per I/O Pin specification

### DIFF
--- a/content/hardware/02.uno/boards/uno-q/tech-specs.yml
+++ b/content/hardware/02.uno/boards/uno-q/tech-specs.yml
@@ -62,7 +62,7 @@ Power:
   USB-C®: +5 VDC max at 3 A to power the board.
   Input voltage (VIN): 7 - 24 VDC
   I/O operating voltage: +3.3 VDC MCU (+5 VDC tolerant) | +1.8 VDC MPU
-  DC Current per I/O Pin: 20 mA (JANALOG and JMEDIA)
+  DC Current per I/O Pin: 20 mA MCU (JDIGITAL, JANALOG, and JMISC)
 Special Connectors:
   Qwiic: Yes, for I2C (3V3)
   JCTL: Yes, MPU Remote Debug connector


### PR DESCRIPTION
## What This PR Changes
- I assume many users of the Arduino Q will be curious of the current limits for the traditional UNO pin footprint.  

Looking at the STM datasheet:
https://www.st.com/resource/en/datasheet/stm32u585ai.pdf

I believe the 20 mA current limit applies to the JDIGITAL pins as well?

I will note, that listing JMEDIA next to the "DC Current per I/O pin:" has me a little unsure.

When I look at the Arduino UNO Q datasheet:
https://docs.arduino.cc/resources/datasheets/ABX00162-ABX00173-datasheet.pdf

I get the impression that JMISC is where I will find some MCU GPIO (Not JMEDIA, which appears to expose MPU pins)

But I may be mistaken.

## Contribution Guidelines
- [ X] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
