### PR TITLE
Updating App Lab version in text

### DIFF
--- a/content/hardware/02.uno/boards/uno-q/tutorials/01.user-manual/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/01.user-manual/content.md
@@ -32,7 +32,7 @@ This user manual will guide you through a practical journey covering the most in
 
 ### Software Requirements
 
-- [Arduino App Lab 0.1.23+](https://www.arduino.cc/en/software/#app-lab-section)
+- [Arduino App Lab](https://www.arduino.cc/en/software/#app-lab-section)
 
 ***You can still use the __Arduino IDE 2+__ to program only the microcontroller (MCU) side of your UNO Q.***
 


### PR DESCRIPTION
## What This PR Changes
We don't need to mention the release version of App Lab in the documentation like this anymore. This PR removes this mention from the UNO Q user manual

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
