### PR TITLE
[PXCT-1948] UNO Q: Shutdown Instructions Update

### DIFF
--- a/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
@@ -1180,7 +1180,7 @@ To safely power down your UNO Q for extended storage or when carrying the board,
 sudo halt
 ```
 
-The `sudo halt` command stops all Linux processes and brings the system to a safe halted state. The board remains powered on, but Linux stops running, the screen goes black, and the system becomes unresponsive to network connections.
+The `sudo halt` command stops all Linux processes and brings the system to a safe halted state. The board remains powered on, but Linux stops running and the system becomes unresponsive to network connections.
 
 It is different from a complete power-off but represents a safe state in which all files are properly closed and the filesystem is protected.
 
@@ -1196,7 +1196,13 @@ sudo halt
 
 ![Shutting Down Your UNO Q Safely (1)](assets/debian_shutdown_halt.gif)
 
-After running this command, watch for the screen to go black, indicating the system is in the halt process. Wait approximately 10 seconds after the screen goes black to make sure the halt is complete. The board will remain powered on but in a halted state. Power can then be safely disconnected; the filesystem has closed safely and all processes have stopped.
+After running this command, the shutdown process begins. The visual indicators and timing depend on how you are connected to the board.
+
+If using SBC mode with a display connected to the board, watch for the screen connected to the board to go black, indicating the system is in the halt process. Wait approximately 10 seconds after the screen goes black to make sure the halt is complete. The board will remain powered on but in a halted state. Power can then be safely disconnected, as the filesystem has closed safely and all processes have stopped.
+
+If using PC-hosted mode (USB-C/ADB or SSH connection, no display on board), after running the `sudo halt` command, wait approximately 10-15 seconds to make sure the halt is complete. The board will remain powered on but in a halted state. Power can then be safely disconnected, as the filesystem has closed safely and all processes have stopped.
+
+If using Arduino App Lab, it may return to the `Welcome to Arduino App Lab` board discovery view after the shutdown completes.
 
 The `sudo halt` command is ideal for long-term storage, carrying the board, or any situation where you want the board to stay off until you manually power it back on.
 
@@ -1212,7 +1218,7 @@ If auto-restart happens even with `sudo halt`, the following approaches may help
 
 Make sure the board runs the latest firmware version. Check for updates through Arduino App Lab or refer to the [UNO Q image flash tutorial](https://docs.arduino.cc/tutorials/uno-q/update-image/).
 
-If auto-restart continues after firmware update, you must disconnect the power source immediately after the screen goes black and before the restart sequence begins. This method requires precise timing. A brief window (1-2 seconds) exists after the screen goes black to disconnect power before the system begins its reboot sequence.
+If auto-restart continues after a firmware update, you must disconnect the power source immediately after observing the shutdown indicators mentioned above (the screen goes black in SBC mode or the shell disconnects in PC-hosted mode) and before the restart sequence begins. This method requires precise timing. A brief window of 1 to 2 seconds exists after the shutdown indicator to disconnect power before the system begins its reboot sequence.
 
 Auto-restart behavior can vary depending on the power source. If experiencing issues with a USB-C hub with Power Delivery, alternative options include:
 
@@ -1241,17 +1247,17 @@ With the graphical interface method (SBC mode):
 
 When using any of these methods, the board will perform a clean shutdown and then automatically restart within a few seconds.
 
-If you need to keep the board powered off while using these methods, you must disconnect the power source immediately after the screen goes black and before the restart sequence begins.
+If you need to keep the board powered off while using these methods, you must disconnect the power source immediately after observing the shutdown indicator (the screen goes black in SBC mode or the shell disconnects in PC-hosted mode) and before the restart sequence begins.
 
-The timing is important when using these auto-restart methods. You have only a brief window after the screen goes black to disconnect power safely. If you wait too long, the system will begin its reboot sequence.
+The timing is important when using these auto-restart methods. You have only a brief window after the shutdown indicator to safely disconnect power. If you wait too long, the system will begin its reboot sequence.
 
 In case of power disconnection by the source:
 
-- For boards powered via USB-C®, unplug the USB-C® cable once the screen goes black
-- When using the *VIN* pin for power with a 7-24 VDC input, disconnect your external power supply once the screen goes black
-- If your board receives power from the 5 V pin, disconnect the 5 V power supply once the screen goes black
+- For boards powered via USB-C®, unplug the USB-C® cable once the shutdown indicator happens
+- When using the *VIN* pin for power with a 7-24 VDC input, disconnect your external power supply once the shutdown indicator happens
+- If your board receives power from the 5 V pin, disconnect the 5 V power supply once the shutdown indicator happens
 
-In SBC mode with a USB-C® dongle, disconnect the dongle's power supply after the screen goes black.
+In SBC mode with a USB-C® dongle, disconnect the dongle's power supply after the shutdown indicator happens.
 
 #### Emergency Shutdown & Best Practices
 
@@ -1265,7 +1271,7 @@ For long-term storage or when carrying the board, use the `sudo halt` command to
 sudo halt
 ```
 
