### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ content/en
 content/de
 content/pt
 .nvmrc
+.env


### PR DESCRIPTION
## What This PR Changes
- Add `.env` to `.gitignore`

## Motivation

The primary purpose of a .env file is to store sensitive information. It should not be committed to the repository.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.