### PR TITLE
Updated Mpy links on category page

### DIFF
--- a/content/programming/04.micropython/micropython.md
+++ b/content/programming/04.micropython/micropython.md
@@ -15,8 +15,8 @@ links:
       url: /micropython/first-steps/install-guide/,
     },
     { 
-      title: "My First Script ", 
-      url: /micropython/first-steps/first-script/ 
+      title: "My First Script", 
+      url: /micropython/first-steps/first-script/,
     },
     { 
       title: "Arduino Runtime for MicroPython", 

--- a/content/programming/04.micropython/micropython.md
+++ b/content/programming/04.micropython/micropython.md
@@ -28,7 +28,7 @@ links:
     },
     { 
       title: "Analog I/O", 
-      url: /micropython/basics/analog-io/ 
+      url: /micropython/basics/analog-io/,
       },
   ]
 ---

--- a/content/programming/04.micropython/micropython.md
+++ b/content/programming/04.micropython/micropython.md
@@ -7,19 +7,28 @@ link: /micropython/
 links:
   [
     {
-      title: "Digital and Analog Pins",
-      url: /micropython/basics/digital-analog-pins/,
+      title: "Introduction to MicroPython",
+      url: /micropython/first-steps/intro-micropython/,
     },
     {
-      title: "Board Installation",
-      url: /micropython/basics/board-installation/,
+      title: "Installing MicroPython",
+      url: /micropython/first-steps/install-guide/,
     },
-    { title: "Examples by Boards", url: /micropython/basics/board-examples/ },
-    { title: "Code Editors", url: /micropython/basics/code-editors/ },
+    { 
+      title: "My First Script ", 
+      url: /micropython/first-steps/first-script/ 
+    },
+    { 
+      title: "Arduino Runtime for MicroPython", 
+      url: /micropython/first-steps/runtime-package/ 
+    },
     {
-      title: "MicroPython Basics",
-      url: /micropython/basics/micropython-basics/,
+      title: "Digital I/O",
+      url: /micropython/basics/digital-io/,
     },
-    { title: "Overview", url: /micropython/basics/overview/ },
+    { 
+      title: "Analog I/O", 
+      url: /micropython/basics/analog-io/ 
+      },
   ]
 ---

--- a/content/programming/04.micropython/micropython.md
+++ b/content/programming/04.micropython/micropython.md
@@ -20,7 +20,7 @@ links:
     },
     { 
       title: "Arduino Runtime for MicroPython", 
-      url: /micropython/first-steps/runtime-package/ 
+      url: /micropython/first-steps/runtime-package/,
     },
     {
       title: "Digital I/O",


### PR DESCRIPTION
## What This PR Changes
The links on the Programming page for MicroPython weren't working. We updated them to the structure currently found in the corresponding page.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