-Wait approximately 10 seconds after the screen goes black before disconnecting power.
+Wait approximately 10 seconds after the shutdown indicator (the screen goes black in SBC mode and the shell disconnects in PC-hosted mode) before disconnecting power.
 
 For continuous operation or automated systems where the board runs indefinitely, manual shutdown procedures are not necessary.
 
@@ -1295,7 +1301,7 @@ sudo shutdown now
 sudo poweroff
 ```
 
-Use `sudo halt` to keep the board off. Use the other shutdown methods only if you specifically want the board to restart, or if you are prepared to disconnect power to prevent the automatic restart quickly, given certain application requirements.
+Use `sudo halt` to keep the board off. Use the other shutdown methods only if you specifically want the board to restart, or if you are prepared to disconnect power to prevent the automatic restart, given certain application requirements.
 
 #### Troubleshooting Shutdown Process
 

--- a/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
@@ -1218,7 +1218,11 @@ If auto-restart happens even with `sudo halt`, the following approaches may help
 
 Make sure the board runs the latest firmware version. Check for updates through Arduino App Lab or refer to the [UNO Q image flash tutorial](https://docs.arduino.cc/tutorials/uno-q/update-image/).
 
-If auto-restart continues after a firmware update, you must disconnect the power source immediately after observing the shutdown indicators mentioned above (the screen goes black in SBC mode or the shell disconnects in PC-hosted mode) and before the restart sequence begins. This method requires precise timing. A brief window of 1 to 2 seconds exists after the shutdown indicator to disconnect power before the system begins its reboot sequence.
+If auto-restart continues after a firmware update, you must disconnect the power source immediately after observing the shutdown indicators mentioned above and before the restart sequence begins.
+
+For SBC mode, this means when the screen goes black. For PC-hosted mode, wait 1-2 seconds after running the command.
+
+This method requires precise timing. A brief window of 1 to 2 seconds exists after the shutdown indicator to disconnect power before the system begins its reboot sequence.
 
 Auto-restart behavior can vary depending on the power source. If experiencing issues with a USB-C hub with Power Delivery, alternative options include:
 
@@ -1235,6 +1239,14 @@ sudo shutdown now
 ```
 
 ```bash
+sudo shutdown -h now
+```
+
+```bash
+sudo shutdown -P now
+```
+
+```bash
 sudo poweroff
 ```
 
@@ -1247,17 +1259,17 @@ With the graphical interface method (SBC mode):
 
 When using any of these methods, the board will perform a clean shutdown and then automatically restart within a few seconds.
 
-If you need to keep the board powered off while using these methods, you must disconnect the power source immediately after observing the shutdown indicator (the screen goes black in SBC mode or the shell disconnects in PC-hosted mode) and before the restart sequence begins.
+If you need to keep the board powered off while using these methods, you must disconnect the power source immediately after the shutdown indicator appears and before the restart sequence begins.
 
 The timing is important when using these auto-restart methods. You have only a brief window after the shutdown indicator to safely disconnect power. If you wait too long, the system will begin its reboot sequence.
 
 In case of power disconnection by the source:
 
-- For boards powered via USB-C®, unplug the USB-C® cable once the shutdown indicator happens
-- When using the *VIN* pin for power with a 7-24 VDC input, disconnect your external power supply once the shutdown indicator happens
-- If your board receives power from the 5 V pin, disconnect the 5 V power supply once the shutdown indicator happens
+- For boards powered via USB-C®, unplug the USB-C® cable once the shutdown indicator appears
+- When using the *VIN* pin for power with a 7-24 VDC input, disconnect your external power supply once the shutdown indicator appears
+- If your board receives power from the 5 V pin, disconnect the 5 V power supply once the shutdown indicator appears
 
-In SBC mode with a USB-C® dongle, disconnect the dongle's power supply after the shutdown indicator happens.
+In SBC mode with a USB-C® dongle, disconnect the dongle's power supply after the shutdown indicator appears.
 
 #### Emergency Shutdown & Best Practices
 
