### PR TITLE
Fixed 10baset1s sample code failing to compile

### DIFF
--- a/content/hardware/02.uno/shields/spe-shield/tutorials/getting-started/spe-getting-started.md
+++ b/content/hardware/02.uno/shields/spe-shield/tutorials/getting-started/spe-getting-started.md
@@ -244,7 +244,7 @@ bool setupNetwork() {
   
   // Create the network components
   networkIO = new TC6::TC6_Io(SPI, CS_PIN, RESET_PIN, IRQ_PIN);
-  networkController = new TC6::TC6_Arduino_10BASE_T1S(networkIO);
+  networkController = new TC6::TC6_Arduino_10BASE_T1S(*networkIO);
   messageService = new Arduino_10BASE_T1S_UDP();
   
   // Set up interrupt (this lets the network chip tell us when data arrives)


### PR DESCRIPTION
## What This PR Changes
- The first sample UDP sketch fails to compile for the SPE shield tutorial. Credit to the issue thread [here](https://github.com/arduino-libraries/Arduino_10BASE_T1S/issues/36). This change allows the code to compile on newer versions of the library.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.
