### PR TITLE
ci: bump actions/checkout to v5 to resolve Node 20 deprecation

### DIFF
--- a/.github/workflows/workflow-validate.yaml
+++ b/.github/workflows/workflow-validate.yaml
@@ -68,7 +68,7 @@ jobs:
     name: Markdown Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate Markdown
         run: python3 scripts/validation/markdownlint/markdownlint.py content
 
@@ -76,7 +76,7 @@ jobs:
     name: Alert Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate Alerts
         run: python3 scripts/validation/alert_tags/alert_tags.py validate content
 
@@ -84,7 +84,7 @@ jobs:
     name: Link Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate Links
         run: python3 scripts/validation/relative_links/relative_links.py validate content
 
@@ -92,6 +92,6 @@ jobs:
     name: Image Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate Images
         run: python3 scripts/validation/image_links/image_links.py validate content


### PR DESCRIPTION
## What This PR Changes

Updates `actions/checkout@v4` to `actions/checkout@v5` across all jobs in `.github/workflows/workflow-validate.yaml`.

### Details
- GitHub Actions runners have deprecated the Node.js 20 runtime environment. Actions targeting Node 20 (such as `actions/checkout@v4`) trigger deprecation warning annotations across validation checks (`Spell Check`, `Content Linter`, `Markdown Check`, `Alert Check`, `Link Check`, and `Image Check`).
- Upgrading to `actions/checkout@v5` transitions the action runtime to Node 24, eliminating the deprecation warning annotations.

## Validation & Testing
- [x] Verified locally with `act`: `act -j validate_images -W .github/workflows/workflow-validate.yaml --container-architecture linux/amd64 -b` passed with 0 errors.

## Contribution Guidelines
- [x] I confirm that I have read the [contribution guidelines](https://github.com/arduino/docs-content/tree/main/contribution-templates) and comply with them.