@@ -1271,7 +1283,7 @@ For long-term storage or when carrying the board, use the `sudo halt` command to
 sudo halt
 ```
 
-Wait approximately 10 seconds after the shutdown indicator (the screen goes black in SBC mode and the shell disconnects in PC-hosted mode) before disconnecting power.
+For SBC mode, wait approximately 10 seconds after the screen goes black before disconnecting power. For PC-hosted mode, wait approximately 10-15 seconds after running the command before disconnecting power.
 
 For continuous operation or automated systems where the board runs indefinitely, manual shutdown procedures are not necessary.
 
@@ -1295,6 +1307,14 @@ The following commands perform a clean system shutdown, but the board's auto-res
 
 ```bash
 sudo shutdown now
+```
+
+```bash
+sudo shutdown -h now
+```
+
+```bash
+sudo shutdown -P now
 ```
 
 ```bash

--- a/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
@@ -1180,7 +1180,7 @@ To safely power down your UNO Q for extended storage or when carrying the board,
 sudo halt
 ```
 
-The `sudo halt` command stops all Linux processes and brings the system to a safe halted state. The board remains powered on, but Linux stops running, the screen goes black, the green LED turns off, and the system becomes unresponsive to network connections.
+The `sudo halt` command stops all Linux processes and brings the system to a safe halted state. The board remains powered on, but Linux stops running, the screen goes black, and the system becomes unresponsive to network connections.
 
 It is different from a complete power-off but represents a safe state in which all files are properly closed and the filesystem is protected.
 
@@ -1196,11 +1196,11 @@ sudo halt
 
 ![Shutting Down Your UNO Q Safely (1)](assets/debian_shutdown_halt.gif)
 
-The green power LED on the board will turn off when the system has halted completely. The board will remain powered on but in a halted state. Power can be disconnected at any time after the halt completes, the filesystem is already safely closed and all processes have stopped.
+After running this command, watch for the screen to go black, indicating the system is in the halt process. Wait approximately 10 seconds after the screen goes black to make sure the halt is complete. The board will remain powered on but in a halted state. Power can then be safely disconnected; the filesystem has closed safely and all processes have stopped.
 
-This makes `sudo halt` ideal for long-term storage, carrying the board, or any situation where you want the board to stay off until you manually power it back on.
+The `sudo halt` command is ideal for long-term storage, carrying the board, or any situation where you want the board to stay off until you manually power it back on.
 
-***__Note:__ In the halted state, the board will not respond to network connections (SSH, App Lab) and interaction requires a power cycle.***
+***__Note:__ In the halted state, the board will not respond to network connections (SSH, App Lab) and interaction requires a power cycle. The green power LED and LED Matrix may remain on even after the system has halted.***
 
 In some configurations, `sudo halt` may cause the board to restart after a few seconds automatically. This behavior can happen with:
 
@@ -1212,7 +1212,7 @@ If auto-restart happens even with `sudo halt`, the following approaches may help
 
 Make sure the board runs the latest firmware version. Check for updates through Arduino App Lab or refer to the [UNO Q image flash tutorial](https://docs.arduino.cc/tutorials/uno-q/update-image/).
 
-If auto-restart continues after firmware update, you must disconnect the power source immediately after the green LED turns off and before the restart sequence begins. This method requires precise timing. A brief window (1-2 seconds) exists after the LED turns off to disconnect power before the system begins its reboot sequence.
+If auto-restart continues after firmware update, you must disconnect the power source immediately after the screen goes black and before the restart sequence begins. This method requires precise timing. A brief window (1-2 seconds) exists after the screen goes black to disconnect power before the system begins its reboot sequence.
 
 Auto-restart behavior can vary depending on the power source. If experiencing issues with a USB-C hub with Power Delivery, alternative options include:
 
@@ -1241,17 +1241,17 @@ With the graphical interface method (SBC mode):
 
 When using any of these methods, the board will perform a clean shutdown and then automatically restart within a few seconds.
 
-If you need to keep the board powered off while using these methods, you must disconnect the power source immediately after the green LED turns off and before the restart sequence begins.
+If you need to keep the board powered off while using these methods, you must disconnect the power source immediately after the screen goes black and before the restart sequence begins.
 
-The timing is important when using these auto-restart methods. You have only a brief window after the LED turns off to safely disconnect power. If you wait too long, the system will begin its reboot sequence.
+The timing is important when using these auto-restart methods. You have only a brief window after the screen goes black to disconnect power safely. If you wait too long, the system will begin its reboot sequence.
 
 In case of power disconnection by the source:
 
-- For boards powered via USB-C®, unplug the USB-C® cable once the LED turns off
-- When using the *VIN* pin for power with a 7-24 VDC input, disconnect your external power supply at this time
-- If your board receives power from the 5 V pin, disconnect the 5 V power supply when the LED indicator turns off
+- For boards powered via USB-C®, unplug the USB-C® cable once the screen goes black
+- When using the *VIN* pin for power with a 7-24 VDC input, disconnect your external power supply once the screen goes black
+- If your board receives power from the 5 V pin, disconnect the 5 V power supply once the screen goes black
 
-In SBC mode with a USB-C® dongle, disconnect the dongle's power supply after the LED turns off.
+In SBC mode with a USB-C® dongle, disconnect the dongle's power supply after the screen goes black.
 
 #### Emergency Shutdown & Best Practices
 
@@ -1264,6 +1264,8 @@ For long-term storage or when carrying the board, use the `sudo halt` command to
 ```bash
 sudo halt
 ```
+
+Wait approximately 10 seconds after the screen goes black before disconnecting power.
 
 For continuous operation or automated systems where the board runs indefinitely, manual shutdown procedures are not necessary.
 

--- a/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
@@ -1160,7 +1160,7 @@ When in doubt about a command's effect, consult the manual with [**`man <command
 
 ### Shutting Down Your UNO Q Safely
 
