### PR TITLE
Change Modulino to arduino_modulino in essentials.md

### DIFF
--- a/content/hardware/02.uno/carriers/uno-media-carrier/essentials.md
+++ b/content/hardware/02.uno/carriers/uno-media-carrier/essentials.md
@@ -1,6 +1,6 @@
 ---
 productsLibrariesMap:
-  - Modulino
+  - arduino_modulino
 ---
 
 <EssentialsColumn title="Suggested Libraries">


### PR DESCRIPTION
Updated product name from 'Modulino' to 'arduino_modulino'.