-Unlike traditional computers, the UNO Q has auto-restart functionality. When you run standard Linux shutdown commands like:
+Unlike traditional computers, the UNO Q's shutdown behavior can vary depending on firmware version, software configuration and power source. Understanding these variations helps allow safe power-down procedures. When running standard Linux shutdown commands like:
 
 ```bash
 sudo shutdown now
@@ -1180,9 +1180,13 @@ To safely power down your UNO Q for extended storage or when carrying the board,
 sudo halt
 ```
 
+The `sudo halt` command stops all Linux processes and brings the system to a safe halted state. The board remains powered on, but Linux stops running, the screen goes black, the green LED turns off, and the system becomes unresponsive to network connections.
+
+It is different from a complete power-off but represents a safe state in which all files are properly closed and the filesystem is protected.
+
 #### Recommended Shutdown Method
 
-The `halt` command is the recommended approach for safely shutting down your UNO Q. It stops all system processes, brings Linux to a safe state, and keeps the board powered off, preventing an automatic restart.
+The `halt` command is the recommended approach for safely shutting down your UNO Q. It stops all system processes, brings Linux to a safe state, and in most cases with current firmware, keeps the board powered off without triggering an automatic restart.
 
 To shut down your UNO Q properly, run:
 
@@ -1192,9 +1196,29 @@ sudo halt
 
 ![Shutting Down Your UNO Q Safely (1)](assets/debian_shutdown_halt.gif)
 
-The green power LED on the board will turn off when the system has halted completely. The board will remain powered off and will not restart automatically.
+The green power LED on the board will turn off when the system has halted completely. The board will remain powered on but in a halted state. Power can be disconnected at any time after the halt completes, the filesystem is already safely closed and all processes have stopped.
 
 This makes `sudo halt` ideal for long-term storage, carrying the board, or any situation where you want the board to stay off until you manually power it back on.
+
+***__Note:__ In the halted state, the board will not respond to network connections (SSH, App Lab) and interaction requires a power cycle.***
+
+In some configurations, `sudo halt` may cause the board to restart after a few seconds automatically. This behavior can happen with:
+
+- Certain USB-C hubs with Power Delivery capabilities
+- Older firmware versions
+- Specific power source configurations (VIN pin / USB-C / 5V pin)
+
+If auto-restart happens even with `sudo halt`, the following approaches may help solve the issue.
+
+Make sure the board runs the latest firmware version. Check for updates through Arduino App Lab or refer to the [UNO Q image flash tutorial](https://docs.arduino.cc/tutorials/uno-q/update-image/).
+
+If auto-restart continues after firmware update, you must disconnect the power source immediately after the green LED turns off and before the restart sequence begins. This method requires precise timing. A brief window (1-2 seconds) exists after the LED turns off to disconnect power before the system begins its reboot sequence.
+
+Auto-restart behavior can vary depending on the power source. If experiencing issues with a USB-C hub with Power Delivery, alternative options include:
+
+- Direct USB-C connection to computer
+- VIN pin with external 7-24V DC supply
+- Different USB-C hub or power adapter
 
 #### Alternative Shutdown Methods
 
@@ -1253,7 +1277,7 @@ The following command cleanly restarts the system as intended:
 sudo reboot
 ```
 
-The following command safely shuts down the board and keeps it powered off, which is the recommended method for this case:
+The following command safely shuts down the board and, in most configurations, keeps it powered off without auto-restart, which is the recommended method:
 
 ```bash
 sudo halt
@@ -1270,6 +1294,16 @@ sudo poweroff
 ```
 
 Use `sudo halt` to keep the board off. Use the other shutdown methods only if you specifically want the board to restart, or if you are prepared to disconnect power to prevent the automatic restart quickly, given certain application requirements.
+
+#### Troubleshooting Shutdown Process
+
+If unexpected auto-restart behavior continues to happen with `sudo halt`:
+
+- **Verify firmware version:** Check the board runs the latest version
+- **Check system logs:** Run `journalctl -b` after boot to view shutdown/startup logs
+- **Test different power sources:** Compare USB-C direct connection with hub and VIN pin behavior
+
+If the issue persists across firmware versions and power sources, the timing-based power disconnection method provides a reliable alternative.
 
 ## Summary
 

--- a/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
@@ -1186,7 +1186,7 @@ It is different from a complete power-off but represents a safe state in which a
 
 #### Recommended Shutdown Method
 
-The `halt` command is the recommended approach for safely shutting down your UNO Q. It stops all system processes, brings Linux to a safe state, and in most cases with current firmware, keeps the board powered off without triggering an automatic restart.
+The `halt` command is the recommended approach for safely shutting down your UNO Q. It stops all system processes, brings Linux to a safe state, and in most cases with current firmware, keeps the board in that state without triggering an automatic restart.
 
 To shut down your UNO Q properly, run:
 

--- a/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
+++ b/content/hardware/02.uno/boards/uno-q/tutorials/07.debian-guide/content.md
@@ -1174,7 +1174,7 @@ sudo poweroff
 
 The board performs a clean shutdown of the Debian system but automatically restarts shortly after. This behavior is built into the board's power management system.
 
-To safely power down your UNO Q for extended storage or when carrying the board, you need to use a proper command that safely shuts down the board and keeps it powered off:
+To safely power down your UNO Q for extended storage or when carrying the board, you need to use a proper command that safely shuts down the board and keeps it in halted state:
 
 ```bash
 sudo halt
@@ -1204,7 +1204,7 @@ If using PC-hosted mode (USB-C/ADB or SSH connection, no display on board), afte
 
 If using Arduino App Lab, it may return to the `Welcome to Arduino App Lab` board discovery view after the shutdown completes.
 
-The `sudo halt` command is ideal for long-term storage, carrying the board, or any situation where you want the board to stay off until you manually power it back on.
+The `sudo halt` command is ideal for long-term storage, carrying the board, or any situation where you want the board to remain halted until the next power cycle.
 
 ***__Note:__ In the halted state, the board will not respond to network connections (SSH, App Lab) and interaction requires a power cycle. The green power LED and LED Matrix may remain on even after the system has halted.***
 
@@ -1259,7 +1259,7 @@ With the graphical interface method (SBC mode):
 
 When using any of these methods, the board will perform a clean shutdown and then automatically restart within a few seconds.
 
-If you need to keep the board powered off while using these methods, you must disconnect the power source immediately after the shutdown indicator appears and before the restart sequence begins.
+If you need to keep the board in halted state while using these methods, you must disconnect the power source immediately after the shutdown indicator appears and before the restart sequence begins.
 
 The timing is important when using these auto-restart methods. You have only a brief window after the shutdown indicator to safely disconnect power. If you wait too long, the system will begin its reboot sequence.
 
@@ -1297,7 +1297,7 @@ The following command cleanly restarts the system as intended:
 sudo reboot
 ```
 
-The following command safely shuts down the board and, in most configurations, keeps it powered off without auto-restart, which is the recommended method:
+The following command safely shuts down the board and, in most configurations, keeps it in halted state without auto-restart, which is the recommended method:
 
 ```bash
 sudo halt
@@ -1321,7 +1321,7 @@ sudo shutdown -P now
 sudo poweroff
 ```
 
-Use `sudo halt` to keep the board off. Use the other shutdown methods only if you specifically want the board to restart, or if you are prepared to disconnect power to prevent the automatic restart, given certain application requirements.
+Use `sudo halt` to keep the board halted. Use the other shutdown methods only if you specifically want the board to restart, or if you are prepared to disconnect power to prevent the automatic restart, given certain application requirements.
 
 #### Troubleshooting Shutdown Process
 


### PR DESCRIPTION
## What This PR Changes
- Updates the shutdown instructions found within the UNO Q Debian documentation

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